### PR TITLE
Postgres + source form UX: dsn field, discover-first layout, columns proposal

### DIFF
--- a/navflow/connectors/__init__.py
+++ b/navflow/connectors/__init__.py
@@ -66,7 +66,7 @@ SPECS = {
                "description": "Push source for Vercel logs — point a Vercel log drain (JSON) at this "
                               "source's ingest endpoint; one event per log entry, keyed by project, "
                               "with environment + source labels."},
-    "postgres": {"label": "Postgres table", "mode": "poll", "discover": True,
+    "postgres": {"label": "Postgres table", "mode": "poll", "discover": True, "poll": "30s",
                  "description": "Polls a table incrementally (cursor by an id or updated_at); one "
                                 "event per new/changed row, keyed by an entity column (tenant_id). "
                                 "Your application's source-of-truth data in the timeline."},
@@ -176,7 +176,8 @@ def _fields_from_schema(schema: dict) -> list:
     def scalar(name, spec):
         ftype = "number" if spec["type"] == "number" else "string"
         return {"name": name, "type": ftype, "required": spec.get("required", False),
-                "help": spec.get("help", "")}
+                "help": spec.get("help", ""), "secret": spec.get("secret", False),
+                "discover_input": spec.get("discover_input", False)}
 
     fields = []
     for name, spec in schema.items():

--- a/navflow/connectors/github.py
+++ b/navflow/connectors/github.py
@@ -51,11 +51,11 @@ def _headers(token: str | None) -> dict:
 
 class GithubConnector(Connector):
     CONFIG_SCHEMA = {
-        "repo": {"type": "string", "required": True,
+        "repo": {"type": "string", "required": True, "discover_input": True,
                  "help": "owner/name, e.g. glassflow/navflow (a pasted GitHub URL works too)"},
         "branch": {"type": "string",
                    "help": "branch to follow (default: the repo's default branch)"},
-        "token": {"type": "string",
+        "token": {"type": "string", "secret": True, "discover_input": True,
                   "help": "GitHub token — required for private repos, recommended otherwise: "
                           "without one GitHub allows 60 API requests/hour per IP "
                           "(or set the GITHUB_TOKEN env var — kept out of the catalog)"},

--- a/navflow/connectors/postgres.py
+++ b/navflow/connectors/postgres.py
@@ -69,10 +69,16 @@ def _connect(dsn: str):
 
 class PostgresConnector(Connector):
     CONFIG_SCHEMA = {
-        "table": {"type": "string", "required": True,
+        "table": {"type": "string", "required": True, "discover_input": True,
                   "help": "table to poll, e.g. orders or public.orders"},
+        "dsn": {"type": "string", "secret": True, "discover_input": True,
+                "help": "postgresql://user:pass@host:port/db — must be reachable from the NavFlow "
+                        "host (local installs can leave this empty and set PG_DSN on the daemon)"},
         "cursor_column": {"type": "string", "required": True,
-                          "help": "monotonic column to track new rows: an id or updated_at"},
+                          "help": "column that only ever grows, used to fetch just the new rows on "
+                                  "each poll: an autoincrement id (captures inserts only) or "
+                                  "updated_at (also captures row updates) — Discover picks this "
+                                  "for you"},
         "cursor_type": {"type": "string", "default": "int",
                         "help": "int (autoincrement id) or timestamp (updated_at)"},
         "key_column": {"type": "string",
@@ -82,8 +88,6 @@ class PostgresConnector(Connector):
                         "help": "timestamp column for event_time (default: the cursor column if it "
                                 "is a timestamp, else ingest time)"},
         "limit": {"type": "number", "default": 200, "help": "rows to fetch per poll"},
-        "dsn": {"type": "string", "advanced": True,
-                "help": "postgresql://user:pass@host:port/db (or set PG_DSN — kept out of the catalog)"},
     }
 
     async def poll(self) -> list[Envelope]:

--- a/navflow/connectors/prometheus.py
+++ b/navflow/connectors/prometheus.py
@@ -30,7 +30,7 @@ class PrometheusConnector(Connector):
     # The authoritative config schema — the source of truth every entry path (form, discover,
     # YAML, API) normalizes to. `SPECS["prometheus"].fields` is generated from it.
     CONFIG_SCHEMA = {
-        "url": {"type": "string", "required": True,
+        "url": {"type": "string", "required": True, "discover_input": True,
                 "help": "Prometheus base URL, e.g. http://localhost:9090"},
         "default_key": {"type": "string", "default": "unknown",
                         "help": "entity key for series that carry no key label"},

--- a/ui/src/components/SourceForm.tsx
+++ b/ui/src/components/SourceForm.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from "react";
 
 import { api } from "../api";
-import type { ConnectorField, ConnectorSpec, DiscoverProposal, EnvScan, TestResult } from "../types";
+import type { ColumnsProposal, ConnectorField, ConnectorSpec, DiscoverProposal, EnvScan, TestResult } from "../types";
 
 // Structured push connectors know their entity shape, so a fresh source starts with sensible
 // label axes (the user can still edit/remove them).
@@ -14,6 +14,14 @@ const DEFAULT_LABELS: Record<string, Array<Record<string, unknown>>> = {
 // Connector-appropriate example names; the generic fallback suits metric-ish sources.
 const NAME_PLACEHOLDER: Record<string, string> = {
   github: "e.g. my-repo-commits",
+  postgres: "e.g. orders-table",
+};
+
+// What Discover does, per connector (fallback: the prometheus introspection copy).
+const DISCOVER_HINT: Record<string, string> = {
+  docker_logs: "list the containers navflowd can see, then pick one to fill this form",
+  github: "enter the repo above, then Discover its default branch + author labels",
+  postgres: "enter the table (and DSN) above, then Discover proposes the cursor, entity key and labels from the table's columns",
 };
 
 interface Props {
@@ -66,6 +74,7 @@ export default function SourceForm({ connector, spec, initial, lockName, submitL
   const [test, setTest] = useState<TestResult>();
   const [busy, setBusy] = useState(false);
   const [proposal, setProposal] = useState<DiscoverProposal>();
+  const [colProposal, setColProposal] = useState<ColumnsProposal>();
   const [containers, setContainers] = useState<EnvScan["containers"]>();
 
   const jsonErrors = useMemo(() => {
@@ -135,10 +144,13 @@ export default function SourceForm({ connector, spec, initial, lockName, submitL
       if (raw && f.type !== "json") cfg[f.name] = f.type === "number" ? Number(raw) : raw;
     }
     const p = await api.discoverSource(connector, cfg);
-    // connectors whose discover proposes a config to confirm in a panel (prometheus) set `proposal`;
-    // simpler ones (github) just apply the proposed config and report a one-line summary
+    // connectors whose discover proposes a config to confirm in a panel set `proposal`
+    // (prometheus: metrics) or `colProposal` (postgres: table columns); simpler ones (github)
+    // just apply the proposed config and report a one-line summary
     if (Array.isArray((p as { metrics?: unknown[] }).metrics)) {
       setProposal(p);
+    } else if (Array.isArray((p as { columns?: unknown[] }).columns)) {
+      setColProposal(p as unknown as ColumnsProposal);
     } else {
       applyConfig((p as { proposed_config?: Record<string, unknown> }).proposed_config ?? {});
       const summary = (p as { summary?: unknown }).summary;
@@ -188,6 +200,25 @@ export default function SourceForm({ connector, spec, initial, lockName, submitL
     JSON.stringify(rs.filter((r) => r.name.trim()).map((r) => [r.name.trim(), r.kind, r.value, r.primary]));
   const labelsChanged = !!initial && canonRows(labelRows) !== canonRows(labelsToRows(initial?.config?.labels));
 
+  const renderField = (f: ConnectorField) =>
+    f.type === "list" ? (
+      <ListFieldEditor key={f.name} field={f} rows={rows[f.name] ?? []}
+                       onChange={(r) => setRows({ ...rows, [f.name]: r })} />
+    ) : (
+      <label className={"field" + (jsonErrors[f.name] ? " invalid" : "")} key={f.name}>
+        <span className="lbl">{f.name} {f.required && <span className="req">*</span>}</span>
+        {f.type === "json" ? (
+          <textarea className="code" value={values[f.name]}
+                    onChange={(e) => setValues({ ...values, [f.name]: e.target.value })} />
+        ) : (
+          <input type={f.secret ? "password" : f.type === "number" ? "number" : "text"}
+                 value={values[f.name]} autoComplete={f.secret ? "off" : undefined}
+                 onChange={(e) => setValues({ ...values, [f.name]: e.target.value })} />
+        )}
+        <span className="help">{jsonErrors[f.name] ?? f.help}</span>
+      </label>
+    );
+
   return (
     <form onSubmit={(e) => { e.preventDefault(); run(async () => onSubmit(build())); }}>
       {error && <div className="alert error">{error}</div>}
@@ -216,24 +247,7 @@ export default function SourceForm({ connector, spec, initial, lockName, submitL
         </label>
       )}
 
-      {spec.fields.map((f) => (
-        f.type === "list" ? (
-          <ListFieldEditor key={f.name} field={f} rows={rows[f.name] ?? []}
-                           onChange={(r) => setRows({ ...rows, [f.name]: r })} />
-        ) : (
-          <label className={"field" + (jsonErrors[f.name] ? " invalid" : "")} key={f.name}>
-            <span className="lbl">{f.name} {f.required && <span className="req">*</span>}</span>
-            {f.type === "json" ? (
-              <textarea className="code" value={values[f.name]}
-                        onChange={(e) => setValues({ ...values, [f.name]: e.target.value })} />
-            ) : (
-              <input type={f.type === "number" ? "number" : "text"} value={values[f.name]}
-                     onChange={(e) => setValues({ ...values, [f.name]: e.target.value })} />
-            )}
-            <span className="help">{jsonErrors[f.name] ?? f.help}</span>
-          </label>
-        )
-      ))}
+      {(spec.discover ? spec.fields.filter((f) => f.discover_input) : spec.fields).map(renderField)}
 
       {spec.discover && (
         <div className="panel" style={{ background: "var(--th-bg)", marginBottom: 14 }}>
@@ -242,14 +256,19 @@ export default function SourceForm({ connector, spec, initial, lockName, submitL
               ✦ {connector === "docker_logs" ? "Discover containers" : "Discover"}
             </button>
             <span className="help" style={{ margin: 0 }}>
-              {connector === "docker_logs"
-                ? "list the containers navflowd can see, then pick one to fill this form"
-                : connector === "github"
-                ? "enter the repo above, then Discover its default branch + author labels"
-                : "fill the URL above, then let NavFlow introspect the source and propose what to ingest — no PromQL to write by hand"}
+              {DISCOVER_HINT[connector]
+                ?? "fill the URL above, then let NavFlow introspect the source and propose what to ingest — no PromQL to write by hand"}
             </span>
           </div>
           {proposal && <ProposalView proposal={proposal} onApply={applyProposal} />}
+          {colProposal && (
+            <ColumnsProposalView proposal={colProposal}
+              onApply={() => {
+                applyConfig(colProposal.proposed_config);
+                setTest({ ok: true, note: colProposal.summary });
+                setColProposal(undefined);
+              }} />
+          )}
           {containers && (
             <table style={{ marginTop: 10 }}>
               <thead><tr><th>service</th><th>image</th><th></th></tr></thead>
@@ -271,6 +290,8 @@ export default function SourceForm({ connector, spec, initial, lockName, submitL
           )}
         </div>
       )}
+
+      {spec.discover && spec.fields.filter((f) => !f.discover_input).map(renderField)}
 
       <LabelsEditor rows={labelRows} onChange={setLabelRows}
                     fields={(spec.provides ?? []).map((p) => p.name)} />
@@ -408,6 +429,40 @@ function ListFieldEditor({ field, rows, onChange }:
       <button type="button" onClick={() => onChange([...rows, blank()])}>
         + Add {field.name === "queries" ? "query" : "row"}
       </button>
+    </div>
+  );
+}
+
+// Table-shaped discover result (postgres): every column with its type, badged with the role the
+// proposal assigns it (cursor / key / label), so the user sees the possible values before applying.
+function ColumnsProposalView({ proposal, onApply }: { proposal: ColumnsProposal; onApply: () => void }) {
+  const cfg = proposal.proposed_config as { cursor_column?: string; key_column?: string;
+                                            labels?: { field?: string }[] };
+  const labelFields = new Set((cfg.labels ?? []).map((l) => l.field).filter(Boolean));
+  const role = (col: string) =>
+    col === cfg.cursor_column ? "cursor" : col === cfg.key_column ? "key"
+      : labelFields.has(col) ? "label" : "";
+  return (
+    <div style={{ marginTop: 12 }}>
+      <p className="subtitle" style={{ marginTop: 0 }}>{proposal.summary}</p>
+      <table>
+        <thead><tr><th>column</th><th style={{ width: 180 }}>type</th><th style={{ width: 90 }}>proposed as</th></tr></thead>
+        <tbody>
+          {proposal.columns.map((c) => (
+            <tr key={c.name}>
+              <td className="mono">{c.name}</td>
+              <td className="help">{c.type}</td>
+              <td>{role(c.name) && <span className="chip">{role(c.name)}</span>}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <button type="button" className="primary" style={{ marginTop: 10 }} onClick={onApply}>
+        Apply to form
+      </button>
+      <span className="help" style={{ marginLeft: 10 }}>
+        fills the fields below — review, Test connection, then Create
+      </span>
     </div>
   );
 }

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -26,6 +26,8 @@ export interface ConnectorField {
   type: "string" | "number" | "json" | "list";
   required: boolean;
   help: string;
+  secret?: boolean;          // render as a password input (tokens, DSNs)
+  discover_input?: boolean;  // Discover needs this field — shown above the Discover panel
   item?: ConnectorField[];   // for type "list": the sub-fields of each row
 }
 
@@ -115,6 +117,15 @@ export interface DiscoverProposal {
   metrics: DiscoverMetric[];
   derived_suggestions: { id: string; label: string; promql: string; event_type: string; field: string; reason: string }[];
   proposed_config: { url: string; default_key: string; queries: unknown[]; labels: { name: string; field: string }[] };
+}
+
+// Discover response for table-shaped connectors (postgres): the columns found plus a proposed
+// config to review and apply. (Prometheus uses the richer DiscoverProposal above.)
+export interface ColumnsProposal {
+  connector: string;
+  summary: string;
+  columns: { name: string; type: string }[];
+  proposed_config: Record<string, unknown>;
 }
 
 export interface ViewFilter {


### PR DESCRIPTION
From cloud-POV testing of the postgres connector:

- **dsn is now a real form field** (was `advanced`/hidden — on a hosted cell, where env vars aren't settable, a postgres source couldn't be created from the console at all). New `secret` schema flag renders it (and github's token) as a password input.
- **Discover-first form layout**: fields Discover needs (`discover_input` flag — postgres table+dsn, github repo+token, prometheus url) render above the Discover panel; the fields Discover fills come after.
- **Postgres proposal panel**: Discover now shows the table's columns with proposed cursor/key/label badges and an explicit Apply, instead of silently rewriting the form (github keeps the silent apply + summary).
- Per-connector Discover hints (postgres users previously saw the Prometheus "no PromQL to write by hand" copy) and name placeholders; clearer cursor_column help.
- postgres default poll 30s (each poll opens a fresh connection; 5s was needlessly aggressive).

Verified end-to-end against a dockerized Postgres: discover proposal, incremental cursor polling, error paths; UI typecheck/build and connector tests pass.