### PR TITLE
Discover error surfacing; Claude Code plugin works on hosted

### DIFF
--- a/navflow/connectors/postgres.py
+++ b/navflow/connectors/postgres.py
@@ -64,7 +64,9 @@ def _connect(dsn: str):
         import asyncpg
     except ImportError:
         raise CatalogError("the postgres connector needs asyncpg — pip install navflow[postgres]")
-    return asyncpg.connect(dsn)
+    # bounded connect: an unreachable host (firewalled DB, wrong IP) should fail in seconds with a
+    # clear error, not sit on asyncpg's 60s default while the console appears hung
+    return asyncpg.connect(dsn, timeout=10)
 
 
 class PostgresConnector(Connector):

--- a/navflow/daemon.py
+++ b/navflow/daemon.py
@@ -7,6 +7,7 @@ view/trigger management happens over /api (or the UI at /).
 """
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import uuid
@@ -220,7 +221,9 @@ def make_app() -> FastAPI:
             path, method = request.url.path, request.method
             if INGEST_TOKEN and method == "POST" and _is_ingest(path):
                 tok = request.headers.get("x-navflow-token") or _bearer(request.headers.get("authorization"))
-                if tok != INGEST_TOKEN:
+                # the auth token also ingests: it's strictly more privileged, and clients that carry
+                # one token for both directions (the Claude Code plugin) can then just use it
+                if tok != INGEST_TOKEN and not (AUTH_TOKEN and tok == AUTH_TOKEN):
                     return JSONResponse({"detail": "invalid or missing ingest token"}, status_code=401)
             if AUTH_TOKEN and not _public(method, path):
                 tok = _bearer(request.headers.get("authorization")) or request.headers.get("x-navflow-token", "")
@@ -560,9 +563,17 @@ def make_app() -> FastAPI:
         if connector not in REGISTRY:
             _err(ValueError(f"unknown connector {connector!r}"), 404)
         try:
-            proposal = await REGISTRY[connector].discover(body.get("config", {}) or {})
-        except ValueError as e:
-            _err(e)
+            # bounded + catch-all: driver errors (asyncpg timeouts/auth/network) are not ValueError
+            # and would otherwise 500 with nothing shown to the user
+            proposal = await asyncio.wait_for(
+                REGISTRY[connector].discover(body.get("config", {}) or {}), timeout=30)
+        except (TimeoutError, asyncio.TimeoutError):
+            _err(ValueError("discover timed out — is the target reachable from the NavFlow "
+                            "server? (a hosted NavFlow can only reach public endpoints)"))
+        except HTTPException:
+            raise
+        except Exception as e:
+            _err(ValueError(f"discover failed: {e}"))
         if proposal is None:
             _err(ValueError(f"connector {connector!r} doesn't support discovery yet"))
         return proposal

--- a/navflow/runtime.py
+++ b/navflow/runtime.py
@@ -112,6 +112,17 @@ class Runtime:
                     if c.ingest_key and c.ingest_key == token), None)
         if cfg is None:
             cfg = self.catalog.sources.get(token)
+        if cfg is None and token == "claude_code":
+            # zero-setup, like the OTLP source: the Claude Code plugin ships with only the ingest
+            # token, and on a hosted cell it can't call the (auth-token-guarded) management API to
+            # create its source — so provision it on first ingest instead.
+            from .connectors import normalize_config, source_type_for
+            self.store.upsert_catalog_source(
+                "claude_code", source_type_for("claude_code"), "claude_code", "10s",
+                normalize_config("claude_code", {"push": True}))
+            self.reload_catalog()
+            cfg = self.catalog.sources.get("claude_code")
+            print("navflowd: auto-provisioned Claude Code source 'claude_code'")
         if cfg is None:
             raise KeyError(f"unknown source {token!r}")
         # push sources, plus poll connectors that opt into accepting pushes too (claude_code can be

--- a/ui/src/components/SourceForm.tsx
+++ b/ui/src/components/SourceForm.tsx
@@ -77,6 +77,8 @@ export default function SourceForm({ connector, spec, initial, lockName, submitL
   const [colProposal, setColProposal] = useState<ColumnsProposal>();
   const [tables, setTables] = useState<string[]>();
   const [containers, setContainers] = useState<EnvScan["containers"]>();
+  const [discovering, setDiscovering] = useState(false);
+  const [discoverErr, setDiscoverErr] = useState<string>();
 
   const jsonErrors = useMemo(() => {
     const errs: Record<string, string> = {};
@@ -134,7 +136,20 @@ export default function SourceForm({ connector, spec, initial, lockName, submitL
     setBusy(false);
   };
 
+  // discover errors surface inside the Discover panel (the top-of-form alert can be scrolled
+  // out of view on long forms — the user is looking at the button they just clicked)
   const discover = (override?: Record<string, unknown>) => run(async () => {
+    setDiscovering(true);
+    setDiscoverErr(undefined);
+    try {
+      await doDiscover(override);
+    } catch (e) {
+      setDiscoverErr(String((e as Error).message ?? e));
+    }
+    setDiscovering(false);
+  });
+
+  const doDiscover = async (override?: Record<string, unknown>) => {
     if (connector === "docker_logs") {
       setContainers((await api.discoverEnvironment("docker")).containers);
       return;
@@ -161,7 +176,7 @@ export default function SourceForm({ connector, spec, initial, lockName, submitL
       const summary = (p as { summary?: unknown }).summary;
       if (typeof summary === "string") setTest({ ok: true, note: summary });
     }
-  });
+  };
 
   const pickTable = (t: string) => {
     setValues((v) => ({ ...v, table: t }));
@@ -265,13 +280,15 @@ export default function SourceForm({ connector, spec, initial, lockName, submitL
         <div className="panel" style={{ background: "var(--th-bg)", marginBottom: 14 }}>
           <div className="btnrow" style={{ alignItems: "center" }}>
             <button type="button" disabled={busy} onClick={() => discover()}>
-              ✦ {connector === "docker_logs" ? "Discover containers" : "Discover"}
+              {discovering ? "⏳ discovering…"
+                : `✦ ${connector === "docker_logs" ? "Discover containers" : "Discover"}`}
             </button>
             <span className="help" style={{ margin: 0 }}>
               {DISCOVER_HINT[connector]
                 ?? "fill the URL above, then let NavFlow introspect the source and propose what to ingest — no PromQL to write by hand"}
             </span>
           </div>
+          {discoverErr && <div className="alert error" style={{ marginTop: 10, marginBottom: 0 }}>{discoverErr}</div>}
           {proposal && <ProposalView proposal={proposal} onApply={applyProposal} />}
           {tables && (
             <table style={{ marginTop: 10 }}>


### PR DESCRIPTION
Two independent fixes from cloud-POV testing:

**Discover hung with no feedback** (postgres DSN pointing at an unreachable host):
- asyncpg connect timeout 10s (was the 60s default)
- /api/sources/discover is bounded (30s) and converts every failure to a clear 400 — driver errors (timeout/auth/network) previously escaped as raw ASGI 500s with nothing shown to the user
- the form shows the error inside the Discover panel (the top-of-form alert can be scrolled out of view) and the button reads "discovering…" while in flight

**Claude Code plugin could not work on a hosted cell** (no single token satisfied both source creation and ingest):
- the claude_code source auto-provisions on first ingest (the OTLP pattern) — the plugin's ingest token is now sufficient; no admin management call needed
- /ingest/* and /v1/* also accept the auth token (strictly more privileged), so clients that carry one token for both directions (the plugin: ship + MCP read-back) can use the auth token for everything

Verified against a locally booted daemon: unreachable-host discover fails in 10s with a reachability message, bad-password shows the auth error; ingest-token-only POST auto-creates the source and stores events; both tokens ingest, wrong token 401s. Auth/ingest/push test suites pass.