### PR TITLE
Scoped API keys: read / ingest / admin

### DIFF
--- a/navflow/daemon.py
+++ b/navflow/daemon.py
@@ -8,8 +8,10 @@ view/trigger management happens over /api (or the UI at /).
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import os
+import secrets
 import uuid
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -215,20 +217,71 @@ def make_app() -> FastAPI:
     app.add_middleware(CORSMiddleware, allow_origins=["*"], allow_methods=["*"],
                        allow_headers=["*"])
 
+    # ── auth: scoped credentials ──────────────────────────────────────────────
+    # Three scopes — read (consume: queries, catalog reads, derive/subscribe), ingest (contribute:
+    # /ingest, /v1/*, remember), admin (configure: catalog CRUD, discover, credentials, keys).
+    # Credentials: the env tokens act as implicit root keys (AUTH_TOKEN = admin, INGEST_TOKEN =
+    # ingest, non-revocable), plus revocable scoped keys in the api_keys table (docs/design).
+    _ADMIN_PATHS = ("/api/security", "/api/catalog/export", "/api/catalog/import", "/api/agent/chat")
+
+    def _required_scope(method: str, path: str) -> str | None:
+        """None = public. 'any' = any valid credential. Reads of credentials and all catalog
+        mutation are admin; a trigger changes what the daemon computes for everyone, so trigger
+        CRUD is admin too — but derive/subscribe stay read: they expose nothing a reader couldn't
+        pull and forward, they only persist that reader's own delivery."""
+        if method == "POST" and (_is_ingest(path) or path == "/remember"):
+            return "ingest"   # before _public(): ingest paths are "public" only in the sense of
+                              # not needing the auth token — they have their own scope
+        if _public(method, path):
+            return None
+        if path == "/api/whoami":
+            return "any"
+        if path in _ADMIN_PATHS or path.startswith("/api/keys") or path.startswith("/api/discover"):
+            return "admin"
+        if method != "GET" and (path.startswith("/api/sources")
+                                or path.startswith("/api/views") or path.startswith("/api/triggers")):
+            return "admin"
+        return "read"
+
+    def _resolve_credential(request) -> tuple[set, dict] | tuple[None, None]:
+        """Token from the request -> (scopes, identity), or (None, None) if unknown/absent."""
+        tok = _bearer(request.headers.get("authorization")) or request.headers.get("x-navflow-token", "")
+        if not tok:
+            return None, None
+        if AUTH_TOKEN and tok == AUTH_TOKEN:
+            return {"read", "ingest", "admin"}, {"id": "env:auth", "name": "auth token (env)"}
+        if INGEST_TOKEN and tok == INGEST_TOKEN:
+            return {"ingest"}, {"id": "env:ingest", "name": "ingest token (env)"}
+        key = store.find_api_key(hashlib.sha256(tok.encode()).hexdigest())
+        if key:
+            last = key.get("last_used_at")
+            if last is None or (now_utc() - last).total_seconds() > 60:   # throttle write churn
+                store.touch_api_key(key["id"])
+            return set(key["scopes"]), {"id": f"key:{key['id']}", "name": key["name"]}
+        return None, None
+
     if READONLY or INGEST_TOKEN or AUTH_TOKEN:
         @app.middleware("http")
         async def _guard(request, call_next):
             path, method = request.url.path, request.method
-            if INGEST_TOKEN and method == "POST" and _is_ingest(path):
-                tok = request.headers.get("x-navflow-token") or _bearer(request.headers.get("authorization"))
-                # the auth token also ingests: it's strictly more privileged, and clients that carry
-                # one token for both directions (the Claude Code plugin) can then just use it
-                if tok != INGEST_TOKEN and not (AUTH_TOKEN and tok == AUTH_TOKEN):
+            required = _required_scope(method, path)
+            # activation matches the pre-keys behavior: ingest is gated only when an ingest token
+            # is configured; reads/management only when an auth token is (open local installs
+            # stay open — keys are meaningful once the root tokens exist, i.e. always on hosted).
+            if required == "ingest" and (INGEST_TOKEN or AUTH_TOKEN):
+                scopes, ident = _resolve_credential(request)
+                if not scopes or not ({"ingest", "admin"} & scopes):
                     return JSONResponse({"detail": "invalid or missing ingest token"}, status_code=401)
-            if AUTH_TOKEN and not _public(method, path):
-                tok = _bearer(request.headers.get("authorization")) or request.headers.get("x-navflow-token", "")
-                if tok != AUTH_TOKEN:
+                request.state.credential = ident
+            elif required in ("read", "admin", "any") and AUTH_TOKEN:
+                scopes, ident = _resolve_credential(request)
+                if not scopes:
                     return JSONResponse({"detail": "authentication required"}, status_code=401)
+                if required != "any" and required not in scopes and "admin" not in scopes:
+                    return JSONResponse({"detail": f"this credential lacks the {required!r} scope"},
+                                        status_code=403)
+                request.state.credential = ident
+                request.state.scopes = sorted(scopes)
             if (READONLY and method not in ("GET", "HEAD", "OPTIONS")
                     and path not in _READ_POST and not _is_ingest(path)):
                 return JSONResponse({"detail": "this NavFlow instance is read-only (control plane "
@@ -273,11 +326,14 @@ def make_app() -> FastAPI:
         return {"payload": payload, "count": nrows, "sources": sources, "rows": rows}
 
     @app.post("/subscribe")
-    async def subscribe(req: SubReq):
+    async def subscribe(req: SubReq, request: Request):
         if req.trigger not in {t.name for t in runtime.catalog.triggers}:
             _err(KeyError(f"unknown trigger {req.trigger!r}"), 404)
         sid = "sub_" + uuid.uuid4().hex[:8]
-        store.add_subscription(sid, req.trigger, req.url)
+        # record the creating credential: revoking a key removes its subscriptions (a revoked
+        # agent must stop receiving trigger dispatches)
+        ident = getattr(request.state, "credential", None)
+        store.add_subscription(sid, req.trigger, req.url, created_by=ident["id"] if ident else None)
         return {"subscription_id": sid}
 
     @app.post("/unsubscribe")
@@ -544,7 +600,49 @@ def make_app() -> FastAPI:
         """Instance credentials, for the authenticated operator. The ingest token is the shared,
         machine-facing secret producers send as X-NavFlow-Token / Bearer on /ingest and /v1/*; the
         console surfaces it here so the operator can hand it to producers without shell access."""
-        return {"ingest_token": INGEST_TOKEN or None, "ingest_required": bool(INGEST_TOKEN)}
+        # ingest is gated whenever ANY root token is configured (a secured instance doesn't accept
+        # anonymous events); auth_required tells the UI whether this instance enforces at all
+        return {"ingest_token": INGEST_TOKEN or None,
+                "ingest_required": bool(INGEST_TOKEN or AUTH_TOKEN),
+                "auth_required": bool(AUTH_TOKEN)}
+
+    # ── API keys: scoped, revocable credentials (admin scope; see docs/design) ─
+    _SCOPES = {"read", "ingest", "admin"}
+
+    @app.get("/api/keys")
+    async def list_keys():
+        return {"keys": store.list_api_keys(),
+                "enforced": bool(AUTH_TOKEN),   # without a root auth token the instance is open
+                "scopes": sorted(_SCOPES)}
+
+    @app.post("/api/keys", status_code=201)
+    async def create_key(body: dict = Body(...)):
+        name = str(body.get("name") or "").strip()
+        scopes = sorted(set(body.get("scopes") or []))
+        if not name:
+            _err(ValueError("name is required"))
+        if not scopes or not set(scopes) <= _SCOPES:
+            _err(ValueError(f"scopes must be a non-empty subset of {sorted(_SCOPES)}"))
+        kid = uuid.uuid4().hex[:8]
+        secret = f"nvf_{kid}_{secrets.token_urlsafe(24)}"
+        store.insert_api_key(kid, name, f"nvf_{kid}", hashlib.sha256(secret.encode()).hexdigest(),
+                             scopes)
+        # the secret exists only in this response; the store keeps its hash
+        return {"id": kid, "name": name, "scopes": scopes, "secret": secret}
+
+    @app.delete("/api/keys/{kid}")
+    async def revoke_key(kid: str):
+        if not store.revoke_api_key(kid):
+            _err(KeyError(f"no active key {kid!r}"), 404)
+        return {"ok": True, "note": "key revoked; its subscriptions were removed"}
+
+    @app.get("/api/whoami")
+    async def whoami(request: Request):
+        ident = getattr(request.state, "credential", None)
+        scopes = getattr(request.state, "scopes", None)
+        if ident is None:   # guard not active (open instance) or ingest-path credential
+            return {"id": "open", "name": "no auth configured", "scopes": sorted(_SCOPES)}
+        return {**ident, "scopes": scopes or []}
 
     @app.get("/api/capabilities")
     async def capabilities():

--- a/navflow/mcp_server.py
+++ b/navflow/mcp_server.py
@@ -13,6 +13,7 @@ all, so a connected agent sees only the read surface (the daemon refuses the wri
 """
 from __future__ import annotations
 
+import contextvars
 import json
 import os
 
@@ -21,15 +22,18 @@ from mcp.server.fastmcp import FastMCP
 
 NAVFLOWD = os.getenv("NAVFLOWD_URL", "http://127.0.0.1:8787")
 READONLY = os.getenv("NAVFLOW_READONLY", "").strip().lower() in ("1", "true", "yes", "on")
-# Shared bearer token (self-hosted single-tenant): connecting agents must present it, and we forward
-# it to navflowd (whose API now requires it too).
+# Bearer credentials. Over HTTP transports each caller presents its own token (the root auth token
+# or a scoped API key) and we forward it per-request — the daemon enforces scopes per route. Over
+# stdio (a local agent spawned the proxy) there is no inbound token; the env token is used.
 AUTH_TOKEN = os.getenv("NAVFLOW_AUTH_TOKEN", "").strip()
-_AUTH_HEADERS = {"Authorization": f"Bearer {AUTH_TOKEN}"} if AUTH_TOKEN else {}
+_CALLER_TOKEN = contextvars.ContextVar("navflow_caller_token", default="")
 
 
 def _cx(timeout: float = 10):
-    """An httpx client that carries the auth token to navflowd (a no-op when none is set)."""
-    return httpx.AsyncClient(timeout=timeout, headers=_AUTH_HEADERS)
+    """An httpx client that carries the caller's token to navflowd (env token as stdio fallback)."""
+    tok = _CALLER_TOKEN.get() or AUTH_TOKEN
+    return httpx.AsyncClient(timeout=timeout,
+                             headers={"Authorization": f"Bearer {tok}"} if tok else {})
 
 # stdio (default) is what a local agent spawns. For remote agents (the demo / a server), run with
 # NAVFLOW_MCP_TRANSPORT=streamable-http (or sse) and the server listens on MCP_HOST:MCP_PORT — at
@@ -208,21 +212,24 @@ async def list_sources() -> str:
 
 
 class _BearerGate:
-    """Pure-ASGI middleware: every HTTP request to the MCP server must carry the bearer token.
+    """Pure-ASGI middleware: every HTTP request to the MCP server must carry *a* bearer token —
+    the root auth token or a scoped API key. The token is forwarded to navflowd per-request, which
+    validates it and enforces scopes per tool call (the proxy can't check key hashes itself).
     Non-HTTP scopes (lifespan/websocket) pass through untouched."""
-    def __init__(self, app, token: str):
-        self.app, self.token = app, token
+    def __init__(self, app):
+        self.app = app
 
     async def __call__(self, scope, receive, send):
         if scope["type"] == "http":
             headers = {k.decode().lower(): v.decode() for k, v in scope.get("headers") or []}
             auth = headers.get("authorization", "")
             tok = auth[7:].strip() if auth.lower().startswith("bearer ") else headers.get("x-navflow-token", "")
-            if tok != self.token:
+            if not tok:
                 await send({"type": "http.response.start", "status": 401,
                             "headers": [(b"content-type", b"application/json")]})
                 await send({"type": "http.response.body", "body": b'{"detail":"unauthorized"}'})
                 return
+            _CALLER_TOKEN.set(tok)
         await self.app(scope, receive, send)
 
 
@@ -234,7 +241,7 @@ def main():
     # HTTP transports: build the ASGI app, gate it with the bearer token, run it under uvicorn.
     app = mcp.streamable_http_app() if transport == "streamable-http" else mcp.sse_app()
     if AUTH_TOKEN:
-        app = _BearerGate(app, AUTH_TOKEN)
+        app = _BearerGate(app)
     import uvicorn
     uvicorn.run(app, host=mcp.settings.host, port=mcp.settings.port)
 

--- a/navflow/store.py
+++ b/navflow/store.py
@@ -41,7 +41,18 @@ CREATE TABLE IF NOT EXISTS subscriptions (
   subscription_id TEXT PRIMARY KEY,
   trigger         TEXT,
   url             TEXT,
-  created_at      TIMESTAMPTZ
+  created_at      TIMESTAMPTZ,
+  created_by      TEXT
+);
+CREATE TABLE IF NOT EXISTS api_keys (
+  id           TEXT PRIMARY KEY,
+  name         TEXT,
+  prefix       TEXT,
+  hash         TEXT,
+  scopes       JSON,
+  created_at   TIMESTAMPTZ,
+  last_used_at TIMESTAMPTZ,
+  revoked_at   TIMESTAMPTZ
 );
 CREATE TABLE IF NOT EXISTS catalog_sources (
   name       TEXT PRIMARY KEY,
@@ -99,6 +110,7 @@ _MIGRATIONS = [
     "ALTER TABLE catalog_views ADD COLUMN IF NOT EXISTS created_by TEXT",
     "ALTER TABLE events ADD COLUMN IF NOT EXISTS labels JSON",
     "ALTER TABLE catalog_sources ADD COLUMN IF NOT EXISTS ingest_key TEXT",
+    "ALTER TABLE subscriptions ADD COLUMN IF NOT EXISTS created_by TEXT",
 ]
 
 _FILTER_COLS = {"event_type", "source", "text", "key_value"}
@@ -581,12 +593,12 @@ class Store:
         return n
 
     # ── subscriptions ─────────────────────────────────────────────────────────
-    def add_subscription(self, sid: str, trigger: str, url: str) -> None:
+    def add_subscription(self, sid: str, trigger: str, url: str, created_by: str | None = None) -> None:
         with self._lock:
             self.con.execute(
-                "INSERT INTO subscriptions VALUES (?, ?, ?, ?) "
+                "INSERT INTO subscriptions VALUES (?, ?, ?, ?, ?) "
                 "ON CONFLICT (subscription_id) DO UPDATE SET trigger = excluded.trigger, url = excluded.url",
-                [sid, trigger, url, now_utc()],
+                [sid, trigger, url, now_utc(), created_by],
             )
 
     def list_subscriptions(self, trigger: str):
@@ -608,3 +620,43 @@ class Store:
     def remove_subscription(self, sid: str) -> None:
         with self._lock:
             self.con.execute("DELETE FROM subscriptions WHERE subscription_id = ?", [sid])
+
+    # ── API keys (scoped credentials; only the SHA-256 of the secret is stored) ─
+    def insert_api_key(self, kid: str, name: str, prefix: str, hash_: str, scopes: list[str]) -> None:
+        with self._lock:
+            self.con.execute("INSERT INTO api_keys VALUES (?, ?, ?, ?, ?, ?, NULL, NULL)",
+                             [kid, name, prefix, hash_, json.dumps(scopes), now_utc()])
+
+    def list_api_keys(self) -> list[dict]:
+        with self._lock:
+            rows = self.con.execute(
+                "SELECT id, name, prefix, scopes, created_at, last_used_at, revoked_at "
+                "FROM api_keys ORDER BY created_at DESC").fetchall()
+        return [{"id": r[0], "name": r[1], "prefix": r[2], "scopes": json.loads(r[3]),
+                 "created_at": r[4], "last_used_at": r[5], "revoked_at": r[6]} for r in rows]
+
+    def find_api_key(self, hash_: str) -> dict | None:
+        """Active (non-revoked) key by secret hash, or None."""
+        with self._lock:
+            r = self.con.execute(
+                "SELECT id, name, scopes, last_used_at FROM api_keys "
+                "WHERE hash = ? AND revoked_at IS NULL", [hash_]).fetchone()
+        if not r:
+            return None
+        return {"id": r[0], "name": r[1], "scopes": json.loads(r[2]), "last_used_at": r[3]}
+
+    def touch_api_key(self, kid: str) -> None:
+        with self._lock:
+            self.con.execute("UPDATE api_keys SET last_used_at = ? WHERE id = ?", [now_utc(), kid])
+
+    def revoke_api_key(self, kid: str) -> bool:
+        """Revoke the key and delete its subscriptions (a revoked agent must stop receiving
+        trigger dispatches — otherwise its webhook is a post-revocation exfiltration path)."""
+        with self._lock:
+            hit = self.con.execute("SELECT 1 FROM api_keys WHERE id = ? AND revoked_at IS NULL",
+                                   [kid]).fetchone()
+            if not hit:
+                return False
+            self.con.execute("UPDATE api_keys SET revoked_at = ? WHERE id = ?", [now_utc(), kid])
+            self.con.execute("DELETE FROM subscriptions WHERE created_by = ?", [f"key:{kid}"])
+        return True

--- a/tests/test_api_keys.py
+++ b/tests/test_api_keys.py
@@ -1,0 +1,145 @@
+"""Scoped API keys — create/list/revoke via /api/keys, and scope enforcement across the surface:
+read (queries, catalog reads, derive/subscribe), ingest (/ingest, /v1/*, remember), admin (CRUD,
+credentials, keys). Env tokens act as implicit root keys. Revoking a key removes its subscriptions.
+"""
+import asyncio, os, subprocess, sys
+import httpx
+
+P = F = 0
+def ck(l, c, d=""):
+    global P, F; P += 1 if c else 0; F += 0 if c else 1
+    print(("  ok   " if c else "  FAIL ") + l + ("" if c else f"  {d}"))
+
+SEED = "/tmp/keys_catalog.yaml"
+with open(SEED, "w") as fh:
+    fh.write("""sources:
+  - name: evt
+    connector: webhook
+    poll: 5s
+    config: {}
+views:
+  - name: v_evt
+    key_field: key_value
+    sources: [evt]
+triggers:
+  - name: t_evt
+    view: v_evt
+    condition: {aggregate: max, field: value, predicate: "> 1.0", window: 1m}
+""")
+DB, PORT = "/tmp/keys.duckdb", "8806"
+AUTH, INGEST = "root-token", "ingest-token"
+
+
+async def _wait(url):
+    for _ in range(80):
+        try:
+            async with httpx.AsyncClient() as cx:
+                if (await cx.get(url, timeout=1)).status_code == 200:
+                    return True
+        except Exception:
+            pass
+        await asyncio.sleep(0.25)
+    return False
+
+
+def H(tok):
+    return {"Authorization": f"Bearer {tok}"}
+
+
+async def main():
+    for p in (DB, DB + ".wal"):
+        if os.path.exists(p):
+            os.remove(p)
+    env = {**os.environ, "NAVFLOW_DB": DB, "NAVFLOW_CATALOG": SEED, "NAVFLOW_PORT": PORT,
+           "NAVFLOW_OTLP_GRPC_PORT": "off", "NAVFLOW_AUTH_TOKEN": AUTH,
+           "NAVFLOW_INGEST_TOKEN": INGEST}
+    proc = subprocess.Popen([sys.executable, "-c", "from navflow.cli import run_daemon; run_daemon()"],
+                            env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    B = f"http://127.0.0.1:{PORT}"
+    try:
+        if not await _wait(f"{B}/health"):
+            ck("daemon up", False); return
+        async with httpx.AsyncClient() as cx:
+            # ── key management (admin only) ──
+            r = await cx.post(f"{B}/api/keys", json={"name": "agent", "scopes": ["read"]}, headers=H(AUTH))
+            ck("create read key (root)", r.status_code == 201, r.text)
+            read_key = r.json()["secret"]
+            ck("secret has nvf_ prefix", read_key.startswith("nvf_"), read_key[:8])
+            r2 = await cx.post(f"{B}/api/keys", json={"name": "producer", "scopes": ["ingest"]}, headers=H(AUTH))
+            ing_key, ing_id = r2.json()["secret"], r2.json()["id"]
+            r3 = await cx.post(f"{B}/api/keys", json={"name": "plugin", "scopes": ["ingest", "read"]}, headers=H(AUTH))
+            both_key = r3.json()["secret"]
+
+            ck("create with bad scope -> 400",
+               (await cx.post(f"{B}/api/keys", json={"name": "x", "scopes": ["root"]}, headers=H(AUTH))).status_code == 400)
+            ck("list keys hides secrets", "secret" not in str((await cx.get(f"{B}/api/keys", headers=H(AUTH))).json()["keys"]))
+            ck("read key cannot manage keys -> 403",
+               (await cx.get(f"{B}/api/keys", headers=H(read_key))).status_code == 403)
+            ck("ingest env token cannot manage keys",
+               (await cx.get(f"{B}/api/keys", headers=H(INGEST))).status_code in (401, 403))
+
+            # ── read scope ──
+            ck("read key: /query ok",
+               (await cx.post(f"{B}/query", json={"view": "v_evt", "key": "k"}, headers=H(read_key))).status_code == 200)
+            ck("read key: catalog ok", (await cx.get(f"{B}/catalog", headers=H(read_key))).status_code == 200)
+            ck("read key: sources list ok", (await cx.get(f"{B}/api/sources", headers=H(read_key))).status_code == 200)
+            ck("read key: /api/security denied -> 403",
+               (await cx.get(f"{B}/api/security", headers=H(read_key))).status_code == 403)
+            ck("read key: create source denied -> 403",
+               (await cx.post(f"{B}/api/sources", json={"name": "n", "connector": "webhook", "config": {}},
+                              headers=H(read_key))).status_code == 403)
+            ck("read key: cannot ingest -> 401",
+               (await cx.post(f"{B}/ingest/evt", json={"m": 1}, headers=H(read_key))).status_code == 401)
+            ck("read key: derive ok",
+               (await cx.post(f"{B}/derive", json={"key_field": "key_value", "sources": ["evt"], "client": "t"},
+                              headers=H(read_key))).status_code == 201)
+            sub = await cx.post(f"{B}/subscribe", json={"trigger": "t_evt", "url": "http://x/hook"},
+                                headers=H(read_key))
+            ck("read key: subscribe ok", sub.status_code == 200, sub.text)
+
+            # ── ingest scope ──
+            ck("ingest key: ingest ok",
+               (await cx.post(f"{B}/ingest/evt", json={"m": 1}, headers=H(ing_key))).status_code == 202)
+            ck("ingest key: remember ok",
+               (await cx.post(f"{B}/remember", json={"key": "k", "content": "obs"}, headers=H(ing_key))).status_code == 202)
+            ck("ingest key: /query denied -> 403",
+               (await cx.post(f"{B}/query", json={"view": "v_evt", "key": "k"}, headers=H(ing_key))).status_code == 403)
+            ck("read+ingest key: both work",
+               (await cx.post(f"{B}/ingest/evt", json={"m": 2}, headers=H(both_key))).status_code == 202
+               and (await cx.get(f"{B}/catalog", headers=H(both_key))).status_code == 200)
+
+            # ── env tokens still root ──
+            ck("env auth token: admin ok", (await cx.get(f"{B}/api/security", headers=H(AUTH))).status_code == 200)
+            ck("env ingest token: ingest ok",
+               (await cx.post(f"{B}/ingest/evt", json={"m": 3}, headers=H(INGEST))).status_code == 202)
+            ck("unknown token -> 401", (await cx.get(f"{B}/catalog", headers=H("nope"))).status_code == 401)
+
+            # ── whoami ──
+            w = (await cx.get(f"{B}/api/whoami", headers=H(read_key))).json()
+            ck("whoami: name + scopes", w.get("name") == "agent" and w.get("scopes") == ["read"], str(w))
+
+            # ── revocation kills access AND subscriptions ──
+            r = await cx.post(f"{B}/api/keys", json={"name": "revoke-me", "scopes": ["read"]}, headers=H(AUTH))
+            rk, rk_id = r.json()["secret"], r.json()["id"]
+            await cx.post(f"{B}/subscribe", json={"trigger": "t_evt", "url": "http://gone/hook"}, headers=H(rk))
+            subs_before = (await cx.get(f"{B}/api/subscriptions", headers=H(AUTH))).json()
+            ck("revoke -> 200", (await cx.delete(f"{B}/api/keys/{rk_id}", headers=H(AUTH))).status_code == 200)
+            ck("revoked key -> 401", (await cx.get(f"{B}/catalog", headers=H(rk))).status_code == 401)
+            subs_after = (await cx.get(f"{B}/api/subscriptions", headers=H(AUTH))).json()
+            gone = all("gone" not in str(s) for s in subs_after) and any("gone" in str(s) for s in subs_before)
+            ck("revocation removed the key's subscriptions", gone,
+               f"before={subs_before} after={subs_after}")
+            ck("revoke twice -> 404", (await cx.delete(f"{B}/api/keys/{rk_id}", headers=H(AUTH))).status_code == 404)
+            ck("revoke ingest key of producer works",
+               (await cx.delete(f"{B}/api/keys/{ing_id}", headers=H(AUTH))).status_code == 200)
+            ck("revoked producer cannot ingest -> 401",
+               (await cx.post(f"{B}/ingest/evt", json={"m": 4}, headers=H(ing_key))).status_code == 401)
+    finally:
+        proc.terminate()
+        proc.wait(timeout=10)
+
+    print(f"\n{P} passed, {F} failed")
+    raise SystemExit(1 if F else 0)
+
+
+asyncio.run(main())

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -56,9 +56,12 @@ async def main():
             ck("POST /query with token -> not 401", (await cx.post(f"{B}/query", json={"view": "x"}, headers=auth)).status_code != 401)
             ck("catalog export protected", (await cx.get(f"{B}/api/catalog/export")).status_code == 401)
 
-            # ingest is NOT gated by the auth token (it has its own; none set here -> open)
+            # a secured instance gates ingest too: with any root token configured, anonymous
+            # events would poison the timelines agents trust. The auth token itself ingests.
             ig = await cx.post(f"{B}/ingest/evt", json={"app": "a", "msg": "hi"})
-            ck("ingest not gated by auth token (202)", ig.status_code == 202, str(ig.status_code))
+            ck("anonymous ingest denied when auth is on (401)", ig.status_code == 401, str(ig.status_code))
+            ig2 = await cx.post(f"{B}/ingest/evt", json={"app": "a", "msg": "hi"}, headers=auth)
+            ck("auth token ingests (202)", ig2.status_code == 202, str(ig2.status_code))
     finally:
         proc.send_signal(signal.SIGTERM)
         try: proc.wait(timeout=5)

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -1,4 +1,5 @@
 import type {
+  ApiKey,
   CatalogDescribe, CatalogList, ConnectorSpec, DiscoverProposal, DispatchLogEntry, Entity, EnvScan,
   LabelFacet, QueryLogEntry, Source, SourceEvent, SourceFieldsProfile, Subscription, TestResult,
   TimelineEventRow, Trigger, View,
@@ -60,6 +61,12 @@ export const api = {
   capabilities: () => request<{ discover_docker: boolean }>("/api/capabilities"),
   security: () =>
     request<{ ingest_token: string | null; ingest_required: boolean }>("/api/security"),
+  keys: () => request<{ keys: ApiKey[]; enforced: boolean; scopes: string[] }>("/api/keys"),
+  createKey: (name: string, scopes: string[]) =>
+    request<{ id: string; name: string; scopes: string[]; secret: string }>(
+      "/api/keys", { method: "POST", body: JSON.stringify({ name, scopes }) }),
+  revokeKey: (id: string) => request<{ ok: boolean }>(`/api/keys/${id}`, { method: "DELETE" }),
+  whoami: () => request<{ id: string; name: string; scopes: string[] }>("/api/whoami"),
 
   sources: () => request<Source[]>("/api/sources"),
   source: (name: string) => request<Source>(`/api/sources/${name}`),

--- a/ui/src/pages/Security.tsx
+++ b/ui/src/pages/Security.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useState } from "react";
 
 import { api } from "../api";
+import ConfirmDialog from "../components/ConfirmDialog";
+import { TimeAgo } from "../components/bits";
+import type { ApiKey } from "../types";
 
 function Copy({ text }: { text: string }) {
   const [done, setDone] = useState(false);
@@ -71,13 +74,148 @@ export default function Security() {
         ) : null}
       </div>
 
-      <div className="panel">
-        <h2 style={{ marginTop: 0 }}>Rotate &amp; revoke</h2>
-        <p className="help" style={{ marginTop: 0 }}>
-          Coming soon — create and revoke ingest tokens from here. Today the token is set once via
-          the <code>NAVFLOW_INGEST_TOKEN</code> environment variable on the daemon.
-        </p>
-      </div>
+      <ApiKeysPanel />
     </>
+  );
+}
+
+// Scope semantics (docs/design/api-keys.md): read = consume (queries, catalog reads, an agent's
+// own derive/subscribe) · ingest = contribute events · admin = configure the instance.
+const SCOPE_HELP: Record<string, string> = {
+  read: "consume — queries, timelines, catalog; agents' own views & subscriptions",
+  ingest: "contribute — POST events to /ingest and /v1/*, write memories",
+  admin: "configure — sources/views/triggers, credentials, keys (implies the rest)",
+};
+
+function ApiKeysPanel() {
+  const [keys, setKeys] = useState<ApiKey[]>();
+  const [enforced, setEnforced] = useState(true);
+  const [err, setErr] = useState<string>();
+  const [name, setName] = useState("");
+  const [scopes, setScopes] = useState<string[]>(["read"]);
+  const [minted, setMinted] = useState<{ name: string; secret: string }>();
+  const [revoking, setRevoking] = useState<ApiKey>();
+  const [busy, setBusy] = useState(false);
+
+  const load = () => api.keys().then((r) => { setKeys(r.keys); setEnforced(r.enforced); })
+    .catch((e) => setErr(String((e as Error).message ?? e)));
+  useEffect(() => { load(); }, []);
+
+  const create = async () => {
+    setBusy(true);
+    setErr(undefined);
+    try {
+      const r = await api.createKey(name.trim(), scopes);
+      setMinted({ name: r.name, secret: r.secret });
+      setName("");
+      load();
+    } catch (e) { setErr(String((e as Error).message ?? e)); }
+    setBusy(false);
+  };
+
+  const active = (keys ?? []).filter((k) => !k.revoked_at);
+
+  return (
+    <div className="panel">
+      <h2 style={{ marginTop: 0 }}>API keys</h2>
+      <p className="help" style={{ marginTop: 0 }}>
+        Scoped, revocable credentials — hand each producer and agent its own key instead of a
+        shared token. <strong>read</strong>: agents over MCP · <strong>ingest</strong>: producers ·{" "}
+        <strong>read + ingest</strong>: the Claude Code plugin · <strong>admin</strong>: full control.
+      </p>
+      {!enforced && keys && (
+        <div className="alert">
+          No <code>NAVFLOW_AUTH_TOKEN</code> is set, so this instance is open and keys are not
+          enforced. Keys become meaningful once the daemon has a root auth token.
+        </div>
+      )}
+      {err && <div className="alert error">{err}</div>}
+
+      {minted && (
+        <div className="alert ok">
+          Key <strong>{minted.name}</strong> created — copy the secret now; it is not shown again:
+          <div className="ingest-url" style={{ marginTop: 8 }}>
+            <code className="mono">{minted.secret}</code>
+            <CopySecret text={minted.secret} />
+          </div>
+          <button style={{ marginTop: 8 }} onClick={() => setMinted(undefined)}>done</button>
+        </div>
+      )}
+
+      {keys && keys.length > 0 && (
+        <table style={{ marginBottom: 14 }}>
+          <thead><tr><th>name</th><th>scopes</th><th>key</th><th>created</th><th>last used</th><th></th></tr></thead>
+          <tbody>
+            {keys.map((k) => (
+              <tr key={k.id} style={k.revoked_at ? { opacity: 0.45 } : undefined}>
+                <td>{k.name}</td>
+                <td>{k.scopes.map((s) => <span className="chip" key={s} title={SCOPE_HELP[s]}>{s}</span>)}</td>
+                <td className="mono">{k.prefix}…</td>
+                <td className="help"><TimeAgo ts={k.created_at} /></td>
+                <td className="help">{k.revoked_at ? "revoked" : k.last_used_at ? <TimeAgo ts={k.last_used_at} /> : "never"}</td>
+                <td style={{ textAlign: "right" }}>
+                  {!k.revoked_at && (
+                    <button className="danger" onClick={() => setRevoking(k)}>revoke</button>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+      {keys && active.length === 0 && <p className="help">no active keys yet — create one below</p>}
+
+      <div style={{ borderTop: "1px solid var(--line)", marginTop: 18, paddingTop: 16, maxWidth: 560 }}>
+        <h3 style={{ margin: "0 0 10px", fontSize: 15 }}>Create a key</h3>
+        <label className="field" style={{ maxWidth: 320 }}>
+          <span className="lbl">name</span>
+          <input type="text" placeholder="e.g. otel-prod, my-agent" value={name}
+                 onChange={(e) => setName(e.target.value)} />
+          <span className="help">who holds it — one key per producer or agent</span>
+        </label>
+        <div className="field">
+          <span className="lbl">scopes</span>
+          {Object.entries(SCOPE_HELP).map(([s, help]) => (
+            <label key={s} style={{ display: "flex", gap: 10, alignItems: "baseline",
+                                     padding: "5px 0", cursor: "pointer" }}>
+              <input type="checkbox" checked={scopes.includes(s)}
+                     style={{ transform: "translateY(1px)" }}
+                     onChange={(e) => setScopes(e.target.checked
+                       ? [...scopes, s] : scopes.filter((x) => x !== s))} />
+              <span className="mono" style={{ minWidth: 56 }}>{s}</span>
+              <span className="help" style={{ margin: 0 }}>{help}</span>
+            </label>
+          ))}
+        </div>
+        <button className="primary" disabled={busy || !name.trim() || scopes.length === 0}
+                onClick={create}>Create key</button>
+      </div>
+
+      {revoking && (
+        <ConfirmDialog
+          title={`Revoke ${revoking.name}?`}
+          message="The key stops working immediately and its subscriptions are removed. Producers or agents still using it will start failing."
+          confirmLabel="Revoke"
+          danger
+          onCancel={() => setRevoking(undefined)}
+          onConfirm={async () => {
+            try { await api.revokeKey(revoking.id); } catch (e) { setErr(String((e as Error).message ?? e)); }
+            setRevoking(undefined);
+            load();
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+function CopySecret({ text }: { text: string }) {
+  const [done, setDone] = useState(false);
+  return (
+    <button onClick={() => {
+      navigator.clipboard?.writeText(text);
+      setDone(true);
+      setTimeout(() => setDone(false), 1500);
+    }}>{done ? "copied" : "copy"}</button>
   );
 }

--- a/ui/src/pages/SourceClaudeCode.tsx
+++ b/ui/src/pages/SourceClaudeCode.tsx
@@ -27,7 +27,8 @@ const INSTALL = "/plugin marketplace add glassflow/navflow\n/plugin install navf
 export default function SourceClaudeCode() {
   const origin = window.location.origin;
   const { data: sources } = usePolling(() => api.sources(), 10000);
-  const [sec, setSec] = useState<{ ingest_token: string | null; ingest_required: boolean }>();
+  const [sec, setSec] = useState<{ ingest_token: string | null; ingest_required: boolean;
+                                   auth_required?: boolean }>();
 
   useEffect(() => {
     api.security().then(setSec).catch(() => setSec(undefined));
@@ -35,6 +36,7 @@ export default function SourceClaudeCode() {
 
   const connected = sources?.some((s) => s.connector === "claude_code") ?? false;
   const token = sec?.ingest_token ?? "";
+  const enforced = !!(sec?.auth_required || sec?.ingest_required);
 
   return (
     <>
@@ -84,23 +86,22 @@ export default function SourceClaudeCode() {
 
         <label className="field" style={{ marginTop: 12 }}>
           <span className="lbl">
-            Auth token{sec && !token && <span className="dim"> (not required)</span>}
+            Auth token{sec && !enforced && <span className="dim"> (not required)</span>}
           </span>
-          {token ? (
-            <>
-              <div className="btnrow" style={{ alignItems: "center" }}>
-                <code className="payload" style={{ flex: 1, margin: 0, wordBreak: "break-all" }}>
-                  {token}
-                </code>
-                <Copy text={token} />
-              </div>
-              <span className="help">
-                This instance requires an ingest token — the plugin sends it when shipping sessions.
-              </span>
-            </>
+          {enforced ? (
+            <span className="help">
+              Create an API key with the <span className="mono">read</span> +{" "}
+              <span className="mono">ingest</span> scopes on the{" "}
+              <Link to="/security">Security page</Link> and paste it here — it lets the plugin
+              stream sessions <em>and</em> query NavFlow over MCP, without full admin rights.
+              {token && (
+                <> (Capture-only alternative: the shared ingest token — sessions stream in, but
+                MCP read-back won&rsquo;t work.)</>
+              )}
+            </span>
           ) : (
             <span className="help">
-              This instance doesn&rsquo;t require an ingest token — leave it blank.
+              This instance is open (no tokens configured) — leave it blank.
             </span>
           )}
         </label>

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -119,6 +119,16 @@ export interface DiscoverProposal {
   proposed_config: { url: string; default_key: string; queries: unknown[]; labels: { name: string; field: string }[] };
 }
 
+export interface ApiKey {
+  id: string;
+  name: string;
+  prefix: string;
+  scopes: string[];
+  created_at: string | null;
+  last_used_at: string | null;
+  revoked_at: string | null;
+}
+
 // Discover response for table-shaped connectors (postgres): the columns found plus a proposed
 // config to review and apply. (Prometheus uses the richer DiscoverProposal above.)
 export interface ColumnsProposal {


### PR DESCRIPTION
Replaces the two-env-token model with scoped, revocable credentials (design discussed during cloud testing; env tokens remain as implicit root keys for full back-compat).

**Model** — one key type, a set of scopes:
- `read`: consume — queries, timelines, catalog reads, and the agent's own derive/subscribe (they expose nothing a reader couldn't pull and forward)
- `ingest`: contribute — /ingest/*, /v1/*, remember (memories are events)
- `admin`: configure — sources/views/triggers CRUD, discover, /api/security, key management (implies the rest)

**Mechanics**
- `api_keys` table stores only the SHA-256 of `nvf_<id>_<random>` secrets (shown once at creation); last-used tracking (throttled), revocation instead of scope editing
- Revoking a key deletes its subscriptions — a revoked agent stops receiving trigger dispatches
- Guard middleware resolves any credential to scopes; env AUTH/INGEST tokens act as non-revocable root keys (admin / ingest); PR #13's auth-token-ingests special case is absorbed by the scope logic
- Semantic tightening: a secured instance (either root token set) no longer accepts anonymous ingest
- MCP proxy forwards each caller's own bearer per-request (scoped keys enforced per tool); stdio keeps the env-token fallback
- `POST/GET /api/keys`, `DELETE /api/keys/{id}`, `GET /api/whoami`

**Console**
- Security page: full key manager (list with scope chips/prefix/created/last-used, create with per-scope explanations, secret-shown-once, revoke with confirm; "instance is open" notice when unenforced)
- Claude Code page: recommends a `read+ingest` key (stream sessions + MCP read-back, no admin); ingest token demoted to capture-only alternative; "leave blank" only when the instance is genuinely open
- `/api/security` reports the new ingest semantics + `auth_required`

Open local installs (`navflow up`, no tokens) are unchanged: no enforcement, and the console says so.

Tests: new `tests/test_api_keys.py` (28 checks: scope matrix, env-token roots, whoami, revocation incl. subscription cleanup); auth/readonly/ingest-key/push-wins/MCP suites pass. (`test_include_payload.py` fails identically on main — pre-existing, unrelated.)