### PR TITLE
Claude Code plugin install + lossless read path

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,13 @@
+{
+  "name": "navflow",
+  "owner": { "name": "GlassFlow", "url": "https://navflow.ai" },
+  "description": "NavFlow — data plane for AI agents. Query NavFlow from Claude Code and stream sessions back in.",
+  "plugins": [
+    {
+      "name": "navflow",
+      "source": "./claude-plugin",
+      "description": "Connect Claude Code to NavFlow (MCP read-back + session capture).",
+      "version": "0.1.0"
+    }
+  ]
+}

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -7,20 +7,19 @@
   "homepage": "https://glassflow.dev",
   "keywords": ["navflow", "data-plane", "agents", "observability"],
   "mcpServers": "./.mcp.json",
-  "hooks": "./hooks/hooks.json",
   "userConfig": {
     "navflow_url": {
       "type": "string",
       "title": "NavFlow URL",
       "description": "Base URL of your NavFlow daemon. Local default works for `navflow up`; set your remote URL otherwise.",
-      "default": "http://127.0.0.1:8787",
-      "required": true
+      "default": "http://127.0.0.1:8787"
     },
     "ingest_token": {
       "type": "string",
       "title": "Auth token (optional)",
       "description": "Only if your NavFlow requires auth (NAVFLOW_AUTH_TOKEN / INGEST_TOKEN). Sent as a Bearer header to the MCP proxy and the ingest endpoint.",
-      "sensitive": true
+      "sensitive": true,
+      "default": ""
     },
     "stream_sessions": {
       "type": "boolean",

--- a/navflow/daemon.py
+++ b/navflow/daemon.py
@@ -91,12 +91,14 @@ class QueryReq(BaseModel):
     where: dict = {}             # {label: value} on any named label — the label-native selector
     window: str = "15m"
     client: str = "http"   # http | mcp | ui — tags the query in the activity log
+    include_payload: bool = False  # also return the raw lossless record as `raw` on each row
 
 
 class ReadReq(BaseModel):
     selector: dict = {}          # {label: value, ...} — strict-AND conjunction; must be non-empty
     window: str = "15m"
     client: str = "http"   # http | mcp | ui — tags the read in the activity log
+    include_payload: bool = False  # also return the raw lossless record as `raw` on each row
 
 
 class SubReq(BaseModel):
@@ -246,7 +248,8 @@ def make_app() -> FastAPI:
         if not req.key and not req.where:
             _err(ValueError("query needs a key or a where selector"))
         payload, nrows, rows = resolve_query_full(store, runtime.catalog, req.view, req.key,
-                                                  req.window, where=req.where or None)
+                                                  req.window, where=req.where or None,
+                                                  include_payload=req.include_payload)
         log_key = req.key if req.key else ", ".join(f"{k}={v}" for k, v in req.where.items())
         store.log_query("q_" + uuid.uuid4().hex[:12], req.view, log_key, req.window,
                         nrows, req.client)
@@ -259,7 +262,8 @@ def make_app() -> FastAPI:
         derive() a view once you know which sources matter."""
         if not req.selector:
             _err(ValueError('read needs a selector, e.g. {"project": "frontend"}'))
-        payload, nrows, sources, rows = resolve_read(store, runtime.catalog, req.selector, req.window)
+        payload, nrows, sources, rows = resolve_read(store, runtime.catalog, req.selector, req.window,
+                                                     include_payload=req.include_payload)
         log_key = ", ".join(f"{k}={v}" for k, v in req.selector.items())
         store.log_query("r_" + uuid.uuid4().hex[:12], "(read)", log_key, req.window,
                         nrows, req.client)

--- a/navflow/mcp_server.py
+++ b/navflow/mcp_server.py
@@ -13,6 +13,7 @@ all, so a connected agent sees only the read surface (the daemon refuses the wri
 """
 from __future__ import annotations
 
+import json
 import os
 
 import httpx
@@ -46,34 +47,45 @@ def writable():
 
 @mcp.tool()
 async def query(view: str, key: str = "", window: str = "15m",
-                where: dict | None = None) -> str:
+                where: dict | None = None, include_payload: bool = False) -> str:
     """Pull one correlated, time-ordered view of everything that happened to an entity over a
     window (metrics, logs, config, deploys, alerts) — already merged. Prefer this over many small
     reads. Select the entity with `key` (the primary key) OR `where`, a {label: value} map on any
     named label, e.g. {"env": "prod"} or {"env": "prod", "app": "ui"}. Use catalog_describe to
-    see a source's labels."""
-    body = {"view": view, "window": window, "client": "mcp"}
+    see a source's labels. Set `include_payload` when you need each event's full lossless record
+    (not just the one-line summary) — the return becomes JSON {timeline, events[]} where each event
+    carries a `raw` field."""
+    body = {"view": view, "window": window, "client": "mcp", "include_payload": include_payload}
     if where:
         body["where"] = where
     if key:
         body["key"] = key
     async with _cx(30) as cx:
         r = await cx.post(f"{NAVFLOWD}/query", json=body)
-    return r.json()["payload"]
+    data = r.json()
+    if include_payload:
+        return json.dumps({"timeline": data["payload"], "events": data["rows"]}, default=str)
+    return data["payload"]
 
 
 @mcp.tool()
-async def read(selector: dict, window: str = "15m") -> str:
+async def read(selector: dict, window: str = "15m", include_payload: bool = False) -> str:
     """Read one correlated, time-ordered timeline of everything matching `selector` across ALL
     sources — no view needed. `selector` is a {label: value} conjunction, matched with strict AND,
     e.g. {"project": "frontend"} or {"service": "api-server", "endpoint": "/login"}. An event
     matches only if it carries every named label with that value, so adding a label narrows and
     removing one widens. Use this to investigate any entity on the fly; once you know which sources
-    matter, save the slice with derive() to create a reusable view you can attach triggers to."""
+    matter, save the slice with derive() to create a reusable view you can attach triggers to. Set
+    `include_payload` when the one-line summaries aren't enough and you need each event's full
+    lossless record — the return becomes JSON {timeline, events[]} where each event carries `raw`."""
     async with _cx(30) as cx:
         r = await cx.post(f"{NAVFLOWD}/read",
-                          json={"selector": selector, "window": window, "client": "mcp"})
-    return r.json()["payload"]
+                          json={"selector": selector, "window": window, "client": "mcp",
+                                "include_payload": include_payload})
+    data = r.json()
+    if include_payload:
+        return json.dumps({"timeline": data["payload"], "events": data["rows"]}, default=str)
+    return data["payload"]
 
 
 @writable()

--- a/navflow/runtime.py
+++ b/navflow/runtime.py
@@ -136,8 +136,23 @@ class Runtime:
                                 affected_sources={source_name})
         return len(envelopes)
 
+    def _ensure_push_wins(self, cfg) -> None:
+        """Push wins: the first pushed event to a poll-mode source that also accepts pushes
+        (claude_code — tailable locally *or* fed by its Claude Code plugin) flips it to push mode,
+        so the daemon stops tailing files the plugin is now feeding. Without this, a source created
+        as a local tail (e.g. via the console's Connect card) and *also* fed by the plugin ingests
+        every event twice. Persisted + reloaded so the running poller actually stops. No-op for
+        native push connectors (no poll() to conflict with) and for sources already in push mode."""
+        if SPECS.get(cfg.connector, {}).get("mode") == "push" or cfg.config.get("push"):
+            return
+        self.store.upsert_catalog_source(cfg.name, cfg.type, cfg.connector, cfg.poll,
+                                         {**cfg.config, "push": True},
+                                         paused=cfg.paused, ingest_key=cfg.ingest_key)
+        self.reload_catalog()
+
     async def ingest(self, token: str, payload) -> int:
         cfg = self._push_cfg(token)   # token may be the ingest_key or the source name
+        self._ensure_push_wins(cfg)   # first push flips a tail source to push mode (no double-ingest)
         conn = build_connector(cfg, self.store)
         return await self._store_envelopes(cfg.name, conn.map_payload(payload))
 

--- a/navflow/store.py
+++ b/navflow/store.py
@@ -189,8 +189,10 @@ class Store:
 
     # ── reads ───────────────────────────────────────────────────────────────
     def read_view_window(self, sources: list[str], key: str | None, since: datetime, cap: int = 12,
-                         filters: list | None = None, where: dict | None = None):
-        """Rows (event_time, source, text, labels) for an entity across sources, time-ordered.
+                         filters: list | None = None, where: dict | None = None,
+                         include_payload: bool = False):
+        """Rows for an entity across sources, time-ordered: (event_time, source, text, labels), plus
+        the raw lossless `payload` as a 5th column when `include_payload` is set.
 
         The entity is selected by `key` (legacy primary key_value) and/or `where` (a
         {label: value} map matching named labels). Passing key=None with a `where` is the
@@ -199,15 +201,18 @@ class Store:
         Caps each source to its most-recent `cap` events so a lossless store doesn't return a
         bloated payload (e.g. thousands of identical log lines or every 5s metric sample). Ingest
         stays lossless; this bound is a read-path summary, matching what an SRE actually wants.
+        `include_payload` pulls the full stored record per row (bounded by the same cap) for callers
+        that need fidelity beyond the summary `text`.
         """
+        cols = "event_time, source, text, labels" + (", payload" if include_payload else "")
         ph = ", ".join(["?"] * len(sources))
         fsql, fparams = _filter_sql(filters)
         wsql, wparams = _where_sql(where)
         ksql, kparams = (" AND key_value = ?", [key]) if key is not None else ("", [])
         with self._lock:
             return self.con.execute(
-                f"SELECT event_time, source, text, labels FROM ("
-                f"  SELECT event_time, source, text, labels, "
+                f"SELECT {cols} FROM ("
+                f"  SELECT {cols}, "
                 f"  ROW_NUMBER() OVER (PARTITION BY source ORDER BY event_time DESC) AS rn "
                 f"  FROM events WHERE source IN ({ph}) AND event_time >= ?{ksql}{fsql}{wsql}"
                 f") WHERE rn <= {int(cap)} ORDER BY event_time",

--- a/navflow/views.py
+++ b/navflow/views.py
@@ -32,21 +32,31 @@ def _labels(raw) -> dict:
     return {}
 
 
-def _render(rows) -> tuple[list, list]:
-    """From read_view_window 4-tuples → (payload lines, structured rows). The labels the connector
+def _render(rows, include_payload: bool = False) -> tuple[list, list]:
+    """From read_view_window rows → (payload lines, structured rows). The labels the connector
     extracted (endpoint, status, …) are appended to each line and returned structured, so a read is
     self-describing: the dimensions you filtered/sliced by are visible on every row, for the human
-    timeline and the agent payload alike."""
+    timeline and the agent payload alike. When `include_payload` is set, each row is a 5-tuple whose
+    trailing element is the raw stored record; it's parsed and attached as `raw` so agents can read
+    the full lossless event, not just the summary `text`."""
     now = now_utc()
     lines, structured = [], []
-    for event_time, source, text, labels in rows:
+    for row in rows:
+        event_time, source, text, labels = row[0], row[1], row[2], row[3]
         ago = int(max((now - _aware(event_time)).total_seconds(), 0))
         lbls = _labels(labels)
         suffix = ("  ·  " + "  ".join(f"{k}={v}" for k, v in lbls.items())) if lbls else ""
         sub = (text or "").splitlines() or [""]
         for i, line in enumerate(sub):
             lines.append(f"[T-{ago}s] [{source}] {line}" + (suffix if i == 0 else ""))
-        structured.append({"offset": f"T-{ago}s", "source": source, "text": (text or ""), "labels": lbls})
+        entry = {"offset": f"T-{ago}s", "source": source, "text": (text or ""), "labels": lbls}
+        if include_payload:
+            raw = row[4]
+            try:
+                entry["raw"] = json.loads(raw) if isinstance(raw, (str, bytes, bytearray)) else raw
+            except (ValueError, TypeError):
+                entry["raw"] = raw   # stored non-JSON payload — pass through as-is
+        structured.append(entry)
     return lines, structured
 
 
@@ -69,13 +79,15 @@ def _selector(key, where) -> str:
 
 
 def resolve_query_full(store, catalog: Catalog, view_name: str, key=None, window: str = "15m",
-                       where: dict | None = None) -> tuple[str, int, list]:
+                       where: dict | None = None, include_payload: bool = False) -> tuple[str, int, list]:
     """(rendered payload, row count, structured rows) — the count feeds the query activity log; the
-    rows carry per-event labels for the console. Entity selected by `key` and/or `where`."""
+    rows carry per-event labels for the console. Entity selected by `key` and/or `where`.
+    `include_payload` adds the raw lossless record as `raw` on each structured row."""
     view = catalog.views[view_name]
     since = now_utc() - parse_window(window)
-    rows = store.read_view_window(view.sources, key, since, filters=view.filters, where=where)
-    lines, structured = _render(rows)
+    rows = store.read_view_window(view.sources, key, since, filters=view.filters, where=where,
+                                  include_payload=include_payload)
+    lines, structured = _render(rows, include_payload)
     return _wrap(view_name, _selector(key, where), window, lines, not rows), len(rows), structured
 
 
@@ -84,14 +96,17 @@ def resolve_query(store, catalog: Catalog, view_name: str, key=None, window: str
     return resolve_query_full(store, catalog, view_name, key, window, where)[0]
 
 
-def resolve_read(store, catalog: Catalog, where: dict, window: str = "15m") -> tuple[str, int, list, list]:
+def resolve_read(store, catalog: Catalog, where: dict, window: str = "15m",
+                 include_payload: bool = False) -> tuple[str, int, list, list]:
     """Raw label-native read across ALL sources — no view. `where` is a {label: value} conjunction
     (strict AND). Reading every source is self-pruning: a source that doesn't stamp one of the
     selector's labels yields NULL for it and drops out, so the result is exactly the strict-AND
-    match. Returns (rendered payload, row count, contributing sources, structured rows)."""
+    match. Returns (rendered payload, row count, contributing sources, structured rows).
+    `include_payload` adds the raw lossless record as `raw` on each structured row."""
     since = now_utc() - parse_window(window)
-    rows = store.read_view_window(sorted(catalog.sources), None, since, filters=None, where=where)
-    lines, structured = _render(rows)
+    rows = store.read_view_window(sorted(catalog.sources), None, since, filters=None, where=where,
+                                  include_payload=include_payload)
+    lines, structured = _render(rows, include_payload)
     payload = _wrap("read", _selector(None, where), window, lines, not rows)
     contributing = sorted({r[1] for r in rows})
     return payload, len(rows), contributing, structured

--- a/tests/test_include_payload.py
+++ b/tests/test_include_payload.py
@@ -1,0 +1,98 @@
+"""include_payload: read/query serve a one-line summary `text` by default, but return the full
+lossless stored record as `raw` on each row when asked. Proves the read path can hand agents the
+complete event (not just the truncated summary) — for both /read and /query (over a view) — while
+the default stays lean. Uses claude_code because its `text` is a deliberately lossy summary (a
+tool_use renders as `→ Bash({first 80 chars…})`) while the raw record keeps the full input.
+"""
+import asyncio, json, os, subprocess, sys
+import httpx
+
+P = F = 0
+def ck(l, c, d=""):
+    global P, F; P += 1 if c else 0; F += 0 if c else 1
+    print(("  ok   " if c else "  FAIL ") + l + ("" if c else f"  {d}"))
+
+DB, PORT = "/tmp/inclpayload.duckdb", "8810"
+LONG_CMD = "echo " + "x" * 300   # >80 chars, so the summary text must truncate it but raw keeps it
+
+
+async def _wait(url):
+    for _ in range(80):
+        try:
+            async with httpx.AsyncClient() as cx:
+                if (await cx.get(url, timeout=1)).status_code == 200:
+                    return True
+        except Exception:
+            pass
+        await asyncio.sleep(0.25)
+    return False
+
+
+async def main():
+    for p in (DB, DB + ".wal"):
+        if os.path.exists(p):
+            os.remove(p)
+    env = {**os.environ, "NAVFLOW_DB": DB, "NAVFLOW_CATALOG": "/tmp/none_ip.yaml",
+           "NAVFLOW_PORT": PORT, "NAVFLOW_OTLP_GRPC_PORT": "off"}
+    proc = subprocess.Popen([sys.executable, "-c", "from navflow.cli import run_daemon; run_daemon()"],
+                            env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    B = f"http://127.0.0.1:{PORT}"
+    line = json.dumps({"sessionId": "sess-raw", "type": "assistant", "cwd": "/tmp/proj",
+                       "timestamp": "2026-07-03T10:00:00Z",
+                       "message": {"role": "assistant",
+                                   "content": [{"type": "tool_use", "name": "Bash",
+                                                "input": {"command": LONG_CMD}}]}})
+    try:
+        if not await _wait(f"{B}/health"):
+            ck("daemon up", False); return
+        async with httpx.AsyncClient() as cx:
+            await cx.post(f"{B}/api/sources", json={"name": "claude_code", "connector": "claude_code",
+                                                    "config": {"push": True}})
+            r = await cx.post(f"{B}/ingest/claude_code", content=line + "\n",
+                              headers={"content-type": "application/x-ndjson"})
+            ck("transcript line ingested", r.status_code == 202 and r.json()["ingested"] == 1, r.text)
+
+            # ── /read default: summary text, no raw ──────────────────────────────
+            r = await cx.post(f"{B}/read", json={"selector": {"session": "sess-raw"}, "window": "1h"})
+            row = r.json()["rows"][0]
+            ck("read (default) returns rows", r.json()["count"] == 1, r.text)
+            ck("default row has summary text", row.get("text", "").startswith("→ Bash"), str(row))
+            ck("default row has NO raw", "raw" not in row, str(row))
+            ck("summary text is lossy (full command not in it)", LONG_CMD not in row.get("text", ""))
+
+            # ── /read include_payload: full lossless record on `raw` ─────────────
+            r = await cx.post(f"{B}/read", json={"selector": {"session": "sess-raw"}, "window": "1h",
+                                                 "include_payload": True})
+            row = r.json()["rows"][0]
+            raw = row.get("raw")
+            ck("include_payload row carries raw", isinstance(raw, dict), str(row)[:200])
+            ck("raw is the full stored record (sessionId, cwd)",
+               raw and raw.get("sessionId") == "sess-raw" and raw.get("cwd") == "/tmp/proj", str(raw)[:200])
+            ck("raw is lossless — full command preserved though text truncated it",
+               raw and raw["message"]["content"][0]["input"]["command"] == LONG_CMD)
+            ck("summary text still present alongside raw", row.get("text", "").startswith("→ Bash"))
+
+            # ── /query over a view: same behaviour ───────────────────────────────
+            await cx.post(f"{B}/api/views", json={"name": "cc", "sources": ["claude_code"]})
+            r = await cx.post(f"{B}/query", json={"view": "cc", "where": {"session": "sess-raw"},
+                                                  "window": "1h"})
+            ck("query (default) has no raw", "raw" not in r.json()["rows"][0], str(r.json()["rows"][0]))
+            r = await cx.post(f"{B}/query", json={"view": "cc", "where": {"session": "sess-raw"},
+                                                  "window": "1h", "include_payload": True})
+            qraw = r.json()["rows"][0].get("raw")
+            ck("query include_payload carries lossless raw",
+               isinstance(qraw, dict) and qraw["message"]["content"][0]["input"]["command"] == LONG_CMD,
+               str(r.json()["rows"][0])[:200])
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except Exception:
+            proc.kill()
+
+    print(f"\n{P} passed, {F} failed")
+    sys.exit(1 if F else 0)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_push_wins.py
+++ b/tests/test_push_wins.py
@@ -1,0 +1,83 @@
+"""Push wins: a poll-mode source that also accepts pushes (claude_code — tailed locally *or* fed by
+its Claude Code plugin) flips to push mode the first time it receives a pushed event, so the daemon
+stops tailing files the plugin is now feeding and events don't land twice. Native push sources
+(webhook) are unaffected.
+"""
+import asyncio, os, subprocess, sys
+import httpx
+
+P = F = 0
+def ck(l, c, d=""):
+    global P, F; P += 1 if c else 0; F += 0 if c else 1
+    print(("  ok   " if c else "  FAIL ") + l + ("" if c else f"  {d}"))
+
+DB, PORT = "/tmp/pushwins.duckdb", "8809"
+
+
+async def _wait(url):
+    for _ in range(80):
+        try:
+            async with httpx.AsyncClient() as cx:
+                if (await cx.get(url, timeout=1)).status_code == 200:
+                    return True
+        except Exception:
+            pass
+        await asyncio.sleep(0.25)
+    return False
+
+
+def _source(sources, name):
+    return next((s for s in sources if s["name"] == name), None)
+
+
+async def main():
+    for p in (DB, DB + ".wal"):
+        if os.path.exists(p):
+            os.remove(p)
+    env = {**os.environ, "NAVFLOW_DB": DB, "NAVFLOW_CATALOG": "/tmp/none_pw.yaml",
+           "NAVFLOW_PORT": PORT, "NAVFLOW_OTLP_GRPC_PORT": "off"}
+    proc = subprocess.Popen([sys.executable, "-c", "from navflow.cli import run_daemon; run_daemon()"],
+                            env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    B = f"http://127.0.0.1:{PORT}"
+    line = ('{"sessionId":"sess-1","type":"assistant","cwd":"/tmp/proj","timestamp":'
+            '"2026-07-03T10:00:00Z","message":{"role":"assistant","content":[{"type":"text",'
+            '"text":"hello"}]}}')
+    try:
+        if not await _wait(f"{B}/health"):
+            ck("daemon up", False); return
+        async with httpx.AsyncClient() as cx:
+            # a claude_code source created as a local tail (push defaults to false)
+            await cx.post(f"{B}/api/sources", json={"name": "claude_code", "connector": "claude_code", "config": {}})
+            src = _source((await cx.get(f"{B}/api/sources")).json(), "claude_code")
+            ck("claude_code starts in tail mode (push falsy)", not src["config"].get("push"), str(src["config"]))
+
+            # first pushed transcript line ingests AND flips the source to push mode
+            r = await cx.post(f"{B}/ingest/claude_code", content=line + "\n",
+                              headers={"content-type": "application/x-ndjson"})
+            ck("push ingests the transcript line", r.status_code == 202 and r.json()["ingested"] == 1, r.text)
+            src = _source((await cx.get(f"{B}/api/sources")).json(), "claude_code")
+            ck("source flipped to push mode after first push", src["config"].get("push") is True, str(src["config"]))
+
+            # second push is a no-op flip (already push) and still ingests
+            r = await cx.post(f"{B}/ingest/claude_code", content=line + "\n",
+                              headers={"content-type": "application/x-ndjson"})
+            ck("second push still ingests (idempotent flip)", r.status_code == 202 and r.json()["ingested"] == 1, r.text)
+
+            # a native push connector (webhook) is never given a push flag by the guard
+            await cx.post(f"{B}/api/sources", json={"name": "evt", "connector": "webhook", "config": {}})
+            await cx.post(f"{B}/ingest/evt", json={"a": 1})
+            src = _source((await cx.get(f"{B}/api/sources")).json(), "evt")
+            ck("webhook source config untouched by guard", "push" not in src["config"], str(src["config"]))
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except Exception:
+            proc.kill()
+
+    print(f"\n{P} passed, {F} failed")
+    sys.exit(1 if F else 0)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
Testing the Claude Code data source ahead of the soft launch surfaced several gaps in the install path and the read API. This PR fixes them.

## Plugin install (user-facing path)
- **Publish `marketplace.json`** at the repo root so users can install with `/plugin marketplace add glassflow/navflow` → `/plugin install navflow@navflow`. Claude Code fetches the plugin from the repo — no clone, and the plugin does not need to be in the pip package.
- **Fix three `plugin.json` load errors** found by a real install on Claude Code 2.1:
  - explicit `hooks` ref duplicated the auto-loaded `hooks/hooks.json` → hooks failed to load, so capture never ran.
  - `ingest_token` had no default → the MCP server's `${CLAUDE_PLUGIN_OPTION_ingest_token}` interpolation was rejected as invalid for every no-auth user.
  - `navflow_url` was `required: true`, so its default was never offered at the install prompt.

  Verified end-to-end afterwards: `/doctor` clean, the `claude_code` push source auto-created, events ingested, and the session timeline read back.

## Push wins (no double-ingest)
A `claude_code` source can be tailed locally **or** fed by the plugin. If it was created as a local tail and the plugin also shipped to it, the daemon both tailed the files and ingested the pushes — every event landed twice. The first pushed event now flips a poll-mode source to `push:true` (persisted + reloaded), making the two transports mutually exclusive by construction.

## Lossless read (`include_payload`)
`read`/`query` served only a one-line summary `text` (truncated per connector); the full stored `payload` was never exposed, so agents never got the lossless record NavFlow promises. Added an opt-in `include_payload` threaded through `read_view_window → _render → resolve_read/resolve_query_full → /read, /query` and the MCP `read`/`query` tools. When set, each row also carries the raw record as `raw`; default behaviour is unchanged. One shared path, so it covers **all connectors** and **both read and query**.

## Tests
- `tests/test_push_wins.py` — tail source flips to push on first push; idempotent; native push connectors untouched.
- `tests/test_include_payload.py` — default = summary only; opt-in returns the full lossless `raw` on `/read` and `/query`, proving a truncated summary vs an intact record.

All new tests pass; existing read/query/ingest tests unaffected.

## Note
The daemon-side changes (push-wins, lossless read) ship in the next release — not in a currently running build. The plugin/marketplace changes are exercised via `/plugin`.