### PR TITLE
Source page: labels visibility, tabs, honest field profile

### DIFF
--- a/navflow/config.py
+++ b/navflow/config.py
@@ -220,6 +220,13 @@ def extract_labels(specs, context: dict | None = None) -> dict:
             out[name] = str(spec["const"])
         elif "field" in spec:
             v = ctx.get(spec["field"]) if isinstance(ctx, dict) else None
+            if v is None and isinstance(ctx, dict) and "." in str(spec["field"]):
+                # dotted path into a nested context (the field profile shows e.g. metric.service;
+                # promoting that name must extract it too)
+                head, _, tail = str(spec["field"]).partition(".")
+                sub = ctx.get(head)
+                if isinstance(sub, dict):
+                    v = sub.get(tail)
             if v is not None:
                 out[name] = str(v)
     return out

--- a/navflow/connectors/claude_code.py
+++ b/navflow/connectors/claude_code.py
@@ -98,6 +98,22 @@ class ClaudeCodeConnector(Connector):
                     out.append(env)
         return out
 
+    def label_context(self, o: dict | None) -> dict:
+        """Synthesized label axes from a raw transcript object — the SAME mapping ingest uses
+        (base-class contract: profiling and retroactive relabel must reproduce ingest labels;
+        without this override the field profile showed the raw transcript keys and 0-coverage
+        phantoms for session/project/…)."""
+        o = o or {}
+        msg = o.get("message") if isinstance(o.get("message"), dict) else {}
+        cwd = o.get("cwd")
+        sid = o.get("sessionId")
+        return {"session": str(sid) if sid else None,
+                "project": Path(str(cwd)).name if cwd else None,
+                "branch": str(o["gitBranch"]) if o.get("gitBranch") else None,
+                "model": str(msg["model"]) if msg.get("model") else None,
+                "type": str(o.get("type")) if o.get("type") else None,
+                "sidechain": "true" if o.get("isSidechain") else "false"}
+
     # ── mapping: one JSONL object → one Envelope ───────────────────────────────
     def _obj_to_envelope(self, o: dict, redact: bool, include_thinking: bool):
         sid = o.get("sessionId")
@@ -105,15 +121,8 @@ class ClaudeCodeConnector(Connector):
             return None  # can't key it to a timeline
 
         msg = o.get("message") if isinstance(o.get("message"), dict) else {}
-        cwd = o.get("cwd")
-        labels = {"session": str(sid), "type": str(o.get("type") or "event")}
-        if cwd:
-            labels["project"] = Path(str(cwd)).name
-        if o.get("gitBranch"):
-            labels["branch"] = str(o["gitBranch"])
-        if msg.get("model"):
-            labels["model"] = str(msg["model"])
-        labels["sidechain"] = "true" if o.get("isSidechain") else "false"
+        labels = {k: v for k, v in self.label_context(o).items() if v not in (None, "")}
+        labels.setdefault("type", "event")
 
         text = self._render_text(o, msg, include_thinking)[:500]
         if redact:

--- a/ui/src/components/SourceForm.tsx
+++ b/ui/src/components/SourceForm.tsx
@@ -1,6 +1,7 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { api } from "../api";
+import { Combo } from "./bits";
 import type { ColumnsProposal, ConnectorField, ConnectorSpec, DiscoverProposal, EnvScan, TestResult } from "../types";
 
 // Structured push connectors know their entity shape, so a fresh source starts with sensible
@@ -73,6 +74,27 @@ export default function SourceForm({ connector, spec, initial, lockName, submitL
   const [error, setError] = useState<string>();
   const [test, setTest] = useState<TestResult>();
   const [busy, setBusy] = useState(false);
+  // For an existing source, what the data actually carries beats the connector's static
+  // `provides` list — merge the observed field profile into the labels editor's suggestions,
+  // keeping coverage so the dropdown can show how many sampled events carry each field.
+  const [observed, setObserved] = useState<{ sampled: number; fields: { name: string; coverage: number }[] }>();
+  useEffect(() => {
+    if (!initial?.name) return;
+    api.sourceFields(initial.name)
+      .then((p) => setObserved({ sampled: p.sampled,
+                                 fields: p.fields.map((f) => ({ name: f.name, coverage: f.coverage })) }))
+      .catch(() => {});
+  }, [initial?.name]);
+  const coverage = new Map((observed?.fields ?? []).map((f) => [f.name, f.coverage]));
+  const labelFieldOpts = Array.from(new Set([
+    ...(spec.provides ?? []).map((p) => p.name),
+    ...(observed?.fields ?? []).map((f) => f.name),
+  ])).sort((a, b) => (coverage.get(b) ?? -1) - (coverage.get(a) ?? -1) || a.localeCompare(b));
+  const labelFieldHints = observed
+    ? Object.fromEntries(labelFieldOpts
+        .filter((n) => coverage.has(n))
+        .map((n) => [n, `${coverage.get(n)} / ${observed.sampled} events`]))
+    : undefined;
   const [proposal, setProposal] = useState<DiscoverProposal>();
   const [colProposal, setColProposal] = useState<ColumnsProposal>();
   const [tables, setTables] = useState<string[]>();
@@ -338,7 +360,7 @@ export default function SourceForm({ connector, spec, initial, lockName, submitL
       {spec.discover && spec.fields.filter((f) => !f.discover_input).map(renderField)}
 
       <LabelsEditor rows={labelRows} onChange={setLabelRows}
-                    fields={(spec.provides ?? []).map((p) => p.name)} />
+                    fields={labelFieldOpts} fieldHints={labelFieldHints} />
 
       {labelsChanged && (
         <div className="alert info">
@@ -375,8 +397,9 @@ function labelsToRows(arr: unknown): LabelRow[] {
   return rows;
 }
 
-function LabelsEditor({ rows, onChange, fields = [] }:
-  { rows: LabelRow[]; onChange: (r: LabelRow[]) => void; fields?: string[] }) {
+function LabelsEditor({ rows, onChange, fields = [], fieldHints }:
+  { rows: LabelRow[]; onChange: (r: LabelRow[]) => void; fields?: string[];
+    fieldHints?: Record<string, string> }) {
   const set = (i: number, patch: Partial<LabelRow>) =>
     onChange(rows.map((r, j) => (j === i ? { ...r, ...patch } : r)));
   const makePrimary = (i: number) => onChange(rows.map((r, j) => ({ ...r, primary: j === i })));
@@ -414,10 +437,15 @@ function LabelsEditor({ rows, onChange, fields = [] }:
             <option value="const">const (fixed)</option>
             <option value="field">field (per event)</option>
           </select>
-          <input className={"label-col-grow" + (row.kind === "field" ? " mono" : "")}
-                 list={row.kind === "field" && fields.length ? "provided-fields" : undefined}
-                 placeholder={row.kind === "const" ? "value, e.g. api-server" : "field, e.g. service"}
-                 value={row.value} onChange={(e) => set(i, { value: e.target.value })} />
+          {row.kind === "field" && fields.length ? (
+            <Combo className="label-col-grow" value={row.value} options={fields}
+                   hints={fieldHints} placeholder="field, e.g. service"
+                   onChange={(v) => set(i, { value: v })} />
+          ) : (
+            <input className="label-col-grow"
+                   placeholder={row.kind === "const" ? "value, e.g. api-server" : "field, e.g. service"}
+                   value={row.value} onChange={(e) => set(i, { value: e.target.value })} />
+          )}
           <button type="button" className="danger label-col-x" onClick={() => remove(i)}>×</button>
         </div>
       ))}
@@ -427,7 +455,6 @@ function LabelsEditor({ rows, onChange, fields = [] }:
       </button>
       {fields.length > 0 && (
         <>
-          <datalist id="provided-fields">{fields.map((f) => <option key={f} value={f} />)}</datalist>
           <div className="help" style={{ marginTop: 6 }}>
             this connector provides: {fields.map((f, i) => <span key={f}><code>{f}</code>{i < fields.length - 1 ? ", " : ""}</span>)}
             {" "}— pick a <code>field</code> from these (the source's page shows each field's coverage once data flows).

--- a/ui/src/components/bits.tsx
+++ b/ui/src/components/bits.tsx
@@ -43,3 +43,47 @@ export function usePolling<T>(fn: () => Promise<T>, intervalMs = 5000): {
 
   return { data, error, reload: () => setTick((t) => t + 1) };
 }
+
+/** Input with styled suggestions — replaces native <datalist> (which can't be themed).
+ *  Free text stays allowed; suggestions filter as you type. */
+export function Combo({ value, onChange, options, placeholder, style, className, hints }: {
+  value: string; onChange: (v: string) => void; options: string[];
+  placeholder?: string; style?: React.CSSProperties; className?: string;
+  hints?: Record<string, string>;   // per-option annotation, right-aligned dim (e.g. coverage)
+}) {
+  const [open, setOpen] = useState(false);
+  const [hi, setHi] = useState(0);
+  const needle = value.trim().toLowerCase();
+  const shown = options.filter((o) => !needle || o.toLowerCase().includes(needle));
+
+  const pick = (o: string) => { onChange(o); setOpen(false); };
+
+  return (
+    <div className={"combo" + (className ? ` ${className}` : "")} style={style}>
+      <input type="text" value={value} placeholder={placeholder}
+             onChange={(e) => { onChange(e.target.value); setOpen(true); setHi(0); }}
+             onFocus={() => setOpen(true)}
+             onBlur={() => setOpen(false)}
+             onKeyDown={(e) => {
+               if (!open || !shown.length) return;
+               if (e.key === "ArrowDown") { e.preventDefault(); setHi((h) => Math.min(h + 1, shown.length - 1)); }
+               else if (e.key === "ArrowUp") { e.preventDefault(); setHi((h) => Math.max(h - 1, 0)); }
+               else if (e.key === "Enter") { e.preventDefault(); pick(shown[hi]); }
+               else if (e.key === "Escape") setOpen(false);
+             }} />
+      {open && shown.length > 0 && (
+        <div className="combo-list">
+          {shown.map((o, i) => (
+            <div key={o} className={"combo-item" + (i === hi ? " active" : "")}
+                 style={hints ? { display: "flex", justifyContent: "space-between", gap: 12 } : undefined}
+                 onMouseDown={(e) => { e.preventDefault(); pick(o); }}
+                 onMouseEnter={() => setHi(i)}>
+              <span>{o}</span>
+              {hints?.[o] && <span className="dim">{hints[o]}</span>}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/src/pages/SourceDetail.tsx
+++ b/ui/src/pages/SourceDetail.tsx
@@ -12,7 +12,7 @@ export default function SourceDetail() {
   const { name = "" } = useParams();
   const nav = useNavigate();
   const [specs, setSpecs] = useState<Record<string, ConnectorSpec>>();
-  const [editing, setEditing] = useState(false);
+  const [tab, setTab] = useState<"fields" | "events" | "config">("fields");
   const [actionError, setActionError] = useState<string>();
   const [confirmDel, setConfirmDel] = useState(false);
   const [purge, setPurge] = useState(false);
@@ -46,7 +46,6 @@ export default function SourceDetail() {
           {source.paused
             ? <button onClick={act(() => api.resumeSource(name))}>Resume</button>
             : <button onClick={act(() => api.pauseSource(name))}>Pause</button>}
-          <button onClick={() => setEditing(!editing)}>{editing ? "Close editor" : "Edit config"}</button>
           <button className="danger" onClick={() => { setPurge(false); setConfirmDel(true); }}>Delete</button>
         </div>
       </div>
@@ -68,11 +67,18 @@ export default function SourceDetail() {
         </div>
       )}
 
-      <FieldsPanel name={name} />
+      <LabelsSummary source={source} onEdit={() => setTab("config")} />
 
-      {editing && spec && (
+      <div className="tabs" style={{ marginTop: 16 }}>
+        <button className={tab === "fields" ? "active" : ""} onClick={() => setTab("fields")}>Fields</button>
+        <button className={tab === "events" ? "active" : ""} onClick={() => setTab("events")}>Recent events</button>
+        <button className={tab === "config" ? "active" : ""} onClick={() => setTab("config")}>Configuration</button>
+      </div>
+
+      {tab === "fields" && <FieldsPanel name={name} />}
+
+      {tab === "config" && spec && (
         <div className="panel">
-          <h2 style={{ marginTop: 0 }}>Edit config</h2>
           <SourceForm
             connector={source.connector}
             spec={spec}
@@ -81,29 +87,32 @@ export default function SourceDetail() {
             submitLabel="Save changes"
             onSubmit={async (body) => {
               await api.updateSource(name, body);
-              setEditing(false);
+              setTab("fields");
               reload();
             }}
           />
         </div>
       )}
 
-      <h2>Recent events</h2>
-      {!events?.length && <div className="empty">nothing ingested from this source yet</div>}
-      {!!events?.length && (
-        <table>
-          <thead><tr><th>ingested</th><th>key</th><th>type</th><th>text</th></tr></thead>
-          <tbody>
-            {events.map((e, i) => (
-              <tr key={i}>
-                <td style={{ whiteSpace: "nowrap" }}><TimeAgo ts={e.ingest_time} /></td>
-                <td className="mono">{e.key}</td>
-                <td className="mono">{e.event_type}</td>
-                <td className="mono" style={{ whiteSpace: "pre-wrap" }}>{e.text}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+      {tab === "events" && (
+        <>
+          {!events?.length && <div className="empty">nothing ingested from this source yet</div>}
+          {!!events?.length && (
+            <table>
+              <thead><tr><th>ingested</th><th>key</th><th>type</th><th>text</th></tr></thead>
+              <tbody>
+                {events.map((e, i) => (
+                  <tr key={i}>
+                    <td style={{ whiteSpace: "nowrap" }}><TimeAgo ts={e.ingest_time} /></td>
+                    <td className="mono">{e.key}</td>
+                    <td className="mono">{e.event_type}</td>
+                    <td className="mono" style={{ whiteSpace: "pre-wrap" }}>{e.text}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </>
       )}
 
       {confirmDel && (
@@ -136,18 +145,70 @@ export default function SourceDetail() {
 // label set) are flattened to sub-fields (metric.service, …) so the real keyable axes are visible;
 // the backend marks which are declared labels/keys. Coverage is only shown when it varies (a full
 // 100%-everywhere column is noise), so partial fields stand out.
+// The declared entity axes — the single most important config of a source, so it lives on the
+// main screen (not buried in the edit form): every event carries these labels, the key names
+// the timeline agents read.
+function LabelsSummary({ source, onEdit }: { source: Source; onEdit: () => void }) {
+  const labels = (source.config?.labels ?? []) as Array<{
+    name: string; field?: string; const?: string; primary?: boolean }>;
+  return (
+    <div className="panel" style={{ marginTop: 14 }}>
+      <div className="pagehead" style={{ marginBottom: labels.length ? 8 : 0 }}>
+        <h2 style={{ margin: 0 }}>Labels &amp; key</h2>
+        <button onClick={onEdit}>Edit</button>
+      </div>
+      {labels.length ? (
+        <table>
+          <thead><tr><th>label</th><th>from</th></tr></thead>
+          <tbody>
+            {labels.map((l) => (
+              <tr key={l.name}>
+                <td className="mono">
+                  {l.name}
+                  {l.primary && <span className="badge ok" style={{ marginLeft: 8 }}>key</span>}
+                </td>
+                <td className="mono">
+                  {"field" in l && l.field
+                    ? <><span className="badge push" style={{ marginRight: 8 }}>field</span>{l.field}</>
+                    : <><span className="badge push" style={{ marginRight: 8 }}>const</span>{String(l.const ?? "")}</>}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      ) : (
+        <p className="help" style={{ margin: 0, whiteSpace: "normal" }}>
+          No labels declared — events fall back to the connector&rsquo;s default key, and agents
+          can&rsquo;t slice this source by any axis. Check <strong>Fields</strong> below for the
+          candidates observed in your data, then declare them here.
+        </p>
+      )}
+    </div>
+  );
+}
+
+const FIELDS_PAGE = 12;
+
 function FieldsPanel({ name }: { name: string }) {
   const { data } = usePolling(() => api.sourceFields(name), 5000);
+  const [showAll, setShowAll] = useState(false);
   if (!data || !data.fields.length) return null;
   const allFull = data.fields.every((f) => f.coverage === data.sampled);
   const fmt = (v: string) => (v.length > 44 ? v.slice(0, 43) + "…" : v);
+  // keys and labels lead, then by how many events actually carry the field — the most
+  // promotable candidates come first, long tails of sparse fields fold behind "show all"
+  const sorted = [...data.fields].sort((a, b) =>
+    (a.is_key ? 0 : a.is_label ? 1 : 2) - (b.is_key ? 0 : b.is_label ? 1 : 2)
+    || b.coverage - a.coverage || a.name.localeCompare(b.name));
+  const shown = showAll ? sorted : sorted.slice(0, FIELDS_PAGE);
   return (
     <div className="panel">
       <h2 style={{ marginTop: 0 }}>Fields <small className="dim">· {data.sampled} events sampled</small></h2>
       <p className="subtitle">
-        What this source carries. <span className="badge ok">key</span> and{" "}
-        <span className="badge starting">label</span> mark the axes you read and alert by; the rest
-        are available to promote to a label.
+        The axes this connector can label events by, profiled from recent events (the full raw
+        payload is always stored regardless). <span className="badge ok">key</span> and{" "}
+        <span className="badge starting">label</span> mark what you read and alert by today; the
+        rest can be promoted to a label in <strong>Configuration</strong>.
       </p>
       <table>
         <thead><tr>
@@ -157,12 +218,19 @@ function FieldsPanel({ name }: { name: string }) {
           <th>top values</th>
         </tr></thead>
         <tbody>
-          {data.fields.map((f) => (
-            <tr key={f.name}>
+          {shown.map((f) => (
+            <tr key={f.name} style={f.coverage === 0 ? { opacity: 0.55 } : undefined}>
               <td className="mono">
                 {f.name}
                 {f.is_key ? <span className="badge ok" style={{ marginLeft: 6 }}>key</span>
                   : f.is_label ? <span className="badge starting" style={{ marginLeft: 6 }}>label</span> : null}
+                {f.coverage === 0 && (
+                  <div className="help" style={{ fontFamily: "inherit" }}>
+                    not observed in the sample{(f.is_key || f.is_label)
+                      ? " — declared as a label but no event carries it; check the field mapping"
+                      : ""}
+                  </div>
+                )}
               </td>
               {!allFull && (
                 <td>
@@ -186,6 +254,11 @@ function FieldsPanel({ name }: { name: string }) {
           ))}
         </tbody>
       </table>
+      {sorted.length > FIELDS_PAGE && (
+        <button style={{ marginTop: 10 }} onClick={() => setShowAll((s) => !s)}>
+          {showAll ? "show fewer" : `show all ${sorted.length} fields`}
+        </button>
+      )}
       {allFull && <p className="help" style={{ marginTop: 8 }}>Every field is present in all {data.sampled} sampled events.</p>}
     </div>
   );

--- a/ui/src/pages/ViewsTriggers.tsx
+++ b/ui/src/pages/ViewsTriggers.tsx
@@ -4,7 +4,7 @@ import { Link } from "react-router-dom";
 import { api } from "../api";
 import ConfirmDialog from "../components/ConfirmDialog";
 import { Search } from "../components/icons";
-import { TimeAgo, usePolling } from "../components/bits";
+import { Combo, TimeAgo, usePolling } from "../components/bits";
 import type { Trigger, View, ViewFilter } from "../types";
 
 const AGGREGATES = ["max", "min", "sum", "avg", "count", "any"];
@@ -50,47 +50,6 @@ function FilterBar({ q, setQ, placeholder, shown, total }: {
       </div>
       <span className="grow" />
       <span className="count">{shown} of {total}</span>
-    </div>
-  );
-}
-
-/** Input with styled suggestions — replaces native <datalist> (which can't be themed).
- *  Free text stays allowed; suggestions filter as you type. */
-function Combo({ value, onChange, options, placeholder, style }: {
-  value: string; onChange: (v: string) => void; options: string[];
-  placeholder?: string; style?: React.CSSProperties;
-}) {
-  const [open, setOpen] = useState(false);
-  const [hi, setHi] = useState(0);
-  const needle = value.trim().toLowerCase();
-  const shown = options.filter((o) => !needle || o.toLowerCase().includes(needle));
-
-  const pick = (o: string) => { onChange(o); setOpen(false); };
-
-  return (
-    <div className="combo" style={style}>
-      <input type="text" value={value} placeholder={placeholder}
-             onChange={(e) => { onChange(e.target.value); setOpen(true); setHi(0); }}
-             onFocus={() => setOpen(true)}
-             onBlur={() => setOpen(false)}
-             onKeyDown={(e) => {
-               if (!open || !shown.length) return;
-               if (e.key === "ArrowDown") { e.preventDefault(); setHi((h) => Math.min(h + 1, shown.length - 1)); }
-               else if (e.key === "ArrowUp") { e.preventDefault(); setHi((h) => Math.max(h - 1, 0)); }
-               else if (e.key === "Enter") { e.preventDefault(); pick(shown[hi]); }
-               else if (e.key === "Escape") setOpen(false);
-             }} />
-      {open && shown.length > 0 && (
-        <div className="combo-list">
-          {shown.map((o, i) => (
-            <div key={o} className={"combo-item" + (i === hi ? " active" : "")}
-                 onMouseDown={(e) => { e.preventDefault(); pick(o); }}
-                 onMouseEnter={() => setHi(i)}>
-              {o}
-            </div>
-          ))}
-        </div>
-      )}
     </div>
   );
 }

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -377,6 +377,7 @@ pre.payload {
 
 /* combobox — a styled replacement for native <datalist> suggestions */
 .combo { position: relative; }
+.combo input { width: 100%; font-family: var(--mono); }
 .combo-list {
   position: absolute; top: calc(100% + 4px); left: 0; right: 0; z-index: 30;
   background: var(--input-bg); border: 1px solid var(--line); border-radius: 8px;


### PR DESCRIPTION
From testing how users organize data after it flows:

- **Labels & key summary on the source's main screen** — the declared mapping (label name ← field/const, key badge) was buried in the edit form; it's now a clean table next to the stats, with an Edit shortcut. Label-less sources get an explanatory empty state instead of silence.
- **Source page tabs**: Fields / Recent events / Configuration (edit config is a tab, not an in-place expansion). Fields sort keys → labels → coverage desc, paginate at 12 with show-all, and 0-coverage rows are dimmed and annotated ("declared as a label but no event carries it — check the field mapping").
- **claude_code implements label_context** (the base-class contract it was missing): the field profile now shows the six real axes with true coverage instead of raw transcript keys and 0-coverage phantoms; ingest and profiling share one mapping (parity verified).
- **Labels editor dropdown**: styled combobox everywhere (native datalist gone), suggestions merge the connector's advertised fields with the observed profile, sorted by coverage and annotated inline with "N / sampled events".
- **extract_labels supports dotted paths** (metric.service) so nested profiled fields are actually bindable.