### PR TITLE
Plugin: fix userConfig wiring; Agents page recommends scoped keys

### DIFF
--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,11 +1,19 @@
 {
   "name": "navflow",
   "displayName": "NavFlow",
-  "version": "0.1.0",
-  "description": "Connect Claude Code to NavFlow — query your data plane over MCP, and stream this session into NavFlow's claude_code source.",
-  "author": { "name": "GlassFlow", "url": "https://glassflow.dev" },
+  "version": "0.1.1",
+  "description": "Connect Claude Code to NavFlow \u2014 query your data plane over MCP, and stream this session into NavFlow's claude_code source.",
+  "author": {
+    "name": "GlassFlow",
+    "url": "https://glassflow.dev"
+  },
   "homepage": "https://glassflow.dev",
-  "keywords": ["navflow", "data-plane", "agents", "observability"],
+  "keywords": [
+    "navflow",
+    "data-plane",
+    "agents",
+    "observability"
+  ],
   "mcpServers": "./.mcp.json",
   "userConfig": {
     "navflow_url": {
@@ -16,8 +24,8 @@
     },
     "ingest_token": {
       "type": "string",
-      "title": "Auth token (optional)",
-      "description": "Only if your NavFlow requires auth (NAVFLOW_AUTH_TOKEN / INGEST_TOKEN). Sent as a Bearer header to the MCP proxy and the ingest endpoint.",
+      "title": "API key / token (optional)",
+      "description": "Only if your NavFlow requires auth. Recommended: an API key with the read + ingest scopes (console -> Security -> API keys) \u2014 streams sessions and enables MCP read-back without admin rights. The root auth token also works.",
       "sensitive": true,
       "default": ""
     },

--- a/claude-plugin/.mcp.json
+++ b/claude-plugin/.mcp.json
@@ -4,7 +4,7 @@
       "command": "navflow-mcp",
       "env": {
         "NAVFLOWD_URL": "${user_config.navflow_url}",
-        "NAVFLOW_AUTH_TOKEN": "${CLAUDE_PLUGIN_OPTION_ingest_token}"
+        "NAVFLOW_AUTH_TOKEN": "${user_config.ingest_token}"
       }
     }
   }

--- a/claude-plugin/scripts/ship.py
+++ b/claude-plugin/scripts/ship.py
@@ -24,6 +24,15 @@ def _truthy(v: str) -> bool:
     return str(v).strip().lower() not in ("0", "false", "off", "no", "")
 
 
+def _opt(name: str, default: str = "") -> str:
+    """userConfig option from the hook env. Claude Code injects CLAUDE_PLUGIN_OPTION_<KEY> with
+    the key UPPERCASED (user_config.ingest_token -> CLAUDE_PLUGIN_OPTION_INGEST_TOKEN); check the
+    verbatim casing too for robustness across versions."""
+    return (os.environ.get(f"CLAUDE_PLUGIN_OPTION_{name.upper()}")
+            or os.environ.get(f"CLAUDE_PLUGIN_OPTION_{name}")
+            or default)
+
+
 def _post(url: str, data: bytes, headers: dict):
     req = urllib.request.Request(url, data=data, headers=headers, method="POST")
     return urllib.request.urlopen(req, timeout=5)
@@ -55,11 +64,11 @@ def main() -> None:
     except Exception:
         return
 
-    if not _truthy(os.environ.get("CLAUDE_PLUGIN_OPTION_stream_sessions", "true")):
+    if not _truthy(_opt("stream_sessions", "true")):
         return
 
-    base = os.environ.get("CLAUDE_PLUGIN_OPTION_navflow_url", "http://127.0.0.1:8787").rstrip("/")
-    token = os.environ.get("CLAUDE_PLUGIN_OPTION_ingest_token", "").strip()
+    base = (_opt("navflow_url") or "http://127.0.0.1:8787").rstrip("/")
+    token = (_opt("ingest_token") or "").strip()
     headers = {"Content-Type": "application/x-ndjson"}
     if token:
         headers["Authorization"] = f"Bearer {token}"

--- a/ui/src/pages/Activity.tsx
+++ b/ui/src/pages/Activity.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
 
 import { api, auth } from "../api";
 import { Close, Search } from "../components/icons";
@@ -151,7 +152,11 @@ function Connect() {
             </div>
           </div>
           <p className="help" style={{ marginTop: 6, whiteSpace: "normal" }}>
-            This is your console access token — agents authenticate with the same bearer token. Keep it secret.
+            This is your console access token — it works in the snippets below, but it carries{" "}
+            <strong>full admin rights</strong>. For an agent, prefer a{" "}
+            <span className="mono">read</span>-scoped API key from the{" "}
+            <Link to="/security">Security page</Link> (add <span className="mono">ingest</span> if
+            the agent also writes memories) and paste it in place of the token.
           </p>
         </div>
       )}


### PR DESCRIPTION
The plugin's token/URL plumbing never actually worked — it was masked by the local default (open daemon at 127.0.0.1:8787):

- `.mcp.json` passed the token as `${CLAUDE_PLUGIN_OPTION_ingest_token}`, which Claude Code does not substitute — the MCP proxy sent that literal string as the bearer (401 on any authed instance). Now `${user_config.ingest_token}`, the documented syntax (same as the already-working URL).
- `ship.py` read `CLAUDE_PLUGIN_OPTION_ingest_token` / `_navflow_url`, but Claude Code injects the env vars with the option key UPPERCASED — so hooks read nothing and fell back to localhost, silently. Now reads the uppercased name (verbatim casing as fallback).
- Plugin 0.1.0 → 0.1.1; token field renamed "API key / token", recommending a read+ingest key.
- Agents page: the access-token panel now says the console token is full-admin and recommends a read-scoped API key from the Security page for agents.

Verified end-to-end: simulated hook invocation (uppercased env, ingest token only) against a fresh authed daemon → claude_code source auto-created, transcript line ingested.