### PR TITLE
ci: build the navflow image multi-arch (amd64 + arm64)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: docker/setup-qemu-action@v3   # arm64 emulation for the multi-arch build
+
       - uses: docker/setup-buildx-action@v3
 
       - uses: docker/login-action@v3
@@ -39,6 +41,7 @@ jobs:
           context: .
           file: deploy/docker/Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha


### PR DESCRIPTION
The `publish` job built the main image only for the runner's architecture (amd64), so `docker pull ghcr.io/glassflow/navflow:<tag>` (and `docker compose` self-host) on **Apple Silicon** fails with `no matching manifest for linux/arm64`. The demo-image job was already multi-arch; this brings the main image in line.

- Add `docker/setup-qemu-action@v3` (arm64 emulation) and `platforms: linux/amd64,linux/arm64` to the build-push step.

Note: arm64 is built under QEMU emulation, so the publish job will be slower. Cache scopes are already separate from the demo job, so no cache clash.

After merge, the next release publishes a multi-arch manifest. (`0.1.5` was published amd64-only just before this; it can be superseded by the next release.)