### PR TITLE
Console + GitHub connector fixes for hosted deployments

### DIFF
--- a/navflow/connectors/__init__.py
+++ b/navflow/connectors/__init__.py
@@ -59,7 +59,7 @@ SPECS = {
              "description": "Receives OTLP/HTTP logs, traces and metrics at POST /v1/{logs,traces,"
                             "metrics}. One source ingests every service; resource attributes "
                             "(service.name) become labels."},
-    "github": {"label": "GitHub commits", "mode": "poll", "discover": True,
+    "github": {"label": "GitHub commits", "mode": "poll", "discover": True, "poll": "2m",
                "description": "Polls a repo's commits (cursor by SHA); one event per commit, "
                               "keyed by repo, with author as a label."},
     "vercel": {"label": "Vercel logs", "mode": "push",

--- a/navflow/connectors/github.py
+++ b/navflow/connectors/github.py
@@ -42,9 +42,11 @@ class GithubConnector(Connector):
         "branch": {"type": "string",
                    "help": "branch to follow (default: the repo's default branch)"},
         "token": {"type": "string",
-                  "help": "GitHub token for private repos / higher rate limits "
+                  "help": "GitHub token — required for private repos, recommended otherwise: "
+                          "without one GitHub allows 60 API requests/hour per IP "
                           "(or set the GITHUB_TOKEN env var — kept out of the catalog)"},
-        "limit": {"type": "number", "default": 20, "help": "commits to fetch per poll"},
+        "limit": {"type": "number", "default": 20,
+                  "help": "newest commits fetched per poll (the first poll imports this many)"},
         "api_url": {"type": "string", "advanced": True,
                     "help": "GitHub API base for GitHub Enterprise (default https://api.github.com)"},
     }
@@ -63,13 +65,29 @@ class GithubConnector(Connector):
         params = {"per_page": int(c.get("limit", 20))}
         if c.get("branch"):
             params["sha"] = c["branch"]
+        headers = _headers(token)
+        # Conditional request: a 304 costs nothing against the rate limit (60/h unauthenticated),
+        # so steady polling only spends quota when there are actually new commits.
+        etag = getattr(self, "_etag", None)
+        if etag:
+            headers["If-None-Match"] = etag
         try:
             async with httpx.AsyncClient(timeout=15) as cx:
-                r = await cx.get(f"{api}/repos/{repo}/commits", params=params, headers=_headers(token))
-        except Exception:
-            return []
+                r = await cx.get(f"{api}/repos/{repo}/commits", params=params, headers=headers)
+        except Exception as e:
+            raise ValueError(f"could not reach GitHub: {e}")
+        if r.status_code == 304:
+            return []   # unchanged since last poll
+        if r.status_code in (403, 429) and r.headers.get("x-ratelimit-remaining") == "0":
+            raise ValueError("GitHub rate limit exhausted (unauthenticated: 60 requests/hour per IP)"
+                             " — set a token or raise the poll interval")
+        if r.status_code == 404:
+            raise ValueError(f"repo {repo!r} not found — private repos need a token")
+        if r.status_code == 401:
+            raise ValueError("GitHub rejected the token (401 unauthorized)")
         if r.status_code != 200:
-            return []
+            raise ValueError(f"GitHub returned {r.status_code} for {repo!r}")
+        self._etag = r.headers.get("etag")
         commits = r.json()
         if not isinstance(commits, list) or not commits:
             return []

--- a/ui/src/components/IngestSetup.tsx
+++ b/ui/src/components/IngestSetup.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+
+import { api } from "../api";
+
+// Auth + setup hints shown next to a push source's ingest URL. When this instance requires an
+// ingest token (a hosted cell always does), the bare URL is not enough — producers get a 401 —
+// so surface the token header and a paste-ready snippet right where the URL is handed out.
+// Renders nothing when ingest is open (a plain local install).
+export default function IngestSetup({ connector, url }: { connector: string; url: string }) {
+  const [sec, setSec] = useState<{ ingest_token: string | null; ingest_required: boolean }>();
+  const [revealed, setRevealed] = useState(false);
+  useEffect(() => { api.security().then(setSec).catch(() => {}); }, []);
+
+  if (!sec?.ingest_required || !sec.ingest_token) return null;
+  const token = sec.ingest_token;
+  const shown = revealed ? token : mask(token);
+
+  const snippet = connector === "otlp"
+    ? [
+        `OTEL_EXPORTER_OTLP_PROTOCOL=http/json`,
+        `OTEL_EXPORTER_OTLP_ENDPOINT=${new URL(url).origin}`,
+        `OTEL_EXPORTER_OTLP_HEADERS=X-NavFlow-Token=${token}`,
+      ].join("\n")
+    : [
+        `curl -X POST ${url} \\`,
+        `  -H 'Content-Type: application/json' \\`,
+        `  -H 'X-NavFlow-Token: ${token}' \\`,
+        `  -d '{"message": "hello from my producer"}'`,
+      ].join("\n");
+
+  return (
+    <div className="ingest-setup">
+      <p className="muted">
+        This instance requires the <Link to="/security">ingest token</Link> — send it as an{" "}
+        <span className="mono">X-NavFlow-Token</span> header (or{" "}
+        <span className="mono">Authorization: Bearer</span>):
+      </p>
+      <div className="ingest-url">
+        <code className="mono">X-NavFlow-Token: {shown}</code>
+        <button onClick={() => setRevealed((r) => !r)}>{revealed ? "hide" : "reveal"}</button>
+        <CopyBtn text={token} label="copy token" />
+      </div>
+      <p className="muted" style={{ marginTop: 12 }}>
+        {connector === "otlp"
+          ? <>Exporter setup — NavFlow accepts OTLP/HTTP <strong>JSON</strong> (not protobuf); use a
+              JSON-capable exporter, e.g. the OTel Collector's <span className="mono">otlphttp</span>{" "}
+              exporter with <span className="mono">encoding: json</span>:</>
+          : <>Or test it right away:</>}
+      </p>
+      <div className="ingest-url">
+        <code className="mono" style={{ whiteSpace: "pre-wrap" }}>
+          {revealed ? snippet : snippet.replace(token, mask(token))}
+        </code>
+        <CopyBtn text={snippet} label="copy" />
+      </div>
+    </div>
+  );
+}
+
+function mask(token: string) {
+  return token.length > 8 ? `${token.slice(0, 4)}…${token.slice(-4)}` : "••••••••";
+}
+
+function CopyBtn({ text, label }: { text: string; label: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <button onClick={() => {
+      navigator.clipboard?.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    }}>{copied ? "copied" : label}</button>
+  );
+}

--- a/ui/src/components/SourceForm.tsx
+++ b/ui/src/components/SourceForm.tsx
@@ -11,6 +11,11 @@ const DEFAULT_LABELS: Record<string, Array<Record<string, unknown>>> = {
   otlp: [{ name: "service", field: "service.name", primary: true }],
 };
 
+// Connector-appropriate example names; the generic fallback suits metric-ish sources.
+const NAME_PLACEHOLDER: Record<string, string> = {
+  github: "e.g. my-repo-commits",
+};
+
 interface Props {
   connector: string;
   spec: ConnectorSpec;
@@ -27,7 +32,7 @@ interface Props {
 export default function SourceForm({ connector, spec, initial, lockName, submitLabel, onSubmit }: Props) {
   const [name, setName] = useState(initial?.name ?? "");
   const type = initial?.type ?? "event_stream";  // ignored by the daemon; derived from connector
-  const [poll, setPoll] = useState(initial?.poll ?? "5s");
+  const [poll, setPoll] = useState(initial?.poll ?? spec.poll ?? "5s");
   const [values, setValues] = useState<Record<string, string>>(() => {
     const v: Record<string, string> = {};
     for (const f of spec.fields) {
@@ -109,7 +114,7 @@ export default function SourceForm({ connector, spec, initial, lockName, submitL
       .map((r) => ({ name: r.name.trim(), [r.kind]: r.value, ...(r.primary ? { primary: true } : {}) }));
     if (labels.length) config.labels = labels;
     if (!name.trim()) throw new Error("name is required");
-    return { name: name.trim(), type, connector, poll: poll.trim() || "5s", config };
+    return { name: name.trim(), type, connector, poll: poll.trim() || spec.poll || "5s", config };
   };
 
   const run = async (fn: () => Promise<void>) => {
@@ -197,7 +202,8 @@ export default function SourceForm({ connector, spec, initial, lockName, submitL
 
       <label className="field" style={{ maxWidth: 360 }}>
         <span className="lbl">name <span className="req">*</span></span>
-        <input type="text" value={name} disabled={lockName} placeholder="e.g. metrics"
+        <input type="text" value={name} disabled={lockName}
+               placeholder={NAME_PLACEHOLDER[connector] ?? "e.g. metrics"}
                onChange={(e) => setName(e.target.value)} />
         <span className="help">logical source name; events carry it forever</span>
       </label>

--- a/ui/src/pages/SourceDetail.tsx
+++ b/ui/src/pages/SourceDetail.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams } from "react-router-dom";
 
 import { api } from "../api";
 import ConfirmDialog from "../components/ConfirmDialog";
+import IngestSetup from "../components/IngestSetup";
 import SourceForm from "../components/SourceForm";
 import { StatusBadge, TimeAgo, usePolling } from "../components/bits";
 import type { ConnectorSpec, Source } from "../types";
@@ -214,14 +215,17 @@ function IngestEndpoint({ source }: { source: Source }) {
         <div className="k">OTLP endpoint</div>
         <CopyableUrl url={`${origin}/v1/logs`} />
         <p className="muted">Point an OTLP/HTTP exporter here (also <span className="mono">/v1/traces</span>, <span className="mono">/v1/metrics</span>).</p>
+        <IngestSetup connector="otlp" url={`${origin}/v1/logs`} />
       </div>
     );
   }
+  const url = `${origin}/ingest/${source.ingest_key || source.name}`;
   return (
     <div className="card ingest-card">
       <div className="k">ingest endpoint · POST</div>
-      <CopyableUrl url={`${origin}/ingest/${source.ingest_key || source.name}`} />
+      <CopyableUrl url={url} />
       <p className="muted">Point your producer (e.g. a Vercel log drain) at this URL.</p>
+      <IngestSetup connector={source.connector} url={url} />
     </div>
   );
 }

--- a/ui/src/pages/SourceNew.tsx
+++ b/ui/src/pages/SourceNew.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 
 import { api } from "../api";
+import IngestSetup from "../components/IngestSetup";
 import SourceForm from "../components/SourceForm";
 import type { ConnectorSpec } from "../types";
 
@@ -10,8 +11,14 @@ export default function SourceNew() {
   const [specs, setSpecs] = useState<Record<string, ConnectorSpec>>();
   const [connector, setConnector] = useState<string>();
   const [created, setCreated] = useState<{ name: string; key: string }>();
+  // Host capabilities gate local-only connectors: docker_logs shells out to `docker logs` on the
+  // NavFlow host, so on a hosted cell (no Docker socket) it can only ever ingest nothing.
+  // Enabled until known false, matching Sources.tsx.
+  const [caps, setCaps] = useState<{ discover_docker: boolean }>();
 
-  useEffect(() => { api.connectors().then(setSpecs); }, []);
+  useEffect(() => { api.connectors().then(setSpecs); api.capabilities().then(setCaps); }, []);
+
+  const unavailable = (key: string) => key === "docker_logs" && caps?.discover_docker === false;
 
   const spec = specs && connector ? specs[connector] : undefined;
 
@@ -27,12 +34,20 @@ export default function SourceNew() {
           <thead><tr><th>connector</th><th>mode</th><th>what it does</th></tr></thead>
           <tbody>
             {Object.entries(specs).map(([key, s]) => (
-              <tr key={key} className="clickable"
-                  onClick={() => key === "claude_code" ? nav("/sources/claude-code") : setConnector(key)}>
-                <td className="mono">{key}</td>
-                <td><span className={`badge ${s.mode === "push" ? "push" : "ok"}`}>{s.mode}</span></td>
-                <td>{s.description}</td>
-              </tr>
+              unavailable(key) ? (
+                <tr key={key} className="dim">
+                  <td className="mono">{key}</td>
+                  <td><span className="badge starting">unavailable</span></td>
+                  <td>{s.description} <em>Needs Docker on the NavFlow host — not available on this deployment.</em></td>
+                </tr>
+              ) : (
+                <tr key={key} className="clickable"
+                    onClick={() => key === "claude_code" ? nav("/sources/claude-code") : setConnector(key)}>
+                  <td className="mono">{key}</td>
+                  <td><span className={`badge ${s.mode === "push" ? "push" : "ok"}`}>{s.mode}</span></td>
+                  <td>{s.description}</td>
+                </tr>
+              )
             ))}
           </tbody>
         </table>
@@ -97,6 +112,7 @@ function IngestUrl({ connector, sourceKey }: { connector: string; sourceKey: str
       {connector === "otlp"
         ? <p className="muted">Point an OTLP/HTTP exporter here (also <span className="mono">/v1/traces</span>, <span className="mono">/v1/metrics</span>).</p>
         : <p className="muted">It accepts JSON or NDJSON; data flows in as soon as the producer posts.</p>}
+      <IngestSetup connector={connector} url={url} />
     </>
   );
 }

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -448,6 +448,9 @@ pre.payload {
 }
 .ingest-url button { white-space: nowrap; }
 .ingest-card .muted { margin: 0.4rem 0 0; font-size: 13px; }
+.ingest-setup { margin-top: 0.9rem; }
+.ingest-setup .muted { margin: 0 0 0.4rem; font-size: 13px; }
+.ingest-setup .ingest-url { margin-bottom: 0.6rem; align-items: flex-start; }
 
 /* field coverage bars (source detail) */
 .cov { height: 6px; background: var(--wash-2); border-radius: 3px; overflow: hidden; margin-bottom: 3px; }

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -33,6 +33,7 @@ export interface ConnectorSpec {
   label: string;
   mode: "poll" | "push";
   discover?: boolean;
+  poll?: string;   // connector-specific default poll interval (e.g. github: "2m")
   description: string;
   fields: ConnectorField[];
   provides?: { name: string; primary?: boolean; help?: string }[];   // synthesized label fields


### PR DESCRIPTION
Fixes from testing the managed cloud deployment from a user's POV:

- **docker_logs marked unavailable in Add Source** when the host has no Docker (capability-gated, same convention as the Auto-discover button). Previously a hosted user could create a source that silently ingests nothing.
- **Ingest-token setup instructions** on the source-created screen and source detail page: when the instance requires an ingest token, show the `X-NavFlow-Token` header (masked, reveal/copy) plus a paste-ready snippet — OTLP exporter env vars (including the OTLP/HTTP **JSON**-only note) or a curl example. Previously only the bare URL was shown and producers got an unexplained 401.
- **GitHub connector: surface errors instead of swallowing them.** Rate limit / 404 / 401 / network failures now raise with a readable message, so the source shows `error` + reason instead of a healthy-looking empty source.
- **GitHub connector: respect the rate limit.** ETag conditional requests (304s don't count against the 60/h unauthenticated quota) and a `2m` default poll interval for new GitHub sources (per-connector `poll` default in SPECS, honored by the form).
- Form copy: per-connector name placeholder (github: "e.g. my-repo-commits" instead of "e.g. metrics"), clearer token/limit help.