### PR TITLE
Organize agent + label value normalization

### DIFF
--- a/navflow/agent.py
+++ b/navflow/agent.py
@@ -75,6 +75,69 @@ TOOLS = [
 ]
 
 
+# Organize mode: the agent PROPOSES catalog changes as structured cards the user applies or skips
+# in the console — these tools mutate nothing server-side (the console fires the normal validated
+# management APIs on Apply). See docs/design/organize-agent.md.
+PROPOSAL_TOOLS = [
+    {"name": "propose_labels",
+     "description": "Propose the labels (and primary key) for ONE source, as a card the user will "
+                    "review. Propose only fields the source's field profile actually shows "
+                    "(source_fields) — anything else cannot be extracted. Give concrete evidence "
+                    "in `reasoning` (coverage, distinct counts, why the key is an entity). This "
+                    "REPLACES the source's label set, so include every label it should end up with.",
+     "input_schema": {"type": "object", "properties": {
+         "source": {"type": "string"},
+         "labels": {"type": "array", "items": {"type": "object", "properties": {
+             "name": {"type": "string"},
+             "field": {"type": "string", "description": "read per-event from this profiled field"},
+             "const": {"type": "string", "description": "or: a fixed value on every event"},
+             "primary": {"type": "boolean", "description": "exactly one label should be primary (the key)"},
+             "pattern": {"type": "string", "description": "optional value normalization: regex "
+                         "substitution applied to the field's value (e.g. '-(service|svc)$')"},
+             "replace": {"type": "string", "description": "replacement for pattern (empty = strip)"},
+             "map": {"type": "object", "description": "optional exact aliases applied AFTER the "
+                     "pattern: {observed: canonical}, e.g. {\"ck\": \"checkout\"}"}},
+             "required": ["name"]}},
+         "reasoning": {"type": "string"}},
+         "required": ["source", "labels", "reasoning"]}},
+    {"name": "propose_view",
+     "description": "Propose a view correlating one or more sources into a single per-entity "
+                    "timeline, as a card the user will review. key_field must be a label the "
+                    "chosen sources share (after any proposed labels are applied). Explain in "
+                    "`reasoning` what one read of this view returns and why it's useful.",
+     "input_schema": {"type": "object", "properties": {
+         "name": {"type": "string"},
+         "key_field": {"type": "string"},
+         "sources": {"type": "array", "items": {"type": "string"}},
+         "filters": {"type": "array", "items": {"type": "object"}},
+         "reasoning": {"type": "string"}},
+         "required": ["name", "key_field", "sources", "reasoning"]}},
+]
+_PROPOSAL_NAMES = {t["name"] for t in PROPOSAL_TOOLS}
+
+
+def _canon_labels(specs) -> list:
+    """Label specs in comparable form: (name, field, const, primary), order-independent."""
+    out = []
+    for s in specs or []:
+        out.append((str(s.get("name") or ""), s.get("field"),
+                    None if s.get("field") else (None if s.get("const") is None else str(s["const"])),
+                    bool(s.get("primary"))))
+    return sorted(out)
+
+
+async def _current_labels(source: str, headers: dict):
+    """The source's declared labels right now, or None if the source can't be read."""
+    try:
+        async with httpx.AsyncClient(timeout=10, headers=headers, base_url=_SELF) as cx:
+            r = await cx.get(f"/api/sources/{source}")
+        if r.status_code != 200:
+            return None
+        return (r.json().get("config") or {}).get("labels") or []
+    except Exception:
+        return None
+
+
 async def _execute_tool(name: str, args: dict, headers: dict) -> str:
     """Run a tool by calling the daemon's own read endpoint. Returns the response text (JSON)."""
     args = args or {}
@@ -131,8 +194,45 @@ You can also CREATE a view (create_view) to correlate sources into one timeline 
 the user wants that — pick a key_field that exists across the sources, and confirm before creating."""
 
 
+_ORGANIZE_SYSTEM = _SYSTEM_BASE + """
+
+You are running in ORGANIZE mode: help the user structure their ingested data with the right
+labels, keys, and views. Work in one pass:
+
+1. Inventory: list_sources, then source_fields (and recent_events where the shape is unclear)
+   for every source that has data.
+2. Judge entity-ness from evidence: a good KEY identifies a durable entity (a service, a session,
+   a tenant) — moderate distinct count, high coverage, stable values. Dimensions (http_method,
+   level, status) make good secondary labels but bad keys. Sparse or constant fields are weak.
+3. FIRST check each source's existing labels (list_sources shows config.labels). If a source's
+   current labels already match what you would propose, do NOT call propose_labels — state in
+   text that its labels look right and why. Propose only for sources whose labels are missing or
+   should change, calling propose_labels ONCE with the complete label set it should have (the
+   proposal replaces, not appends). Only fields the profile shows are extractable — never invent
+   field names. Same discipline for views: if an existing view already covers it, say so instead
+   of proposing a duplicate.
+3b. Watch the top values for VARIANTS of one entity (checkout / checkout-svc / checkout-service):
+   correlation needs values to agree literally, so propose value normalization on the label —
+   `pattern`/`replace` for whole families, `map` for irregular aliases (pattern runs first, map
+   applies to its result). This is often the highest-value fix you can propose.
+4. Then propose views: prefer a natural shared label across sources; when sources share nothing
+   but belong together, propose const labels (same name+value) on each source first, then the
+   view keyed by that label. Call propose_view for each view (1–3 views, not a zoo).
+5. Finish with a short summary of what you proposed and why. Do NOT use create_view in this
+   mode — everything goes through proposals; the user applies or skips each card.
+
+Proposals stream to the user as cards they apply or skip on the spot. Labels apply to new events
+going forward — mention this only if the user asks. Be decisive; don't ask permission to inspect."""
+
+
 def system_prompt(mode: str | None = None) -> str:
-    return _SYSTEM_BASE   # one adaptive agent; `mode` is accepted but no longer changes the prompt
+    return _ORGANIZE_SYSTEM if mode == "organize" else _SYSTEM_BASE
+
+
+def tools_for(mode: str | None = None) -> list:
+    if mode == "organize":   # proposal-only: reads + proposal cards, no direct mutation
+        return [t for t in TOOLS if t["name"] != "create_view"] + PROPOSAL_TOOLS
+    return TOOLS
 
 
 def _sse(obj: dict) -> str:
@@ -156,7 +256,7 @@ async def run_agent(api_key: str, messages: list, mode: str = "explore",
         for _ in range(MAX_ROUNDS):
             async with client.messages.stream(
                 model=model or DEFAULT_MODEL, max_tokens=2048,
-                system=system_prompt(mode), tools=TOOLS, messages=convo,
+                system=system_prompt(mode), tools=tools_for(mode), messages=convo,
             ) as stream:
                 async for event in stream:
                     if event.type == "content_block_delta" and event.delta.type == "text_delta":
@@ -169,6 +269,25 @@ async def run_agent(api_key: str, messages: list, mode: str = "explore",
                 break
             results = []
             for tu in tool_uses:
+                if tu.name in _PROPOSAL_NAMES:
+                    # no-op proposals are suppressed deterministically: re-proposing a source's
+                    # exact current label set produces no card (re-runs must converge, not nag)
+                    if tu.name == "propose_labels":
+                        cur = await _current_labels(str(tu.input.get("source", "")), headers)
+                        if cur is not None and _canon_labels(cur) == _canon_labels(tu.input.get("labels")):
+                            results.append({"type": "tool_result", "tool_use_id": tu.id,
+                                            "content": "this source ALREADY has exactly this label "
+                                                       "set — no card was shown. Tell the user its "
+                                                       "labels already look right; propose only "
+                                                       "changes."})
+                            continue
+                    # a proposal is a card for the user, not a server-side action
+                    kind = "labels" if tu.name == "propose_labels" else "view"
+                    yield _sse({"type": "proposal", "kind": kind, "id": tu.id, "payload": tu.input})
+                    results.append({"type": "tool_result", "tool_use_id": tu.id,
+                                    "content": "proposal recorded — the user will review it as a "
+                                               "card and apply or skip it"})
+                    continue
                 yield _sse({"type": "tool", "name": tu.name, "input": tu.input})
                 out = await _execute_tool(tu.name, tu.input, headers)
                 results.append({"type": "tool_result", "tool_use_id": tu.id, "content": out})

--- a/navflow/config.py
+++ b/navflow/config.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass, field as dc_field
+from functools import lru_cache
 from pathlib import Path
 
 import yaml
@@ -203,6 +204,27 @@ def _check_duration(value, label: str) -> None:
         raise CatalogError(f"{label}: {value!r} is not a duration (use e.g. '5s', '15m', '1h')")
 
 
+@lru_cache(maxsize=256)
+def _compiled(pattern: str):
+    return re.compile(pattern)
+
+
+def _normalize_value(spec: dict, raw: str) -> str:
+    """Value normalization for one field label: regex substitution first, exact-alias map second
+    (map keys are written against the cleaned form). Fail-open: any error keeps the raw value —
+    the lossless payload always preserves the original, so normalization is never destructive."""
+    v = raw
+    try:
+        if spec.get("pattern"):
+            v = _compiled(spec["pattern"]).sub(spec.get("replace", ""), v)
+        m = spec.get("map")
+        if m:
+            v = m.get(v, v)
+    except Exception:
+        return raw
+    return v
+
+
 def extract_labels(specs, context: dict | None = None) -> dict:
     """Build an event's label map from a source's `labels` config and a per-event context dict.
 
@@ -228,7 +250,7 @@ def extract_labels(specs, context: dict | None = None) -> dict:
                 if isinstance(sub, dict):
                     v = sub.get(tail)
             if v is not None:
-                out[name] = str(v)
+                out[name] = _normalize_value(spec, str(v))
     return out
 
 

--- a/navflow/connectors/__init__.py
+++ b/navflow/connectors/__init__.py
@@ -102,6 +102,9 @@ def full_schema(connector: str) -> dict | None:
 _LABEL_NAME = _re.compile(r"^[A-Za-z0-9_]+$")
 
 
+_MAX_PATTERN_LEN = 256
+
+
 def _coerce_labels(val) -> list:
     out, primaries = [], 0
     for spec in val:
@@ -113,6 +116,29 @@ def _coerce_labels(val) -> list:
             raise CatalogError(f"label {spec['name']!r} needs exactly one of const or field")
         row = {"name": str(spec["name"]),
                **({"const": str(spec["const"])} if "const" in spec else {"field": str(spec["field"])})}
+        # value normalization (field labels only): one regex substitution, then one exact-alias
+        # map — validated here so a bad pattern is a save-time 400, never a per-event failure
+        # (docs/design/label-value-normalization.md)
+        if any(k in spec for k in ("pattern", "replace", "map")):
+            if "const" in spec:
+                raise CatalogError(f"label {row['name']!r}: normalization applies to field labels only")
+            if spec.get("pattern"):
+                pat = str(spec["pattern"])
+                if len(pat) > _MAX_PATTERN_LEN:
+                    raise CatalogError(f"label {row['name']!r}: pattern too long (max {_MAX_PATTERN_LEN})")
+                try:
+                    _re.compile(pat)
+                except _re.error as e:
+                    raise CatalogError(f"label {row['name']!r}: invalid pattern: {e}")
+                row["pattern"] = pat
+                row["replace"] = str(spec.get("replace") or "")
+            elif "replace" in spec and spec.get("replace"):
+                raise CatalogError(f"label {row['name']!r}: replace needs a pattern")
+            if spec.get("map"):
+                if not isinstance(spec["map"], dict):
+                    raise CatalogError(f"label {row['name']!r}: map must be an object of "
+                                       "observed-value -> canonical-value strings")
+                row["map"] = {str(k): str(v) for k, v in spec["map"].items()}
         if spec.get("primary"):       # the primary label is the entity key
             row["primary"] = True
             primaries += 1
@@ -158,6 +184,12 @@ def _normalize_against(schema: dict, raw, where: str) -> dict:
     if unknown:
         raise CatalogError(f"{where}: unknown keys {sorted(unknown)}")
     return out
+
+
+def normalize_label_specs(specs: list) -> list:
+    """Validate/canonicalize label specs alone (same rules as a config save) — for callers that
+    work with a label spec outside a full source config, e.g. the normalization preview."""
+    return _coerce_labels(specs or [])
 
 
 def normalize_config(connector: str, raw: dict) -> dict:

--- a/navflow/daemon.py
+++ b/navflow/daemon.py
@@ -48,6 +48,10 @@ INGEST_TOKEN = os.getenv("NAVFLOW_INGEST_TOKEN", "").strip()
 # If set, the whole API + console require this token (self-hosted single-tenant). The SPA shell and
 # static assets stay public so the login screen can load; ingest uses its own token (above).
 AUTH_TOKEN = os.getenv("NAVFLOW_AUTH_TOKEN", "").strip()
+# Server-provisioned Anthropic key for the in-app agent (Ask/Organize). Set at deploy time on
+# hosted cells so users never paste a key; absent locally, the console prompts (BYO, unchanged).
+# Never returned by any API — capabilities exposes only a boolean.
+ANTHROPIC_KEY = os.getenv("NAVFLOW_ANTHROPIC_KEY", "").strip()
 # Vercel verifies a log-drain endpoint by checking an x-vercel-verify response header. Set this to
 # the value Vercel shows when adding the drain (or rely on echoing the request's header).
 VERCEL_VERIFY = os.getenv("NAVFLOW_VERCEL_VERIFY", "").strip()
@@ -652,7 +656,51 @@ def make_app() -> FastAPI:
         import shutil
         return {
             "discover_docker": shutil.which("docker") is not None or os.path.exists("/var/run/docker.sock"),
+            "agent_key_configured": bool(ANTHROPIC_KEY),
         }
+
+    @app.post("/api/labels/preview")
+    async def label_preview(body: dict = Body(...)):
+        """Pure preview of a label spec's value normalization against a source's OBSERVED values:
+        before -> after with event counts, so the user sees the merge they're about to create
+        before saving (docs/design/label-value-normalization.md). No state is touched."""
+        from collections import Counter
+
+        from .config import extract_labels
+        from .connectors import build_connector, normalize_label_specs
+
+        source = body.get("source")
+        spec = body.get("label") or {}
+        cfg = runtime.catalog.sources.get(str(source))
+        if cfg is None:
+            _err(KeyError(f"unknown source {source!r}"), 404)
+        try:   # validate the label spec exactly like a save would (bad regex -> 400 here)
+            normalized = normalize_label_specs([spec])
+        except CatalogError as e:
+            _err(e)
+        if not normalized or "field" not in normalized[0]:
+            _err(ValueError("preview needs a field label spec"))
+        lspec = normalized[0]
+
+        conn = build_connector(cfg, store)
+        pairs: Counter = Counter()   # (before, after) -> events
+        sampled = 0
+        for payload in store.recent_payloads(cfg.name, 2000):
+            ctx = conn.label_context(payload)
+            if not isinstance(ctx, dict):
+                continue
+            sampled += 1
+            plain = extract_labels([{k: v for k, v in lspec.items() if k not in ("pattern", "replace", "map")}], ctx)
+            if lspec["name"] not in plain:
+                continue
+            before = plain[lspec["name"]]
+            after = extract_labels([lspec], ctx)[lspec["name"]]
+            pairs[(before, after)] += 1
+        results = [{"from": b, "to": a, "events": n}
+                   for (b, a), n in sorted(pairs.items(), key=lambda kv: -kv[1])]
+        return {"sampled": sampled, "results": results,
+                "distinct_before": len({b for b, _ in pairs}),
+                "distinct_after": len({a for _, a in pairs})}
 
     @app.post("/api/sources/discover")
     async def discover_source(body: dict = Body(...)):
@@ -842,7 +890,8 @@ def make_app() -> FastAPI:
     @app.post("/api/agent/chat")
     async def agent_chat(request: Request):
         from .agent import run_agent
-        key = request.headers.get("x-anthropic-key", "").strip()
+        # per-request header key wins (a user override); the server-provisioned key is the fallback
+        key = request.headers.get("x-anthropic-key", "").strip() or ANTHROPIC_KEY
         if not key:
             _err(ValueError("add your Anthropic API key to use the assistant"), 400)
         body = await request.json()

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -4,7 +4,7 @@ import { Link, NavLink, Outlet, useLocation } from "react-router-dom";
 import { auth } from "./api";
 import CommandPalette from "./components/CommandPalette";
 import {
-  Activity, Bolt, Book, Chat, ChevronRight, Database, Filter, Lock, Moon,
+  Activity, Bolt, Book, Chat, ChevronRight, Database, Filter, Lock, Moon, Tag,
   Settings as SettingsIco, SignOut, Sun, Terminal,
 } from "./components/icons";
 import { applyTheme, currentTheme, type Theme } from "./theme";
@@ -24,6 +24,7 @@ type NavItem = {
 const NAV_GROUPS: { section: string; items: NavItem[] }[] = [
   { section: "Data in", items: [
     { to: "/", end: true, label: "Sources", icon: Database },
+    { to: "/organize", label: "Organize", icon: Tag },
   ] },
   { section: "The timeline", items: [
     { to: "/explore", label: "Explore", icon: Activity },
@@ -37,6 +38,7 @@ const NAV_GROUPS: { section: string; items: NavItem[] }[] = [
 ];
 
 const SECTION_LABEL: Record<string, string> = {
+  organize: "Organize",
   explore: "Explore",
   views: "Views",
   triggers: "Triggers",

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -58,7 +58,8 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
 export const api = {
   health: () => request<{ status: string; readonly: boolean; auth_required: boolean }>("/health"),
   connectors: () => request<Record<string, ConnectorSpec>>("/api/connectors"),
-  capabilities: () => request<{ discover_docker: boolean }>("/api/capabilities"),
+  capabilities: () =>
+    request<{ discover_docker: boolean; agent_key_configured?: boolean }>("/api/capabilities"),
   security: () =>
     request<{ ingest_token: string | null; ingest_required: boolean }>("/api/security"),
   keys: () => request<{ keys: ApiKey[]; enforced: boolean; scopes: string[] }>("/api/keys"),
@@ -90,6 +91,10 @@ export const api = {
     request<SourceEvent[]>(`/api/sources/${name}/events?limit=${limit}`),
   sourceFields: (name: string) =>
     request<SourceFieldsProfile>(`/api/sources/${name}/fields`),
+  labelPreview: (source: string, label: Record<string, unknown>) =>
+    request<{ sampled: number; distinct_before: number; distinct_after: number;
+              results: { from: string; to: string; events: number }[] }>(
+      "/api/labels/preview", { method: "POST", body: JSON.stringify({ source, label }) }),
 
   views: () => request<View[]>("/api/views"),
   createView: (body: View) =>

--- a/ui/src/components/AskChat.tsx
+++ b/ui/src/components/AskChat.tsx
@@ -1,8 +1,8 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
-import { anthropicKey, authHeader } from "../api";
+import { api, anthropicKey, authHeader } from "../api";
 
 // The Ask assistant, extracted so it can back both the dedicated /ask page and the global ⌘K
 // command palette. Same engine, two doors: the page for long sessions, the overlay to ask from
@@ -41,13 +41,21 @@ function compact(v: unknown): string {
 export default function AskChat() {
   const [key, setKeyState] = useState(anthropicKey.get());
   const [keyInput, setKeyInput] = useState("");
+  // A hosted cell can carry a server-provisioned key — then the console never prompts.
+  const [serverKey, setServerKey] = useState<boolean>();
   const [msgs, setMsgs] = useState<Msg[]>([]);
   const [input, setInput] = useState("");
   const [busy, setBusy] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    api.capabilities().then((c) => setServerKey(!!c.agent_key_configured)).catch(() => setServerKey(false));
+  }, []);
 
-  if (!key) return <KeySetup onSave={(k) => { anthropicKey.set(k); setKeyState(k); }}
-                            value={keyInput} onChange={setKeyInput} />;
+  if (serverKey === undefined) return <div className="dim">loading…</div>;
+  if (!key && !serverKey) {
+    return <KeySetup onSave={(k) => { anthropicKey.set(k); setKeyState(k); }}
+                     value={keyInput} onChange={setKeyInput} />;
+  }
 
   const mutLast = (fn: (parts: Part[]) => Part[]) =>
     setMsgs((cur) => cur.map((m, i) => (i === cur.length - 1 ? { ...m, parts: fn(m.parts) } : m)));
@@ -68,7 +76,8 @@ export default function AskChat() {
     try {
       const res = await fetch("/api/agent/chat", {
         method: "POST",
-        headers: { "content-type": "application/json", "X-Anthropic-Key": key, ...authHeader() },
+        headers: { "content-type": "application/json",
+                   ...(key ? { "X-Anthropic-Key": key } : {}), ...authHeader() },
         body: JSON.stringify({ messages: history.map((m) => ({ role: m.role, content: textOf(m) })) }),
       });
       if (!res.ok || !res.body) {
@@ -104,7 +113,9 @@ export default function AskChat() {
   return (
     <div className="askchat">
       <div className="chat-tools">
-        <button className="dim" onClick={() => { anthropicKey.clear(); setKeyState(""); }}>change key</button>
+        {key
+          ? <button className="dim" onClick={() => { anthropicKey.clear(); setKeyState(""); }}>change key</button>
+          : <span className="dim">using this instance&rsquo;s key</span>}
       </div>
 
       <div className="chat" ref={scrollRef}>

--- a/ui/src/components/OrganizePanel.tsx
+++ b/ui/src/components/OrganizePanel.tsx
@@ -1,0 +1,332 @@
+import { useEffect, useRef, useState } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+import { api, anthropicKey, authHeader } from "../api";
+
+// The Organize agent (docs/design/organize-agent.md): one button on the Sources page starts an
+// agent run that inspects the data and streams PROPOSAL cards — labels for a source, a view across
+// sources. The agent mutates nothing; each card is applied (via the normal management APIs) or
+// skipped by the user, right here. Conversation continues for refinements.
+
+type LabelSpec = { name: string; field?: string; const?: string; primary?: boolean;
+                   pattern?: string; replace?: string; map?: Record<string, string> };
+type Proposal =
+  | { id: string; kind: "labels"; source: string; labels: LabelSpec[]; reasoning: string }
+  | { id: string; kind: "view"; name: string; key_field: string; sources: string[];
+      filters?: Array<Record<string, unknown>>; reasoning: string };
+type Part =
+  | { type: "text"; text: string }
+  | { type: "tool"; name: string }
+  | { type: "proposal"; proposal: Proposal };
+type Msg = { role: "user" | "assistant"; parts: Part[] };
+type Decision = "applied" | "skipped" | "error";
+
+const KICKOFF =
+  "Organize my data: review my sources and propose the labels/keys each should have and the " +
+  "views that would serve agents best.";
+
+export default function OrganizePanel({ onCatalogChanged }: { onCatalogChanged?: () => void }) {
+  const [serverKey, setServerKey] = useState<boolean>();
+  const [key, setKey] = useState(anthropicKey.get());
+  const [keyInput, setKeyInput] = useState("");
+  const [msgs, setMsgs] = useState<Msg[]>([]);
+  const [decisions, setDecisions] = useState<Record<string, { status: Decision; detail?: string }>>({});
+  const [busy, setBusy] = useState(false);
+  const [input, setInput] = useState("");
+  const startedRef = useRef(false);
+  const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    api.capabilities().then((c) => setServerKey(!!c.agent_key_configured)).catch(() => setServerKey(false));
+  }, []);
+
+  // auto-start the sweep once a usable key exists
+  useEffect(() => {
+    if (serverKey === undefined || startedRef.current) return;
+    if (serverKey || key) { startedRef.current = true; void send(KICKOFF); }
+  }, [serverKey, key]);
+
+  const mutLast = (fn: (parts: Part[]) => Part[]) =>
+    setMsgs((cur) => cur.map((m, i) => (i === cur.length - 1 ? { ...m, parts: fn(m.parts) } : m)));
+
+  // History for the model: text plus a compact textual record of proposals and what the user did
+  // with them, so follow-up turns know the state.
+  const historyText = (m: Msg) => m.parts.map((p) => {
+    if (p.type === "text") return p.text;
+    if (p.type === "proposal") {
+      const st = decisions[p.proposal.id]?.status ?? "pending";
+      const what = p.proposal.kind === "labels"
+        ? `labels for source ${p.proposal.source}` : `view ${p.proposal.name}`;
+      return `\n[proposal: ${what} — ${st}]\n`;
+    }
+    return "";
+  }).join("");
+
+  async function send(text: string) {
+    if (!text.trim() || busy) return;
+    setInput("");
+    const history: Msg[] = [...msgs, { role: "user", parts: [{ type: "text", text }] }];
+    setMsgs([...history, { role: "assistant", parts: [] }]);
+    setBusy(true);
+    const ctl = new AbortController();
+    abortRef.current = ctl;
+    try {
+      const res = await fetch("/api/agent/chat", {
+        method: "POST",
+        signal: ctl.signal,
+        headers: { "content-type": "application/json",
+                   ...(key ? { "X-Anthropic-Key": key } : {}), ...authHeader() },
+        body: JSON.stringify({
+          mode: "organize",
+          messages: history.map((m) => ({ role: m.role, content: historyText(m) })),
+        }),
+      });
+      if (!res.ok || !res.body) {
+        mutLast((p) => [...p, { type: "text", text: `⚠️ ${res.statusText}` }]);
+        return;
+      }
+      const reader = res.body.getReader();
+      const dec = new TextDecoder();
+      let buf = "";
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buf += dec.decode(value, { stream: true });
+        let idx;
+        while ((idx = buf.indexOf("\n\n")) >= 0) {
+          const chunk = buf.slice(0, idx); buf = buf.slice(idx + 2);
+          if (!chunk.startsWith("data: ")) continue;
+          const e = JSON.parse(chunk.slice(6));
+          if (e.type === "text") {
+            mutLast((parts) => {
+              const last = parts[parts.length - 1];
+              if (last?.type === "text") return [...parts.slice(0, -1), { type: "text", text: last.text + e.text }];
+              return [...parts, { type: "text", text: e.text }];
+            });
+          } else if (e.type === "tool") {
+            mutLast((p) => [...p, { type: "tool", name: e.name }]);
+          } else if (e.type === "proposal") {
+            const proposal = { id: e.id, kind: e.kind, ...e.payload } as Proposal;
+            mutLast((p) => [...p, { type: "proposal", proposal }]);
+          } else if (e.type === "error") {
+            mutLast((p) => [...p, { type: "text", text: `\n\n⚠️ ${e.detail}` }]);
+          }
+        }
+      }
+    } catch (err) {
+      if ((err as Error).name === "AbortError") {
+        // user hit Stop: cancelling the fetch tears down the SSE stream, which cancels the
+        // server-side agent loop mid-flight. Already-proposed cards stay reviewable.
+        mutLast((p) => [...p, { type: "text", text: "\n\n⏹ stopped — proposals so far are still reviewable" }]);
+      } else {
+        mutLast((p) => [...p, { type: "text", text: `\n\n⚠️ ${String((err as Error).message ?? err)}` }]);
+      }
+    } finally {
+      abortRef.current = null;
+      setBusy(false);
+    }
+  }
+
+  const decide = (id: string, status: Decision, detail?: string) =>
+    setDecisions((d) => ({ ...d, [id]: { status, detail } }));
+
+  const applyLabels = async (p: Extract<Proposal, { kind: "labels" }>) => {
+    try {
+      const src = await api.source(p.source);
+      await api.updateSource(p.source, {
+        name: src.name, type: src.type, connector: src.connector, poll: src.poll,
+        config: { ...src.config, labels: p.labels },
+      });
+      decide(p.id, "applied");
+      onCatalogChanged?.();
+    } catch (e) { decide(p.id, "error", String((e as Error).message ?? e)); }
+  };
+
+  const applyView = async (p: Extract<Proposal, { kind: "view" }>) => {
+    try {
+      await api.createView({ name: p.name, key_field: p.key_field,
+                             sources: p.sources, filters: (p.filters ?? []) as never });
+      decide(p.id, "applied");
+      onCatalogChanged?.();
+    } catch (e) { decide(p.id, "error", String((e as Error).message ?? e)); }
+  };
+
+  if (serverKey === undefined) return <div className="panel"><span className="dim">loading…</span></div>;
+
+  if (!serverKey && !key) {
+    return (
+      <div className="panel" style={{ maxWidth: 560 }}>
+        <h2 style={{ marginTop: 0 }}>Organize needs an Anthropic API key</h2>
+        <p className="help" style={{ whiteSpace: "normal" }}>
+          This instance has no server-provisioned key, so the agent runs on yours — sent per
+          request, kept in this browser, never stored on the server.
+        </p>
+        <form onSubmit={(e) => { e.preventDefault(); if (keyInput.trim()) { anthropicKey.set(keyInput.trim()); setKey(keyInput.trim()); } }}>
+          <input type="password" placeholder="sk-ant-…" value={keyInput}
+                 onChange={(e) => setKeyInput(e.target.value)}
+                 style={{ width: "100%", boxSizing: "border-box", padding: "0.5rem 0.7rem" }} autoFocus />
+          <div className="btnrow" style={{ marginTop: 12 }}>
+            <button className="primary" disabled={!keyInput.trim()}>Save key &amp; start</button>
+          </div>
+        </form>
+      </div>
+    );
+  }
+
+  return (
+    <div className="panel">
+      <div className="pagehead" style={{ marginBottom: 4 }}>
+        <h2 style={{ margin: 0 }}>✨ Organize</h2>
+        {busy && (
+          <button className="danger" onClick={() => abortRef.current?.abort()}>⏹ Stop</button>
+        )}
+      </div>
+      <p className="help" style={{ whiteSpace: "normal", marginTop: 0 }}>
+        The agent inspects your data and proposes labels and views — nothing is changed until you
+        apply a card. Labels apply to events going forward.
+      </p>
+
+      {msgs.map((m, i) => m.role === "user" ? null : (
+        <div key={i}>
+          {m.parts.map((p, j) => {
+            if (p.type === "tool") {
+              return <div key={j} className="toolcall">→ <span className="mono">{p.name}</span></div>;
+            }
+            if (p.type === "text") {
+              return <div key={j} className="md"><ReactMarkdown remarkPlugins={[remarkGfm]}>{p.text}</ReactMarkdown></div>;
+            }
+            return <ProposalCard key={j} proposal={p.proposal}
+                                 decision={decisions[p.proposal.id]}
+                                 onApply={() => p.proposal.kind === "labels"
+                                   ? applyLabels(p.proposal) : applyView(p.proposal)}
+                                 onSkip={() => decide(p.proposal.id, "skipped")} />;
+          })}
+          {busy && i === msgs.length - 1 && m.parts.length === 0 && <div className="dim">inspecting your data…</div>}
+        </div>
+      ))}
+
+      {!busy && msgs.length > 0 && (
+        <form className="btnrow" style={{ marginTop: 12 }}
+              onSubmit={(e) => { e.preventDefault(); void send(input); }}>
+          <input value={input} placeholder="refine — e.g. 'key claude_code by project instead'"
+                 style={{ flex: 1 }} onChange={(e) => setInput(e.target.value)} />
+          <button className="primary" disabled={!input.trim()}>Send</button>
+        </form>
+      )}
+    </div>
+  );
+}
+
+/** The hard evidence for a proposed value merge: the actual before→after table computed against
+ *  the source's observed values (same stateless preview endpoint the label editor uses). */
+function NormPreview({ source, label }: { source: string; label: LabelSpec }) {
+  const [preview, setPreview] = useState<{ sampled: number; distinct_before: number;
+    distinct_after: number; results: { from: string; to: string; events: number }[] }>();
+  const [err, setErr] = useState<string>();
+
+  useEffect(() => {
+    api.labelPreview(source, label as Record<string, unknown>)
+      .then(setPreview)
+      .catch((e) => setErr(String((e as Error).message ?? e)));
+  }, [source, JSON.stringify(label)]);
+
+  if (err) return <div className="alert error">merge preview failed: {err}</div>;
+  if (!preview) return <div className="dim" style={{ marginBottom: 8 }}>computing merge preview…</div>;
+  const merges = preview.results.filter((r) => r.from !== r.to);
+  return (
+    <div style={{ margin: "0 0 10px" }}>
+      <span className="help">
+        <span className="mono">{label.name}</span>: {preview.distinct_before} value{preview.distinct_before === 1 ? "" : "s"} →{" "}
+        <strong>{preview.distinct_after}</strong> after this merge ({preview.sampled} events sampled)
+        {merges.length === 0 && <> — <strong>no observed value actually changes</strong></>}
+      </span>
+      {merges.length > 0 && (
+        <table style={{ marginTop: 6 }}>
+          <thead><tr><th>value seen</th><th className="num">events</th><th>will become</th></tr></thead>
+          <tbody>
+            {merges.slice(0, 8).map((r, k) => (
+              <tr key={k}>
+                <td className="mono">{r.from}</td>
+                <td className="num">{r.events}</td>
+                <td className="mono"><span className="badge ok" style={{ marginRight: 6 }}>→</span>{r.to}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}
+
+function ProposalCard({ proposal, decision, onApply, onSkip }: {
+  proposal: Proposal; decision?: { status: Decision; detail?: string };
+  onApply: () => void; onSkip: () => void;
+}) {
+  const st = decision?.status;
+  return (
+    <div className="card" style={{ margin: "10px 0", padding: 14, opacity: st === "skipped" ? 0.55 : 1 }}>
+      <div className="pagehead" style={{ marginBottom: 8 }}>
+        <h3 style={{ margin: 0 }}>
+          {proposal.kind === "labels"
+            ? <>Labels for <span className="mono">{proposal.source}</span></>
+            : <>View <span className="mono">{proposal.name}</span></>}
+        </h3>
+        {st === "applied" && <span className="badge ok">applied</span>}
+        {st === "skipped" && <span className="badge starting">skipped</span>}
+        {st === "error" && <span className="badge error">failed</span>}
+      </div>
+
+      {proposal.kind === "labels" ? (
+        <table style={{ marginBottom: 8 }}>
+          <thead><tr><th>label</th><th>from</th></tr></thead>
+          <tbody>
+            {proposal.labels.map((l) => (
+              <tr key={l.name}>
+                <td className="mono">{l.name}{l.primary && <span className="badge ok" style={{ marginLeft: 8 }}>key</span>}</td>
+                <td className="mono">
+                  {l.field != null
+                    ? <><span className="badge push" style={{ marginRight: 8 }}>field</span>{l.field}</>
+                    : <><span className="badge push" style={{ marginRight: 8 }}>const</span>{String(l.const ?? "")}</>}
+                  {(l.pattern || l.map) && (
+                    <div className="help">
+                      normalize: {l.pattern && <>s/<span className="mono">{l.pattern}</span>/<span className="mono">{l.replace ?? ""}</span>/</>}
+                      {l.pattern && l.map ? " · " : ""}
+                      {l.map && `${Object.keys(l.map).length} alias(es)`}
+                    </div>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      ) : (
+        <p style={{ margin: "0 0 8px" }}>
+          key <span className="chip mono">{proposal.key_field}</span> over{" "}
+          {proposal.sources.map((s) => <span className="chip mono" key={s}>{s}</span>)}
+          {!!proposal.filters?.length && <> · {proposal.filters.length} filter(s)</>}
+        </p>
+      )}
+
+      {proposal.kind === "labels" && proposal.labels
+        .filter((l) => l.field && (l.pattern || l.map))
+        .map((l) => <NormPreview key={l.name} source={proposal.source} label={l} />)}
+
+      <p className="help" style={{ whiteSpace: "normal", margin: "0 0 10px" }}>{proposal.reasoning}</p>
+      {decision?.detail && <div className="alert error">{decision.detail}</div>}
+
+      {!st && (
+        <div className="btnrow">
+          <button className="primary" onClick={onApply}>Apply</button>
+          <button onClick={onSkip}>Skip</button>
+        </div>
+      )}
+      {st === "error" && (
+        <div className="btnrow">
+          <button className="primary" onClick={onApply}>Retry</button>
+          <button onClick={onSkip}>Skip</button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/SourceForm.tsx
+++ b/ui/src/components/SourceForm.tsx
@@ -143,9 +143,7 @@ export default function SourceForm({ connector, spec, initial, lockName, submitL
       else if (f.type === "number") config[f.name] = Number(raw);
       else config[f.name] = raw;
     }
-    const labels = labelRows
-      .filter((r) => r.name.trim())
-      .map((r) => ({ name: r.name.trim(), [r.kind]: r.value, ...(r.primary ? { primary: true } : {}) }));
+    const labels = labelRows.filter((r) => r.name.trim()).map(rowToSpec);
     if (labels.length) config.labels = labels;
     if (!name.trim()) throw new Error("name is required");
     return { name: name.trim(), type, connector, poll: poll.trim() || spec.poll || "5s", config };
@@ -246,7 +244,7 @@ export default function SourceForm({ connector, spec, initial, lockName, submitL
   // Editing labels re-processes every stored event for the source; warn before that happens.
   // Only meaningful when editing (initial present) — a fresh source has no stored events.
   const canonRows = (rs: LabelRow[]) =>
-    JSON.stringify(rs.filter((r) => r.name.trim()).map((r) => [r.name.trim(), r.kind, r.value, r.primary]));
+    JSON.stringify(rs.filter((r) => r.name.trim()).map(rowToSpec));
   const labelsChanged = !!initial && canonRows(labelRows) !== canonRows(labelsToRows(initial?.config?.labels));
 
   const renderField = (f: ConnectorField) =>
@@ -359,7 +357,7 @@ export default function SourceForm({ connector, spec, initial, lockName, submitL
 
       {spec.discover && spec.fields.filter((f) => !f.discover_input).map(renderField)}
 
-      <LabelsEditor rows={labelRows} onChange={setLabelRows}
+      <LabelsEditor rows={labelRows} onChange={setLabelRows} sourceName={initial?.name}
                     fields={labelFieldOpts} fieldHints={labelFieldHints} />
 
       {labelsChanged && (
@@ -384,22 +382,41 @@ export default function SourceForm({ connector, spec, initial, lockName, submitL
   );
 }
 
-type LabelRow = { name: string; kind: "const" | "field"; value: string; primary: boolean };
+type MapRow = { from: string; to: string };
+type LabelRow = { name: string; kind: "const" | "field"; value: string; primary: boolean;
+                  pattern: string; replace: string; map: MapRow[]; normOpen: boolean };
 
 function labelsToRows(arr: unknown): LabelRow[] {
   if (!Array.isArray(arr)) return [];
   const rows = arr.map((x) => {
     const o = x as Record<string, unknown>;
     const kind: "const" | "field" = "field" in o ? "field" : "const";
-    return { name: String(o.name ?? ""), kind, value: String(o[kind] ?? ""), primary: !!o.primary };
+    const map = o.map && typeof o.map === "object"
+      ? Object.entries(o.map as Record<string, string>).map(([from, to]) => ({ from, to: String(to) }))
+      : [];
+    return { name: String(o.name ?? ""), kind, value: String(o[kind] ?? ""), primary: !!o.primary,
+             pattern: String(o.pattern ?? ""), replace: String(o.replace ?? ""), map,
+             normOpen: !!(o.pattern || map.length) };
   });
   if (rows.length && !rows.some((r) => r.primary)) rows[0].primary = true;  // first is the key by default
   return rows;
 }
 
-function LabelsEditor({ rows, onChange, fields = [], fieldHints }:
+/** Row -> label spec, including the optional value normalization (pattern/replace + alias map). */
+function rowToSpec(r: LabelRow): Record<string, unknown> {
+  const spec: Record<string, unknown> = { name: r.name.trim(), [r.kind]: r.value,
+                                          ...(r.primary ? { primary: true } : {}) };
+  if (r.kind === "field") {
+    if (r.pattern.trim()) { spec.pattern = r.pattern; spec.replace = r.replace; }
+    const map = Object.fromEntries(r.map.filter((m) => m.from.trim()).map((m) => [m.from, m.to]));
+    if (Object.keys(map).length) spec.map = map;
+  }
+  return spec;
+}
+
+function LabelsEditor({ rows, onChange, fields = [], fieldHints, sourceName }:
   { rows: LabelRow[]; onChange: (r: LabelRow[]) => void; fields?: string[];
-    fieldHints?: Record<string, string> }) {
+    fieldHints?: Record<string, string>; sourceName?: string }) {
   const set = (i: number, patch: Partial<LabelRow>) =>
     onChange(rows.map((r, j) => (j === i ? { ...r, ...patch } : r)));
   const makePrimary = (i: number) => onChange(rows.map((r, j) => ({ ...r, primary: j === i })));
@@ -426,31 +443,42 @@ function LabelsEditor({ rows, onChange, fields = [], fieldHints }:
         </div>
       )}
       {rows.map((row, i) => (
-        <div key={i} className="label-row">
-          <span className="label-col-key" title="make this the primary key">
-            <input type="radio" checked={row.primary} onChange={() => makePrimary(i)} />
-          </span>
-          <input className="label-col-grow" placeholder="e.g. service" value={row.name}
-                 onChange={(e) => set(i, { name: e.target.value })} />
-          <select className="label-col-from" value={row.kind}
-                  onChange={(e) => set(i, { kind: e.target.value as LabelRow["kind"] })}>
-            <option value="const">const (fixed)</option>
-            <option value="field">field (per event)</option>
-          </select>
-          {row.kind === "field" && fields.length ? (
-            <Combo className="label-col-grow" value={row.value} options={fields}
-                   hints={fieldHints} placeholder="field, e.g. service"
-                   onChange={(v) => set(i, { value: v })} />
-          ) : (
-            <input className="label-col-grow"
-                   placeholder={row.kind === "const" ? "value, e.g. api-server" : "field, e.g. service"}
-                   value={row.value} onChange={(e) => set(i, { value: e.target.value })} />
+        <div key={i}>
+          <div className="label-row">
+            <span className="label-col-key" title="make this the primary key">
+              <input type="radio" checked={row.primary} onChange={() => makePrimary(i)} />
+            </span>
+            <input className="label-col-grow" placeholder="e.g. service" value={row.name}
+                   onChange={(e) => set(i, { name: e.target.value })} />
+            <select className="label-col-from" value={row.kind}
+                    onChange={(e) => set(i, { kind: e.target.value as LabelRow["kind"] })}>
+              <option value="const">const (fixed)</option>
+              <option value="field">field (per event)</option>
+            </select>
+            {row.kind === "field" && fields.length ? (
+              <Combo className="label-col-grow" value={row.value} options={fields}
+                     hints={fieldHints} placeholder="field, e.g. service"
+                     onChange={(v) => set(i, { value: v })} />
+            ) : (
+              <input className="label-col-grow"
+                     placeholder={row.kind === "const" ? "value, e.g. api-server" : "field, e.g. service"}
+                     value={row.value} onChange={(e) => set(i, { value: e.target.value })} />
+            )}
+            {row.kind === "field" && (
+              <button type="button" title="normalize values (regex + aliases)"
+                      className={row.normOpen || row.pattern || row.map.length ? "active" : "dim"}
+                      onClick={() => set(i, { normOpen: !row.normOpen })}>≈</button>
+            )}
+            <button type="button" className="danger label-col-x" onClick={() => remove(i)}>×</button>
+          </div>
+          {row.kind === "field" && row.normOpen && (
+            <NormalizeEditor row={row} onChange={(patch) => set(i, patch)} sourceName={sourceName} />
           )}
-          <button type="button" className="danger label-col-x" onClick={() => remove(i)}>×</button>
         </div>
       ))}
       <button type="button"
-              onClick={() => onChange([...rows, { name: "", kind: "const", value: "", primary: rows.length === 0 }])}>
+              onClick={() => onChange([...rows, { name: "", kind: "const", value: "", primary: rows.length === 0,
+                                                  pattern: "", replace: "", map: [], normOpen: false }])}>
         + Add label
       </button>
       {fields.length > 0 && (
@@ -460,6 +488,181 @@ function LabelsEditor({ rows, onChange, fields = [], fieldHints }:
             {" "}— pick a <code>field</code> from these (the source's page shows each field's coverage once data flows).
           </div>
         </>
+      )}
+    </div>
+  );
+}
+
+/** Merge value variants for one field label. User-first flow: show the values this field
+ *  actually has, let the user rename the odd ones onto a canonical one, and reflect the result
+ *  live. The regex lives behind an "advanced" toggle for whole families of variants. */
+function NormalizeEditor({ row, onChange, sourceName }:
+  { row: LabelRow; onChange: (patch: Partial<LabelRow>) => void; sourceName?: string }) {
+  const [preview, setPreview] = useState<{ sampled: number; distinct_before: number;
+    distinct_after: number; results: { from: string; to: string; events: number }[] }>();
+  const [pErr, setPErr] = useState<string>();
+  const [advanced, setAdvanced] = useState(!!row.pattern);
+
+  // live preview: on open (bare field -> the observed values), and after every edit (debounced)
+  useEffect(() => {
+    if (!sourceName || !row.value.trim()) return;
+    const t = setTimeout(async () => {
+      try {
+        setPErr(undefined);
+        setPreview(await api.labelPreview(sourceName, rowToSpec(row)));
+      } catch (e) { setPreview(undefined); setPErr(String((e as Error).message ?? e)); }
+    }, 500);
+    return () => clearTimeout(t);
+  }, [sourceName, row.value, row.pattern, row.replace, JSON.stringify(row.map)]);
+
+  const observed = preview?.results ?? [];
+  const merges = observed.filter((r2) => r2.from !== r2.to).length;
+  const fromOpts = observed.map((r2) => r2.from);
+  const fromHints = Object.fromEntries(observed.map((r2) => [r2.from, `${r2.events} events`]));
+
+  const hasRules = !!row.pattern || row.map.length > 0;
+
+  return (
+    <div className="panel" style={{ margin: "2px 0 10px 28px", padding: 12 }}>
+      <div className="pagehead" style={{ marginBottom: 6 }}>
+        <strong>Merge value variants</strong>
+        <span className="btnrow">
+          {hasRules && (
+            <button type="button" className="danger"
+                    title="discard the pattern rule and all renames for this label"
+                    onClick={() => { onChange({ pattern: "", replace: "", map: [] }); }}>
+              Clear
+            </button>
+          )}
+          <button type="button" onClick={() => onChange({ normOpen: false })}>Done</button>
+        </span>
+      </div>
+      <span className="help" style={{ display: "block", marginTop: 0, marginBottom: 8, whiteSpace: "normal" }}>
+        If the same thing appears under different names
+        (say <span className="mono">checkout</span> and <span className="mono">checkout-svc</span>),
+        they count as different entities and won&rsquo;t correlate. Rename the variants onto one
+        name here. Renaming never loses data — the original value stays in the stored event.
+      </span>
+
+      {pErr && <div className="alert error">{pErr}</div>}
+
+      {sourceName && preview && (
+        <div style={{ marginBottom: 10 }}>
+          <span className="help">
+            This field has <strong>{preview.distinct_before}</strong> distinct value{preview.distinct_before === 1 ? "" : "s"} in
+            recent events{merges > 0 && <> — with your renames it becomes <strong>{preview.distinct_after}</strong></>}:
+          </span>
+          <table style={{ marginTop: 6 }}>
+            <thead><tr><th>value seen</th><th className="num">events</th><th>will become</th></tr></thead>
+            <tbody>
+              {observed.slice(0, 12).map((r2, k) => (
+                <tr key={k}>
+                  <td className="mono">{r2.from}</td>
+                  <td className="num">{r2.events}</td>
+                  <td className="mono">
+                    {r2.from === r2.to
+                      ? <span className="dim">unchanged</span>
+                      : <><span className="badge ok" style={{ marginRight: 6 }}>→</span>{r2.to}</>}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+      {sourceName && !preview && !pErr && <div className="dim" style={{ marginBottom: 10 }}>loading observed values…</div>}
+      {!sourceName && (
+        <span className="help" style={{ display: "block", marginBottom: 10 }}>
+          (once this source has data, its actual values will show here so you can pick what to rename)
+        </span>
+      )}
+
+      {row.map.map((m, j) => (
+        <div key={j} className="btnrow" style={{ marginBottom: 6, alignItems: "center" }}>
+          <span className="help">rename</span>
+          <Combo style={{ flex: 1 }} value={m.from} options={fromOpts} hints={fromHints}
+                 placeholder="value seen in the data"
+                 onChange={(v) => onChange({ map: row.map.map((x, k) => k === j ? { ...x, from: v } : x) })} />
+          <span className="help">to</span>
+          <input className="mono" style={{ flex: 1 }} placeholder="the name it should have"
+                 value={m.to}
+                 onChange={(e) => onChange({ map: row.map.map((x, k) => k === j ? { ...x, to: e.target.value } : x) })} />
+          <button type="button" className="danger" onClick={() => onChange({ map: row.map.filter((_, k) => k !== j) })}>×</button>
+        </div>
+      ))}
+      <div className="btnrow">
+        <button type="button" onClick={() => onChange({ map: [...row.map, { from: "", to: "" }] })}>
+          + Rename a value
+        </button>
+        <button type="button" className="dim" onClick={() => setAdvanced((a) => !a)}>
+          {advanced ? "hide pattern rule" : "advanced: pattern rule…"}
+        </button>
+      </div>
+
+      {advanced && (
+        <PatternRule key={row.pattern === "" ? "empty" : "set"} row={row} onChange={onChange} />
+      )}
+    </div>
+  );
+}
+
+const escRe = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+type RuleKind = "suffix" | "prefix" | "after" | "custom";
+
+/** Builds the pattern for the user from plain choices — "remove the ending -svc" — so nobody has
+ *  to write a regex unless they pick custom. The stored config is still just pattern/replace. */
+function PatternRule({ row, onChange }:
+  { row: LabelRow; onChange: (patch: Partial<LabelRow>) => void }) {
+  const [kind, setKind] = useState<RuleKind>(row.pattern ? "custom" : "suffix");
+  const [text, setText] = useState("");
+
+  const apply = (k: RuleKind, t: string) => {
+    if (k === "suffix") onChange({ pattern: t ? `${escRe(t)}$` : "", replace: "" });
+    else if (k === "prefix") onChange({ pattern: t ? `^${escRe(t)}` : "", replace: "" });
+    else if (k === "after") onChange({ pattern: t ? `${escRe(t)}.*$` : "", replace: "" });
+  };
+
+  return (
+    <div style={{ marginTop: 8 }}>
+      <span className="help" style={{ display: "block", marginBottom: 6, whiteSpace: "normal" }}>
+        A pattern rule fixes a whole family of values at once (it runs before the renames above).
+        The table shows its effect live.
+      </span>
+      <div className="btnrow" style={{ alignItems: "center" }}>
+        <select value={kind} style={{ maxWidth: 260 }}
+                onChange={(e) => { const k = e.target.value as RuleKind; setKind(k);
+                                   if (k === "custom") return; apply(k, text); }}>
+          <option value="suffix">remove this ending</option>
+          <option value="prefix">remove this beginning</option>
+          <option value="after">cut everything from … onwards</option>
+          <option value="custom">custom (regular expression)</option>
+        </select>
+        {kind !== "custom" ? (
+          <input className="mono" style={{ flex: 1 }}
+                 placeholder={kind === "suffix" ? "e.g. -svc" : kind === "prefix" ? "e.g. prod-" : "e.g. ."}
+                 value={text}
+                 onChange={(e) => { setText(e.target.value); apply(kind, e.target.value); }} />
+        ) : (
+          <>
+            <input className="mono" style={{ flex: 2 }} placeholder="regex, e.g. -(service|svc)$"
+                   value={row.pattern} onChange={(e) => onChange({ pattern: e.target.value })} />
+            <input className="mono" style={{ flex: 1 }} placeholder="replacement (empty = remove)"
+                   value={row.replace} onChange={(e) => onChange({ replace: e.target.value })} />
+          </>
+        )}
+      </div>
+      {kind === "suffix" && (
+        <span className="help">e.g. entering <span className="mono">-svc</span> turns{" "}
+          <span className="mono">checkout-svc</span> into <span className="mono">checkout</span></span>
+      )}
+      {kind === "prefix" && (
+        <span className="help">e.g. entering <span className="mono">prod-</span> turns{" "}
+          <span className="mono">prod-checkout</span> into <span className="mono">checkout</span></span>
+      )}
+      {kind === "after" && (
+        <span className="help">e.g. entering <span className="mono">.</span> turns{" "}
+          <span className="mono">checkout.internal.eu</span> into <span className="mono">checkout</span></span>
       )}
     </div>
   );

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -7,6 +7,7 @@ import AuthGate from "./components/AuthGate";
 import AgentActivity, { ConnectPage } from "./pages/Activity";
 import Ask from "./pages/Ask";
 import Explore from "./pages/Explore";
+import Organize from "./pages/Organize";
 import SourceClaudeCode from "./pages/SourceClaudeCode";
 import SourceDetail from "./pages/SourceDetail";
 import SourceDiscover from "./pages/SourceDiscover";
@@ -27,6 +28,7 @@ const router = createBrowserRouter([
       { path: "sources/claude-code", element: <SourceClaudeCode /> },
       { path: "sources/new", element: <SourceNew /> },
       { path: "sources/:name", element: <SourceDetail /> },
+      { path: "organize", element: <Organize /> },
       { path: "explore", element: <Explore /> },
       { path: "views", element: <ViewsPage /> },
       { path: "triggers", element: <TriggersPage /> },

--- a/ui/src/pages/Organize.tsx
+++ b/ui/src/pages/Organize.tsx
@@ -1,0 +1,52 @@
+import { useState } from "react";
+
+import OrganizePanel from "../components/OrganizePanel";
+import { api } from "../api";
+import { usePolling } from "../components/bits";
+
+// Dedicated home for the Organize agent (docs/design/organize-agent.md): inspect the ingested
+// data, propose labels/keys per source and views across sources as cards the user applies or
+// skips. The run starts on an explicit click — never on page load (it spends model tokens).
+export default function Organize() {
+  const { data: sources } = usePolling(() => api.sources(), 15000);
+  const [started, setStarted] = useState(false);
+
+  const total = sources?.reduce((n, s) => n + (s.health?.events_total ?? 0), 0) ?? 0;
+  const unlabeled = (sources ?? []).filter(
+    (s) => !((s.config?.labels as unknown[] | undefined)?.length)).length;
+
+  return (
+    <>
+      <h1>Organize</h1>
+      <p className="subtitle">
+        an agent reads your data and proposes labels &amp; views — <em>you apply or skip each card</em>
+      </p>
+
+      {!started && (
+        <div className="panel" style={{ maxWidth: 640 }}>
+          <p className="help" style={{ whiteSpace: "normal", marginTop: 0 }}>
+            The agent inspects every source&rsquo;s field profile and sample events, judges which
+            fields identify real entities, and proposes: the labels &amp; key each source should
+            carry, and the views that give agents one correlated timeline per entity. Nothing is
+            changed without your click, and labels apply to new events going forward.
+          </p>
+          {sources && (
+            <p className="help" style={{ whiteSpace: "normal" }}>
+              Right now: {sources.length} source{sources.length === 1 ? "" : "s"},{" "}
+              {total.toLocaleString()} events{unlabeled > 0 && (
+                <> — <strong>{unlabeled} source{unlabeled === 1 ? "" : "s"} with no labels declared</strong></>
+              )}.
+            </p>
+          )}
+          <button className="primary" disabled={!total}
+                  onClick={() => setStarted(true)}>
+            ✨ Start the sweep
+          </button>
+          {!total && <p className="help" style={{ marginTop: 8 }}>needs at least one source with data</p>}
+        </div>
+      )}
+
+      {started && <OrganizePanel />}
+    </>
+  );
+}


### PR DESCRIPTION
Two features that complete the "organize your data after it flows" story:

**Label value normalization (core capability)**
- Label specs gain optional value normalization: one regex substitution (`pattern`/`replace`, applied first) + one exact-alias `map` (applied to the cleaned result). Implemented inside `extract_labels`, so ingest, the field profiler, and future retroactive relabel share one behavior. Fail-open per event; the lossless payload always keeps the original.
- Validation at save (compile check, length cap, field-labels only, map shape) — a bad regex is a 400 at config-write, never a per-event failure.
- `POST /api/labels/preview`: stateless before→after merge table against a source's observed values.
- Label editor: a "Merge value variants" panel — observed values shown first, "+ Rename a value" picks from them, live-updating will-become table, pattern building via plain choices (remove ending/beginning/cut-from; raw regex only under "custom"), Done/Clear exits.

**Organize agent (in-app, propose-and-consent)**
- New `/organize` page (sidebar: Data in → Organize): explicit start, streamed sweep, stoppable mid-run.
- `organize` mode in the agent loop with proposal tools (`propose_labels`, `propose_view`) that are server-side no-ops — proposals stream as cards; only the user's Apply fires the normal validated APIs. `create_view` excluded in this mode.
- Cards show labels (incl. proposed value merges with the computed before→after evidence table), views, reasoning, apply/skip/retry states; conversation continues for refinement.
- Re-runs converge: proposing a source's exact current label set is suppressed deterministically.
- Anthropic key: server-provisioned `NAVFLOW_ANTHROPIC_KEY` (capabilities exposes only a boolean; key never returned) with the per-request header as override; local BYO prompt unchanged. Ask shares the same path.