### PR TITLE
deploy: non-root image + default compose to :latest

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -20,9 +20,9 @@ extras). **CI builds and publishes it to GHCR** on every push to `main` and on `
 **pull** a prebuilt image rather than building on the box. The image ref is
 `${NAVFLOW_REGISTRY:-ghcr.io/glassflow/navflow}:${NAVFLOW_VERSION:-…}`.
 
-- **Version:** the **self-host** compose defaults to a **pinned** tag (e.g. `0.0.1`) for reproducible
-  deploys; the **demo** tracks `:latest`. Pin a different version without editing files via
-  `NAVFLOW_VERSION=0.0.2`, or `git pull` to pick up a release's bumped default.
+- **Version:** both compose files default to **`:latest`** — CI publishes only on release tags, so
+  `:latest` tracks the newest **release** (not `main`). For a reproducible deploy, pin a specific
+  release without editing files via `NAVFLOW_VERSION=0.1.4`.
 - **Registry:** `NAVFLOW_REGISTRY=registry.example.com/navflow` points at another registry (DOCR,
   Docker Hub).
 - **GHCR access:** make the package public (GitHub → package settings) or `docker login ghcr.io` on
@@ -33,16 +33,16 @@ extras). **CI builds and publishes it to GHCR** on every push to `main` and on `
   docker compose -f deploy/compose/docker-compose.yml -f deploy/compose/docker-compose.build.yml build
   ```
 
-### Cutting a release (pinned versions)
+### Cutting a release
 
 ```sh
-scripts/release.sh 0.0.2          # bumps pyproject + the self-host pin, commits, tags v0.0.2
+scripts/release.sh 0.0.2          # bumps pyproject version, commits, tags v0.0.2
 git push && git push origin v0.0.2
 ```
 
-Pushing the tag triggers CI to publish `ghcr.io/glassflow/navflow:0.1.0` (plus `:0.0` and `:latest`
-on main). Self-host deploys then upgrade by `git pull && docker compose -f …selfhost.yml pull && up -d`,
-or by setting `NAVFLOW_VERSION=0.0.2`. **Tag `v0.0.1` once to publish the current pinned default.**
+Pushing the tag triggers CI to publish `ghcr.io/glassflow/navflow:<version>` (plus `:<major>.<minor>`
+and `:latest`). Self-host deploys on `:latest` upgrade with
+`docker compose -f …selfhost.yml pull && up -d`; pinned deploys bump `NAVFLOW_VERSION=<version>`.
 
 ## Scenario 2 — the public read-only demo
 
@@ -92,7 +92,7 @@ export NAVFLOW_AUTH_TOKEN=$(openssl rand -hex 24)   # the access token (humans +
 export NAVFLOW_DOMAIN=navflow.acme.com
 docker compose -f deploy/compose/docker-compose.selfhost.yml pull   # fetch the prebuilt image
 docker compose -f deploy/compose/docker-compose.selfhost.yml up -d
-# update later:  git pull && docker compose -f …selfhost.yml pull && up -d
+# update later:  docker compose -f …selfhost.yml pull && up -d   (:latest → newest release)
 ```
 
 - **Console:** browse to the host; the login screen takes the token.

--- a/deploy/compose/docker-compose.selfhost.yml
+++ b/deploy/compose/docker-compose.selfhost.yml
@@ -1,6 +1,7 @@
 # NavFlow self-hosted single-tenant (Scenario 3) — a writable instance for one team, behind a token.
-# Pulls a PINNED prebuilt image (default :0.0.1). Bump it with NAVFLOW_VERSION (or `git pull` after a
-# release bumps the default); NAVFLOW_REGISTRY points at another registry. Build with build override.
+# Pulls the latest released image (:latest) — CI publishes only on release tags, so :latest tracks
+# the newest release. Pin a specific one with NAVFLOW_VERSION=0.1.4 for reproducible deploys;
+# NAVFLOW_REGISTRY points at another registry. Build locally with the build override.
 #   NAVFLOW_AUTH_TOKEN=$(openssl rand -hex 24) NAVFLOW_DOMAIN=navflow.acme.com \
 #     docker compose -f deploy/compose/docker-compose.selfhost.yml up -d
 #
@@ -11,7 +12,7 @@ name: navflow
 
 services:
   navflowd:
-    image: ${NAVFLOW_REGISTRY:-ghcr.io/glassflow/navflow}:${NAVFLOW_VERSION:-0.1.0}
+    image: ${NAVFLOW_REGISTRY:-ghcr.io/glassflow/navflow}:${NAVFLOW_VERSION:-latest}
     command: ["navflow", "up", "--host", "0.0.0.0", "--data-dir", "/data"]
     environment:
       NAVFLOW_AUTH_TOKEN: "${NAVFLOW_AUTH_TOKEN:?set NAVFLOW_AUTH_TOKEN (e.g. openssl rand -hex 24)}"
@@ -22,7 +23,7 @@ services:
     restart: unless-stopped
 
   mcp:
-    image: ${NAVFLOW_REGISTRY:-ghcr.io/glassflow/navflow}:${NAVFLOW_VERSION:-0.1.0}
+    image: ${NAVFLOW_REGISTRY:-ghcr.io/glassflow/navflow}:${NAVFLOW_VERSION:-latest}
     command: ["navflow", "mcp", "--transport", "streamable-http", "--host", "0.0.0.0",
               "--port", "8788", "--navflowd", "http://navflowd:8787"]
     environment:

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -18,8 +18,15 @@ COPY navflow/ ./navflow/
 COPY --from=ui /ui/dist ./ui/dist
 RUN pip install --no-cache-dir ".[postgres,otlp-grpc,agent]"
 
+# Run as a non-root user. Own /data before declaring the VOLUME so a first-mount Docker named
+# volume inherits the ownership; on k8s an empty PVC needs fsGroup: 1000 (set in the cell chart).
+RUN groupadd -r -g 1000 navflow \
+ && useradd -r -u 1000 -g navflow -d /data -s /usr/sbin/nologin navflow \
+ && mkdir -p /data && chown navflow:navflow /data
+
 ENV NAVFLOW_HOME=/data
 VOLUME /data
 EXPOSE 8787 8788
+USER navflow
 # the daemon by default; the compose mcp service overrides this with `navflow mcp ...`
 CMD ["navflow", "up", "--host", "0.0.0.0", "--data-dir", "/data"]

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# Cut a pinned release: bump the package version, pin the self-host compose to it, commit + tag.
-# Pushing the tag triggers CI (.github/workflows/docker-publish.yml) to build and publish
-#   ghcr.io/glassflow/navflow:<version>  (+ :<major>.<minor> and :latest on main).
+# Cut a release: bump the package version, commit + tag. The compose files track :latest, so there
+# is no pinned tag to bump here. Pushing the tag triggers CI (.github/workflows/docker-publish.yml)
+# to build and publish ghcr.io/glassflow/navflow:<version> (+ :<major>.<minor> and :latest).
 #
 #   scripts/release.sh 0.0.2
 #   git push && git push origin v0.0.2     # then publish (review first)
@@ -13,15 +13,12 @@ if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
   exit 1
 fi
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-SELFHOST="$ROOT/deploy/compose/docker-compose.selfhost.yml"
 
 # package version
 sed -i.bak -E "s/^version = \".*\"/version = \"$VERSION\"/" "$ROOT/pyproject.toml"
-# the self-host compose's pinned default tag (NAVFLOW_VERSION:-<here>)
-sed -i.bak -E "s/(NAVFLOW_VERSION:-)[0-9][^}]*/\1$VERSION/g" "$SELFHOST"
-rm -f "$ROOT/pyproject.toml.bak" "$SELFHOST.bak"
+rm -f "$ROOT/pyproject.toml.bak"
 
-git -C "$ROOT" add pyproject.toml "$SELFHOST"
+git -C "$ROOT" add pyproject.toml
 git -C "$ROOT" commit -m "Release v$VERSION"
 git -C "$ROOT" tag "v$VERSION"
 


### PR DESCRIPTION
Two deploy-hygiene fixes surfaced while standing up a managed k8s deployment.

## 1. Run the image as non-root
The image ran as **root** (no `USER`), which blocks `runAsNonRoot: true` on Kubernetes.

- Add a `navflow` user (uid/gid **1000**), `chown /data` **before** the `VOLUME` so a first-mount Docker named volume inherits the ownership, and set `USER navflow` before `CMD`.
- **Verified** by building and running: process is `uid=1000(navflow)`, a named volume mounts writable, and the daemon boots non-root and writes `navflow.duckdb` (+ wal) to `/data`, `/health` → 200.
- Note: an **empty k8s PVC** is root-owned, so the deployer sets `fsGroup: 1000` (called out in a Dockerfile comment). Docker named volumes need nothing (they inherit ownership on first mount).

## 2. Default the compose to `:latest`
The self-host compose pinned `NAVFLOW_VERSION:-0.1.0` — a tag that was **never published** (real release is `0.1.4`); the docs said `0.0.1`. Rather than chase a pinned default that goes stale, default to `:latest`:

- **CI publishes only on release tags** (`on: push: tags: ["v*"]`), so `:latest` tracks the newest **release**, not `main`. The demo compose already uses `:latest`.
- Both compose services → `:latest`; `NAVFLOW_VERSION=0.1.4` remains the opt-in pin for reproducible deploys.
- `scripts/release.sh` no longer rewrites a compose pin (there isn't one); `deploy/README` updated to match.

Reproducibility note: `:latest` means `docker compose pull` moves to the newest release — deployers who need a fixed version pin `NAVFLOW_VERSION`.