### PR TITLE
console: Claude Code plugin-only; hide local-only actions on hosted

### DIFF
--- a/claude-plugin/README.md
+++ b/claude-plugin/README.md
@@ -52,9 +52,9 @@ advances the offset on success (so failures retry). It runs on `UserPromptSubmit
 
 ## Notes / caveats (prototype)
 
-- **One transport per source.** A `claude_code` source either tails files locally **or** is fed by
-  this plugin (`config.push: true`). Don't enable both against the same source or events double up.
-- Secrets are redacted **server-side** by the `claude_code` connector before storage (the PII guard),
-  the same as the local tail.
+- **Push-only source.** The `claude_code` source is fed by this plugin over `/ingest` (`config.push:
+  true`, set automatically on first run). Local file tailing was removed — the plugin covers local
+  and remote alike. Capture is forward-only (sessions from install onward; no backfill of old files).
+- Secrets are redacted **server-side** by the `claude_code` connector before storage (the PII guard).
 - `sensitive` config (the token) is passed to hook/MCP processes only as
   `CLAUDE_PLUGIN_OPTION_ingest_token`; the URL is also available as `${user_config.navflow_url}`.

--- a/navflow/connectors/claude_code.py
+++ b/navflow/connectors/claude_code.py
@@ -1,30 +1,24 @@
-"""Claude Code sessions connector — tails local session transcripts into the data plane.
+"""Claude Code sessions connector — receives pushed session transcripts from the NavFlow Claude Code
+plugin and maps them into the data plane.
 
-Claude Code writes one JSONL file per session at ~/.claude/projects/<project-slug>/<sessionId>.jsonl,
-appending one structured event per line (user / assistant / tool_use / tool_result / summary, each
-with a timestamp, sessionId, cwd, gitBranch, and — for assistant turns — model + token usage).
+Claude Code writes one structured JSONL event per line (user / assistant / tool_use / tool_result /
+summary, each with a timestamp, sessionId, cwd, gitBranch, and — for assistant turns — model + token
+usage). The plugin's hook POSTs new transcript lines to /ingest/claude_code (local *or* remote); each
+line becomes an Envelope keyed by `session`, with project/branch/model labels and token-usage as
+numeric fields. Sub-agent (sidechain) transcripts land in the SAME source, tagged `sidechain=true`.
+Secrets are redacted before storage (thin PII guard).
 
-Because navflowd runs on the same machine as ~/.claude (the local scenario), it just reads these
-files directly — no hook, no pusher. Each line becomes an Envelope keyed by `session`, with
-project/branch/model labels and token-usage as numeric fields. Sub-agent (sidechain) transcripts
-are ingested into the SAME source, tagged `sidechain=true`.
-
-Cursor: a JSON map of {filepath: byte_offset}, so growing files resume where we left off and new
-session files get picked up on the next poll. Secrets are redacted before storage (thin PII guard).
+Push-only: install the plugin (claude-plugin/) to feed it. Local file tailing was removed in favor of
+the plugin, which covers both local and remote NavFlow with one path.
 """
 from __future__ import annotations
 
-import json
 import re
 from datetime import datetime
 from pathlib import Path
 
 from ..envelope import Envelope, now_utc
 from .base import Connector
-
-# Cap how many events one poll ingests, so the first poll over a big ~/.claude history drains over
-# several polls instead of one daemon-stalling batch (same idea as the docker_logs backlog cap).
-MAX_PER_POLL = 2000
 
 # Thin PII guard: redact obvious secrets/tokens before anything is stored. Not exhaustive — a real
 # ship would add a configurable redaction pass — but it covers the common credential shapes that
@@ -62,69 +56,30 @@ def _short(v, n: int = 80) -> str:
 
 class ClaudeCodeConnector(Connector):
     CONFIG_SCHEMA = {
-        "root": {"type": "string", "default": "~/.claude/projects",
-                 "help": "directory holding Claude Code session transcripts (one <session>.jsonl per session)"},
         "redact": {"type": "bool", "default": True,
                    "help": "redact obvious secrets/tokens before storing (PII guard)"},
         "include_thinking": {"type": "bool", "default": False,
                              "help": "include assistant <thinking> blocks in the rendered text"},
-        "push": {"type": "bool", "default": False, "advanced": True,
-                 "help": "fed by the Claude Code plugin via /ingest (don't tail files locally)"},
+        # Set by the plugin when it auto-creates the source; kept for compatibility. This connector
+        # is push-only, so poll() is a no-op regardless.
+        "push": {"type": "bool", "default": True, "advanced": True,
+                 "help": "fed by the Claude Code plugin via /ingest (this connector is push-only)"},
     }
     # synthesized correlation axes (surfaced in the source form; set on every event)
-    PROVIDES = ["session", "project", "branch", "model", "type", "sidechain"]
-    # this connector also accepts pushed events (the Claude Code plugin posts transcript lines to
-    # /ingest); the same source can tail locally OR be fed by the plugin (set `push` to skip tailing).
+    PROVIDES = [
+        {"name": "session", "primary": True, "help": "Claude Code session id (the key)"},
+        {"name": "project", "help": "working-directory project name"},
+        {"name": "branch", "help": "git branch"},
+        {"name": "model", "help": "model on assistant turns"},
+        {"name": "type", "help": "message type (user / assistant / tool_use / …)"},
+        {"name": "sidechain", "help": "sub-agent (sidechain) message"},
+    ]
+    # Push-only: the Claude Code plugin POSTs transcript lines to /ingest/claude_code; events are
+    # mapped by map_payload(). There is no local file tail.
     ACCEPTS_PUSH = True
 
     async def poll(self) -> list[Envelope]:
-        c = self.cfg.config
-        if c.get("push"):
-            return []   # plugin-fed source: events arrive via map_payload(), nothing to tail
-        root = Path(str(c.get("root", "~/.claude/projects"))).expanduser()
-        redact = c.get("redact", True)
-        include_thinking = c.get("include_thinking", False)
-        if not root.is_dir():
-            return []
-
-        try:
-            cursor = json.loads(self.store.get_cursor(self.cfg.name) or "{}")
-        except (ValueError, TypeError):
-            cursor = {}
-
-        out: list[Envelope] = []
-        # one level deep: <project-slug>/<sessionId>.jsonl (and sidechain agent-*.jsonl alongside)
-        for f in sorted(root.glob("*/*.jsonl")):
-            key = str(f)
-            try:
-                size = f.stat().st_size
-            except OSError:
-                continue
-            offset = cursor.get(key, 0)
-            if offset > size:        # file was truncated/rotated — re-read from the top
-                offset = 0
-            if offset >= size:
-                continue
-            with f.open("rb") as fh:
-                fh.seek(offset)
-                for raw in fh:
-                    if not raw.endswith(b"\n"):
-                        break        # partial last line still being written; resume next poll
-                    offset += len(raw)
-                    line = raw.decode("utf-8", "replace").strip()
-                    if not line:
-                        continue
-                    env = self._to_envelope(line, redact, include_thinking)
-                    if env is not None:
-                        out.append(env)
-                    if len(out) >= MAX_PER_POLL:
-                        break
-            cursor[key] = offset
-            if len(out) >= MAX_PER_POLL:
-                break
-
-        self.store.set_cursor(self.cfg.name, json.dumps(cursor))
-        return out
+        return []   # push-only: events arrive via map_payload() from the plugin
 
     # ── push ingestion (the Claude Code plugin posts transcript lines to /ingest) ──
     def map_payload(self, payload) -> list[Envelope]:
@@ -143,16 +98,7 @@ class ClaudeCodeConnector(Connector):
                     out.append(env)
         return out
 
-    # ── mapping: one JSONL line / object → one Envelope ───────────────────────
-    def _to_envelope(self, line: str, redact: bool, include_thinking: bool):
-        try:
-            o = json.loads(line)
-        except ValueError:
-            return None
-        if not isinstance(o, dict):
-            return None
-        return self._obj_to_envelope(o, redact, include_thinking)
-
+    # ── mapping: one JSONL object → one Envelope ───────────────────────────────
     def _obj_to_envelope(self, o: dict, redact: bool, include_thinking: bool):
         sid = o.get("sessionId")
         if not sid:

--- a/navflow/daemon.py
+++ b/navflow/daemon.py
@@ -543,6 +543,16 @@ def make_app() -> FastAPI:
         console surfaces it here so the operator can hand it to producers without shell access."""
         return {"ingest_token": INGEST_TOKEN or None, "ingest_required": bool(INGEST_TOKEN)}
 
+    @app.get("/api/capabilities")
+    async def capabilities():
+        """Host capabilities that gate local-only console features, so the UI can hide actions that
+        can't work on this deployment — e.g. a hosted cell has no Docker socket, so Auto-discover
+        would be a dead end. (Claude Code is plugin-based and works everywhere, so it's not gated.)"""
+        import shutil
+        return {
+            "discover_docker": shutil.which("docker") is not None or os.path.exists("/var/run/docker.sock"),
+        }
+
     @app.post("/api/sources/discover")
     async def discover_source(body: dict = Body(...)):
         from .connectors import REGISTRY
@@ -567,17 +577,6 @@ def make_app() -> FastAPI:
         except ValueError as e:
             _err(e)
 
-    @app.get("/api/integrations/claude_code")
-    def claude_code_integration():
-        """Local detection for the console's one-click "Connect Claude Code" card. Reports whether
-        Claude Code session transcripts exist on this (the daemon's) machine and whether a source is
-        already wired. Creating/removing the source is the normal source lifecycle (POST/DELETE
-        /api/sources) — this endpoint only powers the detect + status of the card."""
-        root = Path(os.path.expanduser("~/.claude/projects"))
-        available = root.is_dir()
-        sessions = len(list(root.glob("*/*.jsonl"))) if available else 0
-        connected = any(s.connector == "claude_code" for s in runtime.catalog.sources.values())
-        return {"available": available, "root": str(root), "sessions": sessions, "connected": connected}
 
     # ── management API: sources ───────────────────────────────────────────────
     @app.get("/api/sources")

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -57,6 +57,7 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
 export const api = {
   health: () => request<{ status: string; readonly: boolean; auth_required: boolean }>("/health"),
   connectors: () => request<Record<string, ConnectorSpec>>("/api/connectors"),
+  capabilities: () => request<{ discover_docker: boolean }>("/api/capabilities"),
   security: () =>
     request<{ ingest_token: string | null; ingest_required: boolean }>("/api/security"),
 
@@ -78,9 +79,6 @@ export const api = {
       { method: "POST", body: JSON.stringify({ connector, config }) }),
   discoverEnvironment: (provider = "docker") =>
     request<EnvScan>(`/api/discover/environment?provider=${provider}`),
-  claudeCodeStatus: () =>
-    request<{ available: boolean; root: string; sessions: number; connected: boolean }>(
-      "/api/integrations/claude_code"),
   sourceEvents: (name: string, limit = 50) =>
     request<SourceEvent[]>(`/api/sources/${name}/events?limit=${limit}`),
   sourceFields: (name: string) =>

--- a/ui/src/pages/SourceClaudeCode.tsx
+++ b/ui/src/pages/SourceClaudeCode.tsx
@@ -1,132 +1,118 @@
 import { useEffect, useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
 
 import { api } from "../api";
-import ConfirmDialog from "../components/ConfirmDialog";
 import { usePolling } from "../components/bits";
 
-type Status = { available: boolean; root: string; sessions: number; connected: boolean };
+function Copy({ text }: { text: string }) {
+  const [done, setDone] = useState(false);
+  return (
+    <button
+      className="copybtn"
+      onClick={() => {
+        navigator.clipboard?.writeText(text);
+        setDone(true);
+        setTimeout(() => setDone(false), 1500);
+      }}
+    >
+      {done ? "copied" : "copy"}
+    </button>
+  );
+}
 
-// Dedicated setup page for the Claude Code source — reached from the "Claude Code" button on the
-// Sources page. Treats Claude Code like any other source: detect, choose what to ingest, connect.
-// Nothing is ingested until the user connects; disconnecting removes the source.
+const INSTALL = "/plugin marketplace add glassflow/navflow\n/plugin install navflow@navflow";
+
+// Claude Code is fed by the NavFlow plugin (push), not by tailing files — so this page shows the
+// install command wired to THIS instance's URL, identical for local and remote.
 export default function SourceClaudeCode() {
-  const nav = useNavigate();
-  const { data: sources, reload } = usePolling(() => api.sources(), 10000);
-  const [st, setSt] = useState<Status>();
-  const [redact, setRedact] = useState(true);
-  const [includeThinking, setIncludeThinking] = useState(false);
-  const [pushMode, setPushMode] = useState(false);
-  const [busy, setBusy] = useState(false);
-  const [err, setErr] = useState<string>();
-  const [confirmDisc, setConfirmDisc] = useState(false);
+  const origin = window.location.origin;
+  const { data: sources } = usePolling(() => api.sources(), 10000);
+  const [sec, setSec] = useState<{ ingest_token: string | null; ingest_required: boolean }>();
 
-  const refresh = () => api.claudeCodeStatus().then(setSt).catch(() => setSt(undefined));
-  useEffect(() => { refresh(); }, []);  // eslint-disable-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    api.security().then(setSec).catch(() => setSec(undefined));
+  }, []);
 
-  const connected = (sources?.some((s) => s.connector === "claude_code")) ?? st?.connected ?? false;
-
-  const connect = async () => {
-    setBusy(true); setErr(undefined);
-    const config: Record<string, unknown> = {};
-    if (!redact) config.redact = false;            // redact defaults on; only store the override
-    if (includeThinking) config.include_thinking = true;
-    if (pushMode) config.push = true;              // fed by the plugin via /ingest, not tailed here
-    try {
-      await api.createSource({ name: "claude_code", connector: "claude_code", poll: "10s", config });
-      reload();
-      nav("/sources/claude_code");                 // hand off to the normal source detail page
-    } catch (e) { setErr(String((e as Error).message ?? e)); setBusy(false); }
-  };
-
-  const disconnect = async () => {
-    setBusy(true); setErr(undefined);
-    try { await api.deleteSource("claude_code", false); await refresh(); reload(); }
-    catch (e) { setErr(String((e as Error).message ?? e)); }
-    finally { setBusy(false); }
-  };
+  const connected = sources?.some((s) => s.connector === "claude_code") ?? false;
+  const token = sec?.ingest_token ?? "";
 
   return (
     <>
-      <h1>Claude Code sessions</h1>
+      <h1>Connect Claude Code</h1>
       <p className="subtitle">
-        Stream this machine's Claude Code sessions into NavFlow — keyed by session, with project,
-        branch and model labels. Secrets are redacted. Nothing is ingested until you connect.
+        Install the NavFlow plugin for Claude Code — it streams your sessions into the{" "}
+        <span className="mono">claude_code</span> source (keyed by session, with project / branch /
+        model labels; secrets redacted server-side) and adds MCP read-back. Same steps local or remote.
       </p>
 
-      {err && <div className="alert error">{err}</div>}
+      {connected && (
+        <div className="panel">
+          <div className="pagehead">
+            <h2 style={{ margin: 0 }}>Status</h2>
+            <span className="badge ok">connected</span>
+          </div>
+          <p className="help" style={{ marginTop: 8 }}>
+            A <span className="mono">claude_code</span> source exists — sessions are streaming in.{" "}
+            <Link to="/sources/claude_code">Manage source</Link>.
+          </p>
+        </div>
+      )}
 
       <div className="panel">
-        <div className="pagehead" style={{ marginBottom: st?.available || !st ? 8 : 0 }}>
-          <h2 style={{ margin: 0 }}>Detection</h2>
-          {connected && <span className="badge ok">connected</span>}
-        </div>
-        {!st && <div className="dim">checking this machine…</div>}
-        {st && (
-          <div className="help" style={{ whiteSpace: "normal" }}>
-            {st.available
-              ? <><span className="mono">{st.sessions}</span> session{st.sessions === 1 ? "" : "s"} found in <span className="mono">{st.root}</span></>
-              : <>No Claude Code sessions found here (<span className="mono">~/.claude/projects</span> not present). If NavFlow is running remotely, you'll connect from your own machine instead.</>}
+        <h2 style={{ marginTop: 0 }}>1. Install the plugin</h2>
+        <p className="help" style={{ marginTop: 0 }}>In Claude Code, run:</p>
+        <div className="codeblock">
+          <div className="codeblock-head">
+            <span>claude code</span>
+            <Copy text={INSTALL} />
           </div>
-        )}
+          <pre className="payload">{INSTALL}</pre>
+        </div>
       </div>
 
-      {connected ? (
-        <div className="panel">
-          <p className="subtitle" style={{ marginTop: 0 }}>
-            Connected — sessions are tailing into the <span className="mono">claude_code</span> source.
-            Edit what's ingested or remove it from the source page.
-          </p>
-          <div className="btnrow">
-            <Link className="btn primary" to="/sources/claude_code">Manage source</Link>
-            <button className="danger" onClick={() => setConfirmDisc(true)} disabled={busy}>{busy ? "…" : "Disconnect"}</button>
-          </div>
-        </div>
-      ) : (
-        <div className="panel">
-          <h2 style={{ marginTop: 0 }}>What to ingest</h2>
-          <label className="field" style={{ marginBottom: 12 }}>
-            <span style={{ display: "inline-flex", gap: 8, alignItems: "center", fontWeight: 600, fontSize: 13 }}>
-              <input type="checkbox" checked={redact} onChange={(e) => setRedact(e.target.checked)} />
-              Redact secrets <span className="dim" style={{ fontWeight: 400 }}>(recommended)</span>
-            </span>
-            <span className="help">Strip obvious API keys, tokens and private keys from text and payload before storage.</span>
-          </label>
-          <label className="field" style={{ marginBottom: 12 }}>
-            <span style={{ display: "inline-flex", gap: 8, alignItems: "center", fontWeight: 600, fontSize: 13 }}>
-              <input type="checkbox" checked={includeThinking} onChange={(e) => setIncludeThinking(e.target.checked)} />
-              Include assistant thinking
-            </span>
-            <span className="help">Ingest the model's private reasoning blocks into the event text. Off by default.</span>
-          </label>
-          <label className="field">
-            <span style={{ display: "inline-flex", gap: 8, alignItems: "center", fontWeight: 600, fontSize: 13 }}>
-              <input type="checkbox" checked={pushMode} onChange={(e) => setPushMode(e.target.checked)} />
-              Stream via the Claude Code plugin <span className="dim" style={{ fontWeight: 400 }}>(don't read files here)</span>
-            </span>
-            <span className="help">
-              For remote NavFlow, or to capture live via hooks: the plugin posts sessions to this source
-              instead of NavFlow tailing files on this machine. Install the plugin from <span className="mono">claude-plugin/</span>.
-            </span>
-          </label>
-          <div className="btnrow" style={{ marginTop: 8 }}>
-            <button className="primary" onClick={connect} disabled={busy || (!!st && !st.available)}>
-              {busy ? "Connecting…" : "Connect"}
-            </button>
-            <Link className="btn" to="/">Cancel</Link>
-          </div>
-        </div>
-      )}
+      <div className="panel">
+        <h2 style={{ marginTop: 0 }}>2. Point it at this NavFlow</h2>
+        <p className="help" style={{ marginTop: 0 }}>When the installer prompts you, enter:</p>
 
-      {confirmDisc && (
-        <ConfirmDialog
-          title="Disconnect Claude Code?"
-          message="The source is removed and new sessions stop streaming. Stored session events are kept unless you later delete the source with purge."
-          confirmLabel="Disconnect" danger
-          onCancel={() => setConfirmDisc(false)}
-          onConfirm={() => { setConfirmDisc(false); disconnect(); }}
-        />
-      )}
+        <label className="field">
+          <span className="lbl">NavFlow URL</span>
+          <div className="btnrow" style={{ alignItems: "center" }}>
+            <code className="payload" style={{ flex: 1, margin: 0 }}>{origin}</code>
+            <Copy text={origin} />
+          </div>
+        </label>
+
+        <label className="field" style={{ marginTop: 12 }}>
+          <span className="lbl">
+            Auth token{sec && !token && <span className="dim"> (not required)</span>}
+          </span>
+          {token ? (
+            <>
+              <div className="btnrow" style={{ alignItems: "center" }}>
+                <code className="payload" style={{ flex: 1, margin: 0, wordBreak: "break-all" }}>
+                  {token}
+                </code>
+                <Copy text={token} />
+              </div>
+              <span className="help">
+                This instance requires an ingest token — the plugin sends it when shipping sessions.
+              </span>
+            </>
+          ) : (
+            <span className="help">
+              This instance doesn&rsquo;t require an ingest token — leave it blank.
+            </span>
+          )}
+        </label>
+      </div>
+
+      <div className="panel">
+        <p className="help" style={{ marginTop: 0 }}>
+          Sessions stream <strong>from install onward</strong> (existing sessions aren&rsquo;t
+          backfilled). Once you run a session, the <span className="mono">claude_code</span> source
+          shows up under <Link to="/">Sources</Link>.
+        </p>
+      </div>
     </>
   );
 }

--- a/ui/src/pages/SourceNew.tsx
+++ b/ui/src/pages/SourceNew.tsx
@@ -27,7 +27,8 @@ export default function SourceNew() {
           <thead><tr><th>connector</th><th>mode</th><th>what it does</th></tr></thead>
           <tbody>
             {Object.entries(specs).map(([key, s]) => (
-              <tr key={key} className="clickable" onClick={() => setConnector(key)}>
+              <tr key={key} className="clickable"
+                  onClick={() => key === "claude_code" ? nav("/sources/claude-code") : setConnector(key)}>
                 <td className="mono">{key}</td>
                 <td><span className={`badge ${s.mode === "push" ? "push" : "ok"}`}>{s.mode}</span></td>
                 <td>{s.description}</td>

--- a/ui/src/pages/Sources.tsx
+++ b/ui/src/pages/Sources.tsx
@@ -8,6 +8,9 @@ import { StatusBadge, TimeAgo, usePolling } from "../components/bits";
 export default function Sources() {
   const nav = useNavigate();
   const { data: sources, error } = usePolling(() => api.sources());
+  // Host capabilities gate local-only actions: hide Auto-discover where Docker isn't reachable
+  // (a hosted cell, or a local box without Docker). Shown until known false.
+  const { data: caps } = usePolling(() => api.capabilities());
 
   const [q, setQ] = useState("");
   const [status, setStatus] = useState("all");
@@ -37,8 +40,9 @@ export default function Sources() {
           <p className="subtitle">everything NavFlow ingests — <em>lossless, normalized, one project</em></p>
         </div>
         <span className="btnrow">
-          <Link to="/sources/discover" className="btn">✦ Auto-discover</Link>
-          <Link to="/sources/claude-code" className="btn">Claude Code</Link>
+          {caps?.discover_docker !== false && (
+            <Link to="/sources/discover" className="btn">✦ Auto-discover</Link>
+          )}
           <Link to="/sources/new" className="btn primary">Add source</Link>
         </span>
       </div>
@@ -55,8 +59,10 @@ export default function Sources() {
 
       {sources && sources.length === 0 && (
         <div className="empty">
-          No sources yet. <Link to="/sources/discover">Auto-discover from Docker</Link>,{" "}
-          <Link to="/sources/new">add one by hand</Link>, or import a catalog YAML.
+          No sources yet — <Link to="/sources/new">add one by hand</Link> or import a catalog YAML
+          {caps?.discover_docker !== false && (
+            <>, or <Link to="/sources/discover">auto-discover from Docker</Link></>
+          )}.
         </div>
       )}
 


### PR DESCRIPTION
Reworks the two **local-only** console actions so a hosted deployment isn't offered dead ends, and consolidates Claude Code capture on the **plugin** (which works local *and* remote — a hosted cell has no local `~/.claude` to tail).

## Claude Code → plugin-only
- **Connector is push-only.** Removed the local file tail (`poll()` is now a no-op); the plugin POSTs transcript lines to `/ingest/claude_code`. `map_payload` + **server-side redaction** are unchanged, so pushed data is redacted exactly as before.
- **Header button removed.** Claude Code is no longer a Sources-header shortcut. It's reached via **Add source → `claude_code`**, which routes to a **plugin-install page** showing the install command wired to *this instance's* URL (`window.location.origin`) and the token (from `/api/security`, or "not required" when open) — identical steps local or remote. Capture is forward-only.
- Removed the obsolete `GET /api/integrations/claude_code` local-detection route.

### Also fixes a latent crash
`claude_code`'s `PROVIDES` was a list of **strings**, but `source_fields` (`daemon.py`) and `SPECS["provides"]` expect the `{name, help, primary}` **dict** form (as `github`/`vercel` use). So viewing **any** `claude_code` source's fields (`/api/sources/{name}/fields`) always raised `TypeError`. Converted to the dict form — verified `/fields` now returns 200.

## Auto-discover gated by capability
- `GET /api/capabilities` → `{ discover_docker }` (auth-gated): `docker` on PATH or `/var/run/docker.sock` present.
- The Sources page hides **Auto-discover** when Docker isn't reachable (a hosted cell, or a local box without Docker). Shown until known-false, so local users see no flicker. Framed as *capability*, not "local vs hosted".

## Docs
- `claude-plugin/README.md`: the source is push-only (tailing removed), forward-only. (Website connector docs updated in a companion PR.)

## Verification
- `npm run build` (console) passes.
- Daemon smoke tests: `/api/capabilities` → `{discover_docker:true}`; removed route 404s; `claude_code` push source create (201) + ingest (202) map correctly; `/fields` returns 200 (no crash).