### PR TITLE
Console: agent connect/activity split, guided view & trigger editors

### DIFF
--- a/navflow/runtime.py
+++ b/navflow/runtime.py
@@ -119,7 +119,11 @@ class Runtime:
             from .connectors import normalize_config, source_type_for
             self.store.upsert_catalog_source(
                 "claude_code", source_type_for("claude_code"), "claude_code", "10s",
-                normalize_config("claude_code", {"push": True}))
+                normalize_config("claude_code", {"push": True, "labels": [
+                    {"name": "session", "field": "session", "primary": True},
+                    {"name": "project", "field": "project"},
+                    {"name": "branch", "field": "branch"},
+                    {"name": "model", "field": "model"}]}))
             self.reload_catalog()
             cfg = self.catalog.sources.get("claude_code")
             print("navflowd: auto-provisioned Claude Code source 'claude_code'")

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -4,7 +4,7 @@ import { Link, NavLink, Outlet, useLocation } from "react-router-dom";
 import { auth } from "./api";
 import CommandPalette from "./components/CommandPalette";
 import {
-  Activity, Bolt, Book, Chat, ChevronRight, Database, Lock, Moon,
+  Activity, Bolt, Book, Chat, ChevronRight, Database, Filter, Lock, Moon,
   Settings as SettingsIco, SignOut, Sun, Terminal,
 } from "./components/icons";
 import { applyTheme, currentTheme, type Theme } from "./theme";
@@ -29,9 +29,10 @@ const NAV_GROUPS: { section: string; items: NavItem[] }[] = [
     { to: "/explore", label: "Explore", icon: Activity },
   ] },
   { section: "Serve to agents", items: [
+    { to: "/connect", label: "Connect", icon: Terminal },
     { to: "/views", label: "Views", icon: Book },
     { to: "/triggers", label: "Triggers", icon: Bolt },
-    { to: "/agents", label: "Agents", icon: Terminal },
+    { to: "/activity", label: "Activity", icon: Filter },
   ] },
 ];
 
@@ -39,7 +40,8 @@ const SECTION_LABEL: Record<string, string> = {
   explore: "Explore",
   views: "Views",
   triggers: "Triggers",
-  agents: "Agents",
+  connect: "Connect",
+  activity: "Activity",
   catalog: "Catalog",
   ask: "Ask",
   security: "Security",

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -4,7 +4,7 @@ import { createBrowserRouter, Navigate, RouterProvider } from "react-router-dom"
 
 import App from "./App";
 import AuthGate from "./components/AuthGate";
-import Activity from "./pages/Activity";
+import AgentActivity, { ConnectPage } from "./pages/Activity";
 import Ask from "./pages/Ask";
 import Explore from "./pages/Explore";
 import SourceClaudeCode from "./pages/SourceClaudeCode";
@@ -30,7 +30,9 @@ const router = createBrowserRouter([
       { path: "explore", element: <Explore /> },
       { path: "views", element: <ViewsPage /> },
       { path: "triggers", element: <TriggersPage /> },
-      { path: "agents", element: <Activity /> },
+      { path: "connect", element: <ConnectPage /> },
+      { path: "activity", element: <AgentActivity /> },
+      { path: "agents", element: <Navigate to="/connect" replace /> },
       { path: "ask", element: <Ask /> },
       { path: "security", element: <Security /> },
       { path: "settings", element: <Settings /> },
@@ -38,7 +40,6 @@ const router = createBrowserRouter([
       // dissolved: source schema/freshness now lives on the source detail; the agent's-eye read
       // is Explore's Agent-view toggle.
       { path: "entities", element: <Navigate to="/explore" replace /> },
-      { path: "activity", element: <Navigate to="/agents" replace /> },
       { path: "catalog", element: <Navigate to="/" replace /> },
     ],
   },

--- a/ui/src/pages/Activity.tsx
+++ b/ui/src/pages/Activity.tsx
@@ -6,30 +6,56 @@ import { Close, Search } from "../components/icons";
 import { TimeAgo, usePolling } from "../components/bits";
 import type { DispatchLogEntry } from "../types";
 
-type Tab = "connect" | "queries" | "dispatches" | "subscriptions";
-const LABELS: Record<Tab, string> = {
-  connect: "Connect", queries: "Reads", dispatches: "Trigger dispatches",
-  subscriptions: "Subscriptions",
+// Two pages share this module: Connect (how an agent hooks up — one tab per integration mode)
+// and AgentActivity (what agents have been doing — reads + trigger dispatches).
+type ConnectTab = "mcp" | "push" | "rest";
+const CONNECT_LABELS: Record<ConnectTab, string> = {
+  mcp: "MCP (pull)", push: "Webhook (push)", rest: "REST",
 };
 
-export default function Activity() {
-  const [tab, setTab] = useState<Tab>("connect");
+export function ConnectPage() {
+  const [tab, setTab] = useState<ConnectTab>("mcp");
 
   return (
     <>
-      <h1>Agents</h1>
-      <p className="subtitle">connect an external agent to this NavFlow instance, and watch what they do</p>
+      <h1>Connect</h1>
+      <p className="subtitle">
+        hook an agent up to this NavFlow — <em>it pulls (MCP), gets pushed (webhook), or calls
+        plain REST</em>
+      </p>
 
       <div className="tabs">
-        {(Object.keys(LABELS) as Tab[]).map((t) => (
-          <button key={t} className={tab === t ? "active" : ""} onClick={() => setTab(t)}>{LABELS[t]}</button>
+        {(Object.keys(CONNECT_LABELS) as ConnectTab[]).map((t) => (
+          <button key={t} className={tab === t ? "active" : ""} onClick={() => setTab(t)}>{CONNECT_LABELS[t]}</button>
         ))}
       </div>
 
-      {tab === "connect" && <Connect />}
+      <Connect tab={tab} />
+    </>
+  );
+}
+
+type ActivityTab = "queries" | "dispatches";
+const ACTIVITY_LABELS: Record<ActivityTab, string> = {
+  queries: "Reads", dispatches: "Trigger dispatches",
+};
+
+export default function AgentActivity() {
+  const [tab, setTab] = useState<ActivityTab>("queries");
+
+  return (
+    <>
+      <h1>Activity</h1>
+      <p className="subtitle">what agents have been doing — every read, every trigger dispatch</p>
+
+      <div className="tabs">
+        {(Object.keys(ACTIVITY_LABELS) as ActivityTab[]).map((t) => (
+          <button key={t} className={tab === t ? "active" : ""} onClick={() => setTab(t)}>{ACTIVITY_LABELS[t]}</button>
+        ))}
+      </div>
+
       {tab === "queries" && <Queries />}
       {tab === "dispatches" && <Dispatches />}
-      {tab === "subscriptions" && <Subscriptions />}
     </>
   );
 }
@@ -68,12 +94,14 @@ function CodeBlock({ title, code }: { title: string; code: string }) {
   );
 }
 
-function Connect() {
+function Connect({ tab }: { tab: ConnectTab }) {
   const origin = window.location.origin;
   const [authReq, setAuthReq] = useState<boolean>();
   const [status, setStatus] = useState<"checking" | "live" | "absent">("checking");
   const [url, setUrl] = useState(`${origin}/mcp`);
   const [tools, setTools] = useState<{ name: string; description: string }[]>();
+  const [triggers, setTriggers] = useState<{ name: string }[]>();
+  const [trig, setTrig] = useState<string>();
   const [reveal, setReveal] = useState(false);
   const [toolQ, setToolQ] = useState("");
   const token = auth.get();
@@ -81,6 +109,8 @@ function Connect() {
   useEffect(() => {
     api.health().then((h) => setAuthReq(h.auth_required)).catch(() => setAuthReq(false));
     api.mcpTools().then(setTools).catch(() => setTools([]));
+    api.triggers().then((t) => { setTriggers(t); if (t.length) setTrig(t[0].name); })
+      .catch(() => setTriggers([]));
 
     // The MCP endpoint sits in one of two places: same host/port behind a reverse proxy
     // (the compose deployment — Caddy routes /mcp to the MCP server), or on its own port
@@ -127,6 +157,16 @@ function Connect() {
   const stdioJson = (t: string) => JSON.stringify({
     mcpServers: { navflow: { command: "navflow-mcp", env: { NAVFLOWD_URL: origin, ...(authReq ? { NAVFLOW_AUTH_TOKEN: t } : {}) } } },
   }, null, 2);
+  const subscribeCurl = (t: string) =>
+    `curl -X POST ${origin}/subscribe \\\n` +
+    `  -H 'Content-Type: application/json' \\\n` +
+    (authReq ? `  -H 'Authorization: Bearer ${t}' \\\n` : "") +
+    `  -d '{"trigger": "${trig ?? "<trigger>"}", "url": "https://your-agent.example.com/hook"}'`;
+  const queryCurl = (t: string) =>
+    `curl -X POST ${origin}/query \\\n` +
+    `  -H 'Content-Type: application/json' \\\n` +
+    (authReq ? `  -H 'Authorization: Bearer ${t}' \\\n` : "") +
+    `  -d '{"view": "<view>", "key": "<entity>", "window": "15m"}'`;
 
   const shownTools = useMemo(() => {
     const needle = toolQ.trim().toLowerCase();
@@ -136,13 +176,15 @@ function Connect() {
 
   return (
     <div className="connect">
-      <div className={`mcp-status ${status}`}>
-        {status === "checking" && "checking the MCP endpoint…"}
-        {status === "live" && <span>MCP endpoint is live at <span className="mono">{url}</span></span>}
-        {status === "absent" && <span>No MCP endpoint found — neither at <span className="mono">{origin}/mcp</span> (reverse-proxied) nor on the default port <span className="mono">:8788</span> (separate process). Run <span className="mono">navflow mcp</span> alongside the daemon (the compose deployment includes it), or use the <strong>stdio</strong> proxy below.</span>}
-      </div>
+      {tab === "mcp" && (
+        <div className={`mcp-status ${status}`}>
+          {status === "checking" && "checking the MCP endpoint…"}
+          {status === "live" && <span>MCP endpoint is live at <span className="mono">{url}</span></span>}
+          {status === "absent" && <span>No MCP endpoint found — neither at <span className="mono">{origin}/mcp</span> (reverse-proxied) nor on the default port <span className="mono">:8788</span> (separate process). Run <span className="mono">navflow mcp</span> alongside the daemon (the compose deployment includes it), or use the <strong>stdio</strong> proxy below.</span>}
+        </div>
+      )}
 
-      {authReq && (
+      {tab === "mcp" && authReq && (
         <div className="panel" style={{ marginTop: 14 }}>
           <div className="row" style={{ justifyContent: "space-between", alignItems: "center" }}>
             <div><span className="lbl">access token</span> <span className="mono">{shownTok}</span></div>
@@ -161,11 +203,108 @@ function Connect() {
         </div>
       )}
 
+      {tab === "push" && (
+        <>
+          <p className="help" style={{ whiteSpace: "normal", marginTop: 14 }}>
+            Flip the loop: NavFlow watches, the agent sleeps. When a trigger&rsquo;s condition
+            trips, NavFlow POSTs the <strong>correlated timeline</strong> to a URL your agent
+            listens on — the investigation starts with the evidence already attached,{" "}
+            <strong>zero reads</strong>. (In our SRE incident benchmark the same diagnosis took 6
+            fan-out reads baseline, 1 correlated read over MCP, 0 when pushed.)
+          </p>
+
+          <h3 style={{ marginBottom: 4 }}>1 · Give your agent an HTTP endpoint</h3>
+          <p className="help" style={{ whiteSpace: "normal" }}>
+            Anything that accepts a POST and starts your agent with the request body as context — a
+            small FastAPI/Express route, a serverless function, a workflow-engine webhook. It must
+            be reachable <em>from this NavFlow server</em>. Every delivery is JSON shaped like:
+          </p>
+          <CodeBlock title="what your endpoint receives on each firing" code={JSON.stringify({
+            dispatch_id: "9f2c81d4…",
+            trigger: trig ?? "error_spike",
+            kind: "alert",
+            key: "api-server",
+            fired_at: "2026-07-17T09:14:03+00:00",
+            payload: "…the correlated timeline for this entity, ready to hand to the model…",
+          }, null, 2)} />
+          <p className="help" style={{ whiteSpace: "normal" }}>
+            Delivery is <strong>at-least-once</strong> with retries — dedupe on{" "}
+            <span className="mono">dispatch_id</span>. Answer anything below 500 to acknowledge.
+          </p>
+
+          <h3 style={{ marginBottom: 4 }}>2 · Subscribe that endpoint to a trigger</h3>
+          {triggers && triggers.length > 0 ? (
+            <>
+              <p className="help" style={{ whiteSpace: "normal" }}>
+                A trigger is a condition NavFlow evaluates continuously over a view. Pick one,
+                replace the URL with your endpoint, and run (needs a{" "}
+                <span className="mono">read</span>-scoped <Link to="/security">API key</Link>;
+                revoking the key removes its subscriptions):
+              </p>
+              {triggers.length > 1 && (
+                <label className="field" style={{ maxWidth: 300 }}>
+                  <span className="lbl">trigger</span>
+                  <select value={trig} onChange={(e) => setTrig(e.target.value)}>
+                    {triggers.map((t) => <option key={t.name} value={t.name}>{t.name}</option>)}
+                  </select>
+                </label>
+              )}
+              <CodeBlock title="subscribe your agent's endpoint" code={subscribeCurl(shownTok)} />
+            </>
+          ) : (
+            <p className="help" style={{ whiteSpace: "normal" }}>
+              This instance has no triggers yet, so there is nothing to subscribe to — create one
+              under <Link to="/triggers">Triggers</Link> (a condition over a view), then come back
+              here.
+            </p>
+          )}
+
+          <h3 style={{ marginBottom: 4 }}>3 · That&rsquo;s the loop</h3>
+          <p className="help" style={{ whiteSpace: "normal" }}>
+            From now on every firing wakes your agent with the timeline attached; it can query back
+            over MCP or REST if it needs more, and <span className="mono">remember</span> its
+            conclusion so the next dispatch arrives with prior findings included. Watch real
+            deliveries under <Link to="/activity">Activity → Trigger dispatches</Link> (every
+            firing is logged there, even with no subscribers — useful to test a trigger before
+            wiring the agent). Full walkthrough and a runnable incident-response example:{" "}
+            <a href="https://www.navflow.ai/docs/agents" target="_blank" rel="noreferrer">
+              navflow.ai/docs/agents</a>.
+          </p>
+
+          <h3 style={{ marginTop: 22 }}>Subscribed agents</h3>
+          <p className="help" style={{ whiteSpace: "normal" }}>
+            The endpoints currently wired to be woken — one row per <span className="mono">subscribe</span>.
+          </p>
+          <Subscriptions />
+        </>
+      )}
+
+      {tab === "rest" && (
+        <>
+          <p className="help" style={{ whiteSpace: "normal", marginTop: 14 }}>
+            No MCP client? The same read surface is plain HTTP — one call returns the correlated
+            timeline. Agents can also write conclusions back with{" "}
+            <span className="mono">POST /remember</span> (needs <span className="mono">ingest</span>),
+            so the next timeline arrives with prior findings attached.
+          </p>
+          <CodeBlock title="read a correlated timeline" code={queryCurl(shownTok)} />
+        </>
+      )}
+
+      {tab === "mcp" && (
+        <>
+      <p className="help" style={{ whiteSpace: "normal", marginTop: 14 }}>
+        The agent connects as an MCP client and reads on demand: <span className="mono">read</span>,{" "}
+        <span className="mono">query</span>, <span className="mono">catalog_*</span> — one correlated
+        timeline per call instead of fanning out across your systems. Needs a{" "}
+        <span className="mono">read</span>-scoped key.
+      </p>
+
+      <h3 style={{ marginBottom: 4 }}>Any MCP client (HTTP)</h3>
+      <CodeBlock title="add to the client's MCP config" code={httpJson(shownTok)} />
+
       <h3 style={{ marginBottom: 4 }}>Claude Code</h3>
       <CodeBlock title="run in your terminal" code={claudeCode(tok)} />
-
-      <h3 style={{ marginBottom: 4 }}>Claude Desktop · Cursor · generic MCP client (HTTP)</h3>
-      <CodeBlock title="add to the client's MCP config" code={httpJson(shownTok)} />
 
       <h3 style={{ marginBottom: 4 }}>stdio (agent on the same machine, or no /mcp endpoint)</h3>
       <p className="help" style={{ whiteSpace: "normal" }}>
@@ -196,6 +335,8 @@ function Connect() {
               )}
             </tbody>
           </table>
+        </>
+      )}
         </>
       )}
     </div>

--- a/ui/src/pages/ViewsTriggers.tsx
+++ b/ui/src/pages/ViewsTriggers.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
 
 import { api } from "../api";
 import ConfirmDialog from "../components/ConfirmDialog";
-import { Close, Search } from "../components/icons";
+import { Search } from "../components/icons";
 import { TimeAgo, usePolling } from "../components/bits";
 import type { Trigger, View, ViewFilter } from "../types";
 
@@ -53,6 +54,47 @@ function FilterBar({ q, setQ, placeholder, shown, total }: {
   );
 }
 
+/** Input with styled suggestions — replaces native <datalist> (which can't be themed).
+ *  Free text stays allowed; suggestions filter as you type. */
+function Combo({ value, onChange, options, placeholder, style }: {
+  value: string; onChange: (v: string) => void; options: string[];
+  placeholder?: string; style?: React.CSSProperties;
+}) {
+  const [open, setOpen] = useState(false);
+  const [hi, setHi] = useState(0);
+  const needle = value.trim().toLowerCase();
+  const shown = options.filter((o) => !needle || o.toLowerCase().includes(needle));
+
+  const pick = (o: string) => { onChange(o); setOpen(false); };
+
+  return (
+    <div className="combo" style={style}>
+      <input type="text" value={value} placeholder={placeholder}
+             onChange={(e) => { onChange(e.target.value); setOpen(true); setHi(0); }}
+             onFocus={() => setOpen(true)}
+             onBlur={() => setOpen(false)}
+             onKeyDown={(e) => {
+               if (!open || !shown.length) return;
+               if (e.key === "ArrowDown") { e.preventDefault(); setHi((h) => Math.min(h + 1, shown.length - 1)); }
+               else if (e.key === "ArrowUp") { e.preventDefault(); setHi((h) => Math.max(h - 1, 0)); }
+               else if (e.key === "Enter") { e.preventDefault(); pick(shown[hi]); }
+               else if (e.key === "Escape") setOpen(false);
+             }} />
+      {open && shown.length > 0 && (
+        <div className="combo-list">
+          {shown.map((o, i) => (
+            <div key={o} className={"combo-item" + (i === hi ? " active" : "")}
+                 onMouseDown={(e) => { e.preventDefault(); pick(o); }}
+                 onMouseEnter={() => setHi(i)}>
+              {o}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
 /** Esc-to-close for an open editor sheet. */
 function useEscape(active: boolean, close: () => void) {
   useEffect(() => {
@@ -80,9 +122,35 @@ function ViewsSection({ views, sourceNames, onChange }:
   const [editing, setEditing] = useState<View | null>(null);
   const [isNew, setIsNew] = useState(false);
   const [error, setError] = useState<string>();
-  const [filtersText, setFiltersText] = useState("");
+  const [fRows, setFRows] = useState<Array<{ field: string; op: string; value: string }>>([]);
+  const [labelOpts, setLabelOpts] = useState<string[]>([]);   // entity labels/keys — key_field candidates
+  const [fieldOpts, setFieldOpts] = useState<string[]>([]);   // every field — for filter rows
   const [q, setQ] = useState("");
   const [confirmDelName, setConfirmDelName] = useState<string | null>(null);
+
+  // Suggest real field/label names from the selected sources, so key_field and filters are
+  // picked rather than guessed.
+  useEffect(() => {
+    if (!editing?.sources.length) { setLabelOpts([]); setFieldOpts([]); return; }
+    let live = true;
+    Promise.all(editing.sources.map((s) => api.sourceFields(s).catch(() => null)))
+      .then((profiles) => {
+        if (!live) return;
+        const labels = new Set<string>();
+        const names = new Set<string>();
+        for (const p of profiles) {
+          for (const f of p?.fields ?? []) {
+            names.add(f.name);
+            if (f.is_label || f.is_key) labels.add(f.name);   // only entity axes fit key_field
+          }
+        }
+        // sources created without declared labels flag nothing — fall back to every field
+        // rather than suggesting nothing at all
+        setLabelOpts(Array.from(labels.size ? labels : names).sort());
+        setFieldOpts(Array.from(names).sort());
+      });
+    return () => { live = false; };
+  }, [editing?.sources.join("|")]);
 
   const shown = useMemo(() => {
     const needle = q.trim().toLowerCase();
@@ -99,22 +167,19 @@ function ViewsSection({ views, sourceNames, onChange }:
     setEditing({ ...v });
     setIsNew(fresh);
     setError(undefined);
-    setFiltersText(v.filters?.length ? JSON.stringify(v.filters, null, 2) : "");
+    setFRows((v.filters ?? []).map((f) => ({ field: f.field, op: f.op, value: String(f.value) })));
   };
 
-  const parseFilters = (): ViewFilter[] | null => {
-    if (!filtersText.trim()) return [];
-    try {
-      const parsed = JSON.parse(filtersText);
-      return Array.isArray(parsed) ? parsed : null;
-    } catch { return null; }
-  };
+  const NUMERIC_OPS = new Set(["gt", "lt", "gte", "lte"]);
+  const buildFilters = (): ViewFilter[] =>
+    fRows.filter((r) => r.field.trim())
+      .map((r) => ({ field: r.field.trim(), op: r.op as ViewFilter["op"],
+                     value: NUMERIC_OPS.has(r.op) ? Number(r.value) : r.value }));
 
   const save = async () => {
     if (!editing) return;
     setError(undefined);
-    const filters = parseFilters();
-    if (filters === null) { setError("filters must be a JSON list of {field, op, value}"); return; }
+    const filters = buildFilters();
     const body = { ...editing, filters };
     try {
       if (isNew) await api.createView(body);
@@ -134,13 +199,106 @@ function ViewsSection({ views, sourceNames, onChange }:
     <>
       <div className="pagehead">
         <span />
-        <button onClick={() => openEditor({ name: "", key_field: "service", sources: [] }, true)}>
+        <button disabled={!!editing}
+                onClick={() => openEditor({ name: "", key_field: "", sources: [] }, true)}>
           Add view
         </button>
       </div>
       {error && !editing && <div className="alert error">{error}</div>}
 
-      {!views.length && <div className="empty">no views — agents have nothing to query yet</div>}
+      {editing && (
+        <div className="panel" style={{ marginBottom: 18 }}>
+          <div className="pagehead" style={{ marginBottom: 8 }}>
+            <h2 style={{ margin: 0 }}>{isNew ? "New view" : <>Edit <span className="mono">{editing.name}</span></>}</h2>
+            <button onClick={close}>Cancel</button>
+          </div>
+          {error && <div className="alert error">{error}</div>}
+
+          <label className="field" style={{ maxWidth: 340 }}>
+            <span className="lbl">name</span>
+            <input type="text" value={editing.name} disabled={!isNew} placeholder="e.g. service_timeline"
+                   onChange={(e) => setEditing({ ...editing, name: e.target.value })} />
+            <span className="help">agents query it by this name</span>
+          </label>
+
+          <div className="field">
+            <span className="lbl">sources to correlate</span>
+            <span className="help" style={{ display: "block", marginTop: 0, marginBottom: 6 }}>
+              events from every ticked source merge into one time-ordered timeline
+            </span>
+            {sourceNames.length === 0 && <span className="help">no sources yet — add one under Sources first</span>}
+            {sourceNames.map((s) => (
+              <label key={s} style={{ display: "inline-flex", gap: 6, marginRight: 16, marginBottom: 4, alignItems: "center" }}>
+                <input type="checkbox" checked={editing.sources.includes(s)}
+                       onChange={(e) => setEditing({
+                         ...editing,
+                         sources: e.target.checked
+                           ? [...editing.sources, s]
+                           : editing.sources.filter((x) => x !== s),
+                       })} />
+                <span className="mono">{s}</span>
+              </label>
+            ))}
+          </div>
+
+          <div className="field" style={{ marginTop: 14 }}>
+            <span className="lbl">key field</span>
+            <span className="help" style={{ display: "block", marginTop: 0, marginBottom: 6 }}>
+              the label agents look an entity up by — pick one the ticked sources share
+            </span>
+            <Combo value={editing.key_field} options={labelOpts}
+                   style={{ maxWidth: 340 }}
+                   placeholder={labelOpts.length ? `e.g. ${labelOpts[0]}` : "e.g. service"}
+                   onChange={(v) => setEditing({ ...editing, key_field: v })} />
+            {labelOpts.length > 0 && (
+              <div style={{ marginTop: 6 }}>
+                {labelOpts.map((f) => (
+                  <button key={f} type="button" className="chip"
+                          style={{ cursor: "pointer", marginRight: 6,
+                                   outline: editing.key_field === f ? "2px solid var(--accent)" : undefined }}
+                          onClick={() => setEditing({ ...editing, key_field: f })}>
+                    {f}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+
+          <div className="field">
+            <span className="lbl">filters (optional)</span>
+            <span className="help" style={{ display: "block", marginTop: 0, marginBottom: 6 }}>
+              narrow what the view returns — applied on reads and trigger evaluation
+            </span>
+            {fRows.map((r, i) => (
+              <div key={i} className="btnrow" style={{ marginBottom: 6, alignItems: "center" }}>
+                <Combo value={r.field} options={fieldOpts} placeholder="field"
+                       style={{ maxWidth: 200, flex: 1 }}
+                       onChange={(v) => setFRows(fRows.map((x, j) => j === i ? { ...x, field: v } : x))} />
+                <select value={r.op} style={{ maxWidth: 130 }}
+                        onChange={(e) => setFRows(fRows.map((x, j) => j === i ? { ...x, op: e.target.value } : x))}>
+                  {["eq", "neq", "contains", "gt", "lt", "gte", "lte"].map((o) => <option key={o} value={o}>{o}</option>)}
+                </select>
+                <input type="text" className="mono" style={{ maxWidth: 180 }} placeholder="value" value={r.value}
+                       onChange={(e) => setFRows(fRows.map((x, j) => j === i ? { ...x, value: e.target.value } : x))} />
+                <button type="button" className="danger" onClick={() => setFRows(fRows.filter((_, j) => j !== i))}>×</button>
+              </div>
+            ))}
+            <button type="button" onClick={() => setFRows([...fRows, { field: "", op: "eq", value: "" }])}>
+              + Add filter
+            </button>
+          </div>
+
+          <div className="btnrow">
+            <button className="primary" onClick={save}
+                    disabled={!editing.name.trim() || !editing.key_field.trim() || !editing.sources.length}>
+              {isNew ? "Create view" : "Save"}
+            </button>
+            <button onClick={close}>Cancel</button>
+          </div>
+        </div>
+      )}
+
+      {!views.length && !editing && <div className="empty">no views — agents have nothing to query yet</div>}
       {!!views.length && (
         <>
           <FilterBar q={q} setQ={setQ} placeholder="Filter by name, key, source…" shown={shown.length} total={views.length} />
@@ -175,65 +333,6 @@ function ViewsSection({ views, sourceNames, onChange }:
               {!shown.length && <tr><td colSpan={7} className="dim" style={{ textAlign: "center", padding: 24 }}>no views match “{q}”</td></tr>}
             </tbody>
           </table>
-        </>
-      )}
-
-      {editing && (
-        <>
-          <div className="sheet-overlay" onClick={close} />
-          <aside className="sheet" role="dialog" aria-label="View editor">
-            <div className="sheet-head">
-              <div className="sheet-title">
-                <h2>{isNew ? "New view" : <>Edit <span className="mono">{editing.name}</span></>}</h2>
-              </div>
-              <button className="sheet-close" onClick={close} aria-label="Close"><Close /></button>
-            </div>
-            <div className="sheet-body">
-              {error && <div className="alert error">{error}</div>}
-              <div className="row2">
-                <label className="field">
-                  <span className="lbl">name</span>
-                  <input type="text" value={editing.name} disabled={!isNew}
-                         onChange={(e) => setEditing({ ...editing, name: e.target.value })} />
-                </label>
-                <label className="field">
-                  <span className="lbl">key field</span>
-                  <input type="text" value={editing.key_field}
-                         onChange={(e) => setEditing({ ...editing, key_field: e.target.value })} />
-                  <span className="help">what the entity key means, e.g. service</span>
-                </label>
-              </div>
-              <div className="field">
-                <span className="lbl">sources in this view</span>
-                {sourceNames.length === 0 && <span className="help">no sources yet</span>}
-                {sourceNames.map((s) => (
-                  <label key={s} style={{ display: "inline-flex", gap: 6, marginRight: 16, alignItems: "center" }}>
-                    <input type="checkbox" checked={editing.sources.includes(s)}
-                           onChange={(e) => setEditing({
-                             ...editing,
-                             sources: e.target.checked
-                               ? [...editing.sources, s]
-                               : editing.sources.filter((x) => x !== s),
-                           })} />
-                    <span className="mono">{s}</span>
-                  </label>
-                ))}
-              </div>
-              <label className="field">
-                <span className="lbl">filters (optional, JSON)</span>
-                <textarea className="code" style={{ minHeight: 70 }} value={filtersText}
-                          placeholder={'[{"field": "latency_ms", "op": "gt", "value": 1000}]'}
-                          onChange={(e) => setFiltersText(e.target.value)} />
-                <span className="help">
-                  narrow the view: ops eq · neq · contains · gt · lt · gte · lte; applied on reads and trigger eval
-                </span>
-              </label>
-            </div>
-            <div className="sheet-foot">
-              <button className="primary" onClick={save}>{isNew ? "Create view" : "Save"}</button>
-              <button onClick={close}>Cancel</button>
-            </div>
-          </aside>
         </>
       )}
 
@@ -305,13 +404,94 @@ function TriggersSection({ triggers, viewNames, onChange }:
       <div className="pagehead">
         <span />
         <button disabled={!viewNames.length}
+                title={viewNames.length ? undefined : "a trigger watches a view — create a view first"}
                 onClick={() => { setEditing(emptyTrigger(viewNames[0])); setIsNew(true); setError(undefined); }}>
           Add trigger
         </button>
       </div>
       {error && !editing && <div className="alert error">{error}</div>}
 
-      {!triggers.length && <div className="empty">no triggers — nothing wakes agents yet</div>}
+      {!viewNames.length && (
+        <div className="alert">
+          A trigger is a condition evaluated over a <strong>view</strong>, and this instance has no
+          views yet — <Link to="/views">create a view</Link> first (pick the sources and the entity
+          key it correlates by), then come back and add a trigger on it.
+        </div>
+      )}
+
+      {editing && (
+        <div className="panel" style={{ marginBottom: 18 }}>
+          <div className="pagehead" style={{ marginBottom: 8 }}>
+            <h2 style={{ margin: 0 }}>{isNew ? "New trigger" : <>Edit <span className="mono">{editing.name}</span></>}</h2>
+            <button onClick={close}>Cancel</button>
+          </div>
+          {error && <div className="alert error">{error}</div>}
+          <div className="row2">
+            <label className="field">
+              <span className="lbl">name</span>
+              <input type="text" value={editing.name} disabled={!isNew} placeholder="e.g. error_spike"
+                     onChange={(e) => setEditing({ ...editing, name: e.target.value })} />
+            </label>
+            <label className="field">
+              <span className="lbl">view</span>
+              <select value={editing.view} onChange={(e) => setEditing({ ...editing, view: e.target.value })}>
+                {viewNames.map((v) => <option key={v} value={v}>{v}</option>)}
+              </select>
+            </label>
+          </div>
+          <div className="row2">
+            <label className="field">
+              <span className="lbl">aggregate</span>
+              <select value={editing.condition.aggregate}
+                      onChange={(e) => setEditing({ ...editing, condition: { ...editing.condition, aggregate: e.target.value } })}>
+                {AGGREGATES.map((a) => <option key={a} value={a}>{a}</option>)}
+              </select>
+            </label>
+            <label className="field">
+              <span className="lbl">field</span>
+              <input type="text" value={editing.condition.field ?? ""}
+                     placeholder="e.g. rate_5xx (empty for count)"
+                     onChange={(e) => setEditing({ ...editing, condition: { ...editing.condition, field: e.target.value } })} />
+            </label>
+          </div>
+          <div className="row2">
+            <label className="field">
+              <span className="lbl">predicate</span>
+              <input type="text" value={editing.condition.predicate}
+                     onChange={(e) => setEditing({ ...editing, condition: { ...editing.condition, predicate: e.target.value } })} />
+              <span className="help">e.g. &gt; 1.0, &gt;= 100, == 0</span>
+            </label>
+            <label className="field">
+              <span className="lbl">window</span>
+              <input type="text" value={editing.condition.window}
+                     onChange={(e) => setEditing({ ...editing, condition: { ...editing.condition, window: e.target.value } })} />
+              <span className="help">detection window, e.g. 1m</span>
+            </label>
+          </div>
+          <div className="row2">
+            <label className="field">
+              <span className="lbl">context window</span>
+              <input type="text" value={String(editing.emit.context_window ?? "15m")}
+                     onChange={(e) => setEditing({ ...editing, emit: { ...editing.emit, context_window: e.target.value } })} />
+              <span className="help">how much timeline the woken agent receives</span>
+            </label>
+            <label className="field">
+              <span className="lbl">cooldown</span>
+              <input type="text" value={editing.cooldown}
+                     onChange={(e) => setEditing({ ...editing, cooldown: e.target.value })} />
+              <span className="help">minimum gap between firings per key</span>
+            </label>
+          </div>
+          <div className="btnrow">
+            <button className="primary" onClick={save} disabled={!editing.name.trim()}>
+              {isNew ? "Create trigger" : "Save"}
+            </button>
+            <button onClick={close}>Cancel</button>
+          </div>
+        </div>
+      )}
+
+      {!triggers.length && !!viewNames.length && !editing && <div className="empty">no triggers — nothing wakes agents yet</div>}
       {!!triggers.length && (
         <>
           <FilterBar q={q} setQ={setQ} placeholder="Filter by name, view, condition…" shown={shown.length} total={triggers.length} />
@@ -341,83 +521,6 @@ function TriggersSection({ triggers, viewNames, onChange }:
               {!shown.length && <tr><td colSpan={5} className="dim" style={{ textAlign: "center", padding: 24 }}>no triggers match “{q}”</td></tr>}
             </tbody>
           </table>
-        </>
-      )}
-
-      {editing && (
-        <>
-          <div className="sheet-overlay" onClick={close} />
-          <aside className="sheet" role="dialog" aria-label="Trigger editor">
-            <div className="sheet-head">
-              <div className="sheet-title">
-                <h2>{isNew ? "New trigger" : <>Edit <span className="mono">{editing.name}</span></>}</h2>
-              </div>
-              <button className="sheet-close" onClick={close} aria-label="Close"><Close /></button>
-            </div>
-            <div className="sheet-body">
-              {error && <div className="alert error">{error}</div>}
-              <div className="row2">
-                <label className="field">
-                  <span className="lbl">name</span>
-                  <input type="text" value={editing.name} disabled={!isNew}
-                         onChange={(e) => setEditing({ ...editing, name: e.target.value })} />
-                </label>
-                <label className="field">
-                  <span className="lbl">view</span>
-                  <select value={editing.view} onChange={(e) => setEditing({ ...editing, view: e.target.value })}>
-                    {viewNames.map((v) => <option key={v} value={v}>{v}</option>)}
-                  </select>
-                </label>
-              </div>
-              <div className="row2">
-                <label className="field">
-                  <span className="lbl">aggregate</span>
-                  <select value={editing.condition.aggregate}
-                          onChange={(e) => setEditing({ ...editing, condition: { ...editing.condition, aggregate: e.target.value } })}>
-                    {AGGREGATES.map((a) => <option key={a} value={a}>{a}</option>)}
-                  </select>
-                </label>
-                <label className="field">
-                  <span className="lbl">field</span>
-                  <input type="text" value={editing.condition.field ?? ""}
-                         placeholder="e.g. rate_5xx (empty for count)"
-                         onChange={(e) => setEditing({ ...editing, condition: { ...editing.condition, field: e.target.value } })} />
-                </label>
-              </div>
-              <div className="row2">
-                <label className="field">
-                  <span className="lbl">predicate</span>
-                  <input type="text" value={editing.condition.predicate}
-                         onChange={(e) => setEditing({ ...editing, condition: { ...editing.condition, predicate: e.target.value } })} />
-                  <span className="help">e.g. &gt; 1.0, &gt;= 100, == 0</span>
-                </label>
-                <label className="field">
-                  <span className="lbl">window</span>
-                  <input type="text" value={editing.condition.window}
-                         onChange={(e) => setEditing({ ...editing, condition: { ...editing.condition, window: e.target.value } })} />
-                  <span className="help">detection window, e.g. 1m</span>
-                </label>
-              </div>
-              <div className="row2">
-                <label className="field">
-                  <span className="lbl">context window</span>
-                  <input type="text" value={String(editing.emit.context_window ?? "15m")}
-                         onChange={(e) => setEditing({ ...editing, emit: { ...editing.emit, context_window: e.target.value } })} />
-                  <span className="help">how much timeline the woken agent receives</span>
-                </label>
-                <label className="field">
-                  <span className="lbl">cooldown</span>
-                  <input type="text" value={editing.cooldown}
-                         onChange={(e) => setEditing({ ...editing, cooldown: e.target.value })} />
-                  <span className="help">minimum gap between firings per key</span>
-                </label>
-              </div>
-            </div>
-            <div className="sheet-foot">
-              <button className="primary" onClick={save}>{isNew ? "Create trigger" : "Save"}</button>
-              <button onClick={close}>Cancel</button>
-            </div>
-          </aside>
         </>
       )}
 

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -374,6 +374,19 @@ pre.payload {
 .empty { color: var(--ink-soft); padding: 32px 28px; text-align: center; background: var(--panel); border: 1px solid var(--line); border-radius: 8px; }
 
 .row2 { display: grid; grid-template-columns: 1fr 1fr; gap: 0 18px; }
+
+/* combobox — a styled replacement for native <datalist> suggestions */
+.combo { position: relative; }
+.combo-list {
+  position: absolute; top: calc(100% + 4px); left: 0; right: 0; z-index: 30;
+  background: var(--input-bg); border: 1px solid var(--line); border-radius: 8px;
+  box-shadow: 0 8px 24px var(--sheet-shadow); max-height: 240px; overflow-y: auto; padding: 4px;
+}
+.combo-item {
+  padding: 6px 10px; border-radius: 6px; cursor: pointer;
+  font-family: var(--mono); font-size: 12.5px;
+}
+.combo-item:hover, .combo-item.active { background: var(--row-hover); }
 .pagehead { display: flex; justify-content: space-between; align-items: baseline; gap: 12px; flex-wrap: wrap; }
 
 /* labels & key editor (SourceForm) */


### PR DESCRIPTION
UX round from testing the serve-to-agents surfaces:

- **Agents page split**: sidebar now has Connect (first entry under Serve to agents) and Activity. Connect = one tab per integration mode — MCP (pull), Webhook (push), REST. Activity = Reads + Trigger dispatches. /agents redirects to /connect.
- **Webhook (push) tab is a real how-to**: 1) give the agent an HTTP endpoint (with the actual dispatch payload shape, at-least-once/dedupe note), 2) subscribe it to a live-listed trigger (ready curl), 3) the loop (query back, remember write-back, dispatches logged even with zero subscribers). Subscriptions table moved here as "Subscribed agents" — it's push-mode wiring, not activity. SRE benchmark numbers (6→1→0 reads) cited inline; docs link for the runnable example.
- **View/trigger editors: no more side sheet** — inline panels at the top of the page. The view form is guided: sources first, key field suggested from the sources' actual label profiles (clickable chips; falls back to all fields when a source declares no labels), filters as field/op/value rows instead of raw JSON, create disabled until valid.
- **Styled combobox** replaces native datalist suggestions (themed, keyboard nav, filter-as-you-type).
- **Triggers page explains its prerequisite** (needs a view) instead of a silently disabled Add button.
- **claude_code auto-provision now declares its labels** (session primary, project, branch, model) so field profiles and key suggestions know the entity axes, matching the OTLP pattern.