### PR TITLE
Postgres: two-stage Discover, DSN-first form, database visibility

### DIFF
--- a/navflow/connectors/postgres.py
+++ b/navflow/connectors/postgres.py
@@ -69,11 +69,14 @@ def _connect(dsn: str):
 
 class PostgresConnector(Connector):
     CONFIG_SCHEMA = {
-        "table": {"type": "string", "required": True, "discover_input": True,
-                  "help": "table to poll, e.g. orders or public.orders"},
         "dsn": {"type": "string", "secret": True, "discover_input": True,
-                "help": "postgresql://user:pass@host:port/db — must be reachable from the NavFlow "
-                        "host (local installs can leave this empty and set PG_DSN on the daemon)"},
+                "help": "postgresql://user:pass@host:port/dbname — the path after the slash picks "
+                        "the database (omitted, Postgres silently defaults to a db named after "
+                        "the user). Must be reachable from the NavFlow host; local installs can "
+                        "leave this empty and set PG_DSN on the daemon"},
+        "table": {"type": "string", "required": True, "discover_input": True,
+                  "help": "table to poll, e.g. orders or public.orders — leave empty and Discover "
+                          "lists the tables it can see"},
         "cursor_column": {"type": "string", "required": True,
                           "help": "column that only ever grows, used to fetch just the new rows on "
                                   "each poll: an autoincrement id (captures inserts only) or "
@@ -159,9 +162,31 @@ class PostgresConnector(Connector):
 
     @classmethod
     async def discover(cls, config: dict) -> dict:
-        """Introspect a table: pick a cursor column (updated_at > id), guess the entity key
+        """Two-stage introspection. Without a table: list the tables the DSN can see, for the user
+        to pick. With a table: pick a cursor column (updated_at > id), guess the entity key
         (a *_id column), infer cursor_type from the column's data type, and propose labels."""
-        table = _ident(config.get("table") or "", "table", _TABLE)
+        if not config.get("table"):
+            conn = await _connect(_dsn(config))
+            try:
+                db = await conn.fetchval("SELECT current_database()")
+                rows = await conn.fetch(
+                    "SELECT table_schema, table_name FROM information_schema.tables "
+                    "WHERE table_type = 'BASE TABLE' "
+                    "AND table_schema NOT IN ('pg_catalog', 'information_schema') "
+                    "ORDER BY table_schema, table_name")
+            finally:
+                await conn.close()
+            if not rows:
+                raise ValueError(f"connected to database {db!r}, but no tables are visible — "
+                                 "wrong database in the DSN (the path after the slash), or the "
+                                 "user lacks privileges")
+            tables = [r["table_name"] if r["table_schema"] == "public"
+                      else f"{r['table_schema']}.{r['table_name']}" for r in rows]
+            return {"connector": "postgres", "tables": tables,
+                    "summary": f"connected to database {db!r} — {len(tables)} tables; "
+                               "pick one to introspect (another database needs its own "
+                               "source with its DSN)"}
+        table = _ident(config["table"], "table", _TABLE)
         schema, name = (table.split(".") + [None])[:2] if "." in table else (None, table)
         name = name or table
         conn = await _connect(_dsn(config))

--- a/ui/src/components/SourceForm.tsx
+++ b/ui/src/components/SourceForm.tsx
@@ -21,7 +21,7 @@ const NAME_PLACEHOLDER: Record<string, string> = {
 const DISCOVER_HINT: Record<string, string> = {
   docker_logs: "list the containers navflowd can see, then pick one to fill this form",
   github: "enter the repo above, then Discover its default branch + author labels",
-  postgres: "enter the table (and DSN) above, then Discover proposes the cursor, entity key and labels from the table's columns",
+  postgres: "enter the DSN above, then Discover — it lists the tables it can see; pick one and it proposes the cursor, entity key and labels from the columns",
 };
 
 interface Props {
@@ -75,6 +75,7 @@ export default function SourceForm({ connector, spec, initial, lockName, submitL
   const [busy, setBusy] = useState(false);
   const [proposal, setProposal] = useState<DiscoverProposal>();
   const [colProposal, setColProposal] = useState<ColumnsProposal>();
+  const [tables, setTables] = useState<string[]>();
   const [containers, setContainers] = useState<EnvScan["containers"]>();
 
   const jsonErrors = useMemo(() => {
@@ -133,7 +134,7 @@ export default function SourceForm({ connector, spec, initial, lockName, submitL
     setBusy(false);
   };
 
-  const discover = () => run(async () => {
+  const discover = (override?: Record<string, unknown>) => run(async () => {
     if (connector === "docker_logs") {
       setContainers((await api.discoverEnvironment("docker")).containers);
       return;
@@ -143,20 +144,31 @@ export default function SourceForm({ connector, spec, initial, lockName, submitL
       const raw = values[f.name]?.trim();
       if (raw && f.type !== "json") cfg[f.name] = f.type === "number" ? Number(raw) : raw;
     }
+    Object.assign(cfg, override);
     const p = await api.discoverSource(connector, cfg);
     // connectors whose discover proposes a config to confirm in a panel set `proposal`
-    // (prometheus: metrics) or `colProposal` (postgres: table columns); simpler ones (github)
-    // just apply the proposed config and report a one-line summary
+    // (prometheus: metrics), `colProposal` (postgres: table columns) or `tables` (postgres
+    // without a table yet: pick one); simpler ones (github) just apply the proposed config
+    // and report a one-line summary
     if (Array.isArray((p as { metrics?: unknown[] }).metrics)) {
       setProposal(p);
     } else if (Array.isArray((p as { columns?: unknown[] }).columns)) {
       setColProposal(p as unknown as ColumnsProposal);
+    } else if (Array.isArray((p as { tables?: unknown[] }).tables)) {
+      setTables((p as unknown as { tables: string[] }).tables);
     } else {
       applyConfig((p as { proposed_config?: Record<string, unknown> }).proposed_config ?? {});
       const summary = (p as { summary?: unknown }).summary;
       if (typeof summary === "string") setTest({ ok: true, note: summary });
     }
   });
+
+  const pickTable = (t: string) => {
+    setValues((v) => ({ ...v, table: t }));
+    if (!name.trim()) setName(`${t.split(".").pop()}-table`);
+    setTables(undefined);
+    void discover({ table: t });   // straight to the columns proposal for the picked table
+  };
 
   const pickContainer = (c: { name: string; service: string; project: string }) => {
     setValues((v) => ({ ...v, container: c.name }));
@@ -252,7 +264,7 @@ export default function SourceForm({ connector, spec, initial, lockName, submitL
       {spec.discover && (
         <div className="panel" style={{ background: "var(--th-bg)", marginBottom: 14 }}>
           <div className="btnrow" style={{ alignItems: "center" }}>
-            <button type="button" disabled={busy} onClick={discover}>
+            <button type="button" disabled={busy} onClick={() => discover()}>
               ✦ {connector === "docker_logs" ? "Discover containers" : "Discover"}
             </button>
             <span className="help" style={{ margin: 0 }}>
@@ -261,6 +273,21 @@ export default function SourceForm({ connector, spec, initial, lockName, submitL
             </span>
           </div>
           {proposal && <ProposalView proposal={proposal} onApply={applyProposal} />}
+          {tables && (
+            <table style={{ marginTop: 10 }}>
+              <thead><tr><th>table</th><th style={{ width: 100 }}></th></tr></thead>
+              <tbody>
+                {tables.map((t) => (
+                  <tr key={t}>
+                    <td className="mono">{t}</td>
+                    <td style={{ textAlign: "right" }}>
+                      <button type="button" disabled={busy} onClick={() => pickTable(t)}>use this</button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
           {colProposal && (
             <ColumnsProposalView proposal={colProposal}
               onApply={() => {

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -321,7 +321,7 @@ label.field.invalid input:focus, label.field.invalid textarea:focus { box-shadow
 label.field.invalid .help { color: var(--err); }
 label.field .help { display: block; font-size: 12px; color: var(--ink-soft); margin-top: 3px; }
 .help { color: var(--ink-soft); }
-input[type="text"], input[type="number"], select, textarea {
+input[type="text"], input[type="number"], input[type="password"], select, textarea {
   font: inherit;
   font-size: 13.5px;
   width: 100%;


### PR DESCRIPTION
Follow-ups from cloud-POV testing of the postgres source form:

- **Two-stage Discover**: with only a DSN, Discover lists the tables it can see (schema-qualified outside public); picking one fills the form, suggests a name, and immediately re-discovers to the columns proposal. Typing the table still skips stage one.
- **DSN before table** in the form — connection first, then what to read.
- **Database visibility**: discover summaries name the database the connection landed in (a path-less DSN silently defaults to a db named after the user), and the "no tables" error points at the DSN path / privileges. dsn help explains the /dbname path.
- **Style password inputs**: the global input CSS didn't cover type=password, so dsn/token (and the auth gate + Ask key fields) rendered as tiny browser defaults.

Verified against a live Postgres: table listing across schemas, pick→proposal flow, explicit/omitted/wrong database DSNs. UI typecheck/build and postgres tests pass.