### PR TITLE
console: Security sidebar showing the ingest token

### DIFF
--- a/navflow/daemon.py
+++ b/navflow/daemon.py
@@ -536,6 +536,13 @@ def make_app() -> FastAPI:
     async def connectors():
         return {name: spec for name, spec in SPECS.items()}
 
+    @app.get("/api/security")
+    async def security():
+        """Instance credentials, for the authenticated operator. The ingest token is the shared,
+        machine-facing secret producers send as X-NavFlow-Token / Bearer on /ingest and /v1/*; the
+        console surfaces it here so the operator can hand it to producers without shell access."""
+        return {"ingest_token": INGEST_TOKEN or None, "ingest_required": bool(INGEST_TOKEN)}
+
     @app.post("/api/sources/discover")
     async def discover_source(body: dict = Body(...)):
         from .connectors import REGISTRY

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -42,6 +42,7 @@ const SECTION_LABEL: Record<string, string> = {
   agents: "Agents",
   catalog: "Catalog",
   ask: "Ask",
+  security: "Security",
   settings: "Settings",
 };
 
@@ -138,6 +139,10 @@ export default function App() {
           <Chat className="ico" />
           <span className="nav-label">Ask</span>
           <kbd className="nav-kbd" title="Ask from anywhere">⌘K</kbd>
+        </NavLink>
+        <NavLink to="/security" className={link}>
+          <Lock className="ico" />
+          <span className="nav-label">Security</span>
         </NavLink>
         <NavLink to="/settings" className={link}>
           <SettingsIco className="ico" />

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -57,6 +57,8 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
 export const api = {
   health: () => request<{ status: string; readonly: boolean; auth_required: boolean }>("/health"),
   connectors: () => request<Record<string, ConnectorSpec>>("/api/connectors"),
+  security: () =>
+    request<{ ingest_token: string | null; ingest_required: boolean }>("/api/security"),
 
   sources: () => request<Source[]>("/api/sources"),
   source: (name: string) => request<Source>(`/api/sources/${name}`),

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -11,6 +11,7 @@ import SourceClaudeCode from "./pages/SourceClaudeCode";
 import SourceDetail from "./pages/SourceDetail";
 import SourceDiscover from "./pages/SourceDiscover";
 import SourceNew from "./pages/SourceNew";
+import Security from "./pages/Security";
 import Settings from "./pages/Settings";
 import Sources from "./pages/Sources";
 import { TriggersPage, ViewsPage } from "./pages/ViewsTriggers";
@@ -31,6 +32,7 @@ const router = createBrowserRouter([
       { path: "triggers", element: <TriggersPage /> },
       { path: "agents", element: <Activity /> },
       { path: "ask", element: <Ask /> },
+      { path: "security", element: <Security /> },
       { path: "settings", element: <Settings /> },
       // legacy paths → new homes (bookmarks, the old Entities/Activity/Catalog nav). Catalog
       // dissolved: source schema/freshness now lives on the source detail; the agent's-eye read

--- a/ui/src/pages/Security.tsx
+++ b/ui/src/pages/Security.tsx
@@ -1,0 +1,83 @@
+import { useEffect, useState } from "react";
+
+import { api } from "../api";
+
+function Copy({ text }: { text: string }) {
+  const [done, setDone] = useState(false);
+  return (
+    <button
+      className="copybtn"
+      onClick={() => {
+        navigator.clipboard?.writeText(text);
+        setDone(true);
+        setTimeout(() => setDone(false), 1500);
+      }}
+    >
+      {done ? "copied" : "copy"}
+    </button>
+  );
+}
+
+// Instance credentials the operator hands to machines. Read-only for now; create/revoke lands here
+// later (today the ingest token is set once via NAVFLOW_INGEST_TOKEN on the daemon).
+export default function Security() {
+  const [data, setData] = useState<{ ingest_token: string | null; ingest_required: boolean }>();
+  const [err, setErr] = useState<string>();
+  const [revealed, setRevealed] = useState(false);
+
+  useEffect(() => {
+    api.security().then(setData).catch((e) => setErr(String((e as Error).message ?? e)));
+  }, []);
+
+  const token = data?.ingest_token ?? "";
+  const masked =
+    token.length > 8
+      ? `${token.slice(0, 4)}${"•".repeat(token.length - 8)}${token.slice(-4)}`
+      : "••••••••";
+
+  return (
+    <>
+      <h1>Security</h1>
+      <p className="subtitle">
+        instance credentials — the tokens machines use to reach this NavFlow
+      </p>
+
+      {err && <div className="alert error">{err}</div>}
+
+      <div className="panel">
+        <h2 style={{ marginTop: 0 }}>Ingest token</h2>
+        <p className="help" style={{ marginTop: 0 }}>
+          Producers (webhooks, Vercel / OTLP drains) send this as <code>X-NavFlow-Token</code> or{" "}
+          <code>Authorization: Bearer …</code> when POSTing to <code>/ingest/&lt;source&gt;</code> and{" "}
+          <code>/v1/*</code>. It is separate from your console / MCP login token.
+        </p>
+
+        {!data && !err ? (
+          <div className="muted">loading…</div>
+        ) : data?.ingest_required && token ? (
+          <div className="btnrow" style={{ alignItems: "center" }}>
+            <code className="payload" style={{ flex: 1, margin: 0, wordBreak: "break-all" }}>
+              {revealed ? token : masked}
+            </code>
+            <button onClick={() => setRevealed((r) => !r)}>{revealed ? "hide" : "reveal"}</button>
+            <Copy text={token} />
+          </div>
+        ) : data ? (
+          <div className="alert">
+            Ingest is <strong>open</strong> on this instance — no token is required, so anyone who
+            knows an <code>/ingest/&lt;key&gt;</code> URL can post to it. Set{" "}
+            <code>NAVFLOW_INGEST_TOKEN</code> on the daemon to require a token.
+          </div>
+        ) : null}
+      </div>
+
+      <div className="panel">
+        <h2 style={{ marginTop: 0 }}>Rotate &amp; revoke</h2>
+        <p className="help" style={{ marginTop: 0 }}>
+          Coming soon — create and revoke ingest tokens from here. Today the token is set once via
+          the <code>NAVFLOW_INGEST_TOKEN</code> environment variable on the daemon.
+        </p>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
Adds a **Security** section to the console so the operator can see the instance's ingest token and hand it to producers — without shell access. The console previously showed a source's ingest **URL** but not the `NAVFLOW_INGEST_TOKEN` that URL requires, so wiring a producer (or a Vercel/OTLP drain) meant digging the token out of the environment.

## Backend
- `GET /api/security` → `{ ingest_token, ingest_required }`. Auth-gated like every other `/api` route (returns 401 without the console login token). Verified against the daemon: 401 unauthenticated, `{"ingest_token":"…","ingest_required":true}` with the token.

## Console
- New **Security** page: shows the ingest token (masked with reveal + copy), an explainer of where producers send it (`X-NavFlow-Token` / Bearer on `/ingest/*` and `/v1/*`), and an empty-state when ingest is open (no token set). A "Rotate & revoke — coming soon" panel marks the next step.
- **Security** nav link (Lock icon) + `/security` route + breadcrumb label.

## Scope
Read-only for now. Create/revoke tokens (moving off the single `NAVFLOW_INGEST_TOKEN` env var to managed, revocable tokens) is deliberately stubbed as "coming soon" — that's a larger change.

## Verification
- `npm run build` (console) passes.
- Endpoint smoke-tested against the daemon (auth gating + payload).