### PR TITLE
Serve-to-agents rebuild: named agents, delivery history, dedicated view/trigger pages

### DIFF
--- a/navflow/daemon.py
+++ b/navflow/daemon.py
@@ -1003,6 +1003,65 @@ def make_app() -> FastAPI:
     async def activity_dispatches(limit: int = 100):
         return store.list_dispatches(limit=min(limit, 500))
 
+    # ── connected agents: subscriptions grouped by endpoint, named deterministically ──
+    _AGENT_ADJ = ["brisk", "quiet", "amber", "bold", "calm", "deft", "eager", "fleet",
+                  "keen", "lucid", "merry", "noble", "prime", "swift", "vivid", "wry"]
+    _AGENT_NOUN = ["heron", "otter", "drake", "skiff", "beacon", "compass", "gull", "harbor",
+                   "keel", "lantern", "mast", "pilot", "rudder", "sextant", "tide", "wake"]
+
+    def _agent_identity(url: str) -> tuple[str, str]:
+        """(deterministic name, masked display URL) for a subscriber endpoint. The URL is the
+        identity; hook URLs carry secrets in the path, so the last path segment is masked."""
+        norm = url.rstrip("/")
+        h = int(hashlib.sha256(norm.encode()).hexdigest(), 16)
+        name = f"{_AGENT_ADJ[h % len(_AGENT_ADJ)]}-{_AGENT_NOUN[(h // 16) % len(_AGENT_NOUN)]}"
+        try:
+            from urllib.parse import urlsplit
+            u = urlsplit(norm)
+            segs = [seg for seg in u.path.split("/") if seg]
+            if segs:
+                segs[-1] = segs[-1][:2] + "…" if len(segs[-1]) > 2 else "…"
+            masked = f"{u.scheme}://{u.netloc}/" + "/".join(segs)
+        except Exception:
+            masked = norm[:24] + "…"
+        return name, masked
+
+    @app.get("/api/agents")
+    async def connected_agents():
+        """The roster: every subscribed endpoint as a named agent — its wiring (triggers,
+        creating credential), delivery health, and recent wakes."""
+        stats = store.delivery_stats()
+        agents: dict[str, dict] = {}
+        for sub in store.all_subscriptions():
+            norm = sub["url"].rstrip("/")
+            a = agents.get(norm)
+            if a is None:
+                name, masked = _agent_identity(norm)
+                st = stats.get(sub["url"], stats.get(norm, {}))
+                a = agents[norm] = {
+                    "name": name, "endpoint": masked,
+                    "subscriptions": [], "triggers": [], "created_by": set(),
+                    "first_seen": sub["created_at"],
+                    "delivered_ok": st.get("ok", 0), "delivered_fail": st.get("fail", 0),
+                    "last_woken": st.get("last_at"),
+                    "recent": [{"at": d["at"], "ok": d["ok"], "trigger": d["trigger"],
+                                "key": d["key"]} for d in store.recent_deliveries(sub["url"], 10)],
+                }
+            a["subscriptions"].append({"subscription_id": sub["subscription_id"],
+                                       "trigger": sub["trigger"], "created_at": sub["created_at"]})
+            if sub["trigger"] not in a["triggers"]:
+                a["triggers"].append(sub["trigger"])
+            if sub["created_by"]:
+                a["created_by"].add(sub["created_by"])
+            if sub["created_at"] and (a["first_seen"] is None or sub["created_at"] < a["first_seen"]):
+                a["first_seen"] = sub["created_at"]
+        out = []
+        for a in agents.values():
+            a["created_by"] = sorted(a["created_by"])
+            out.append(a)
+        out.sort(key=lambda x: str(x.get("last_woken") or x.get("first_seen") or ""), reverse=True)
+        return {"agents": out}
+
     @app.get("/api/subscriptions")
     async def subscriptions():
         return store.list_all_subscriptions()

--- a/navflow/dispatch.py
+++ b/navflow/dispatch.py
@@ -30,8 +30,10 @@ class Dispatcher:
             "payload": payload,
         }
         delivered = 0
-        for _sid, _trig, url in subs:
-            if await self._post(url, body):
+        for sid, _trig, url in subs:
+            ok = await self._post(url, body)
+            self.store.log_delivery(dispatch_id, sid, url, ok)   # per-agent delivery history
+            if ok:
                 delivered += 1
         # log every firing, even with zero subscribers — the UI shows what would have woken agents
         self.store.log_dispatch(dispatch_id, trigger.name, key, kind,

--- a/navflow/store.py
+++ b/navflow/store.py
@@ -44,6 +44,13 @@ CREATE TABLE IF NOT EXISTS subscriptions (
   created_at      TIMESTAMPTZ,
   created_by      TEXT
 );
+CREATE TABLE IF NOT EXISTS dispatch_deliveries (
+  dispatch_id     TEXT,
+  subscription_id TEXT,
+  url             TEXT,
+  ok              BOOLEAN,
+  delivered_at    TIMESTAMPTZ
+);
 CREATE TABLE IF NOT EXISTS api_keys (
   id           TEXT PRIMARY KEY,
   name         TEXT,
@@ -244,7 +251,10 @@ class Store:
         ph = ", ".join(["?"] * len(sources))
         fsql, fparams = _filter_sql(filters)
         wsql, wparams = _where_sql(where)
-        valexpr = (f"CAST(json_extract_string(fields, '$.{field}') AS DOUBLE)"
+        if field and not re.match(r"^[A-Za-z0-9_.]+$", str(field)):
+            raise ValueError(f"bad aggregate field {field!r}")
+        # quoted JSON path so dotted field names (http.status_code) resolve as one flat key
+        valexpr = (f"CAST(json_extract_string(fields, '$.\"{field}\"') AS DOUBLE)"
                    if field else "1")
         aggexpr = {
             "count": "COUNT(*)",
@@ -620,6 +630,38 @@ class Store:
     def remove_subscription(self, sid: str) -> None:
         with self._lock:
             self.con.execute("DELETE FROM subscriptions WHERE subscription_id = ?", [sid])
+
+    def log_delivery(self, dispatch_id: str, subscription_id: str, url: str, ok: bool) -> None:
+        with self._lock:
+            self.con.execute("INSERT INTO dispatch_deliveries VALUES (?, ?, ?, ?, ?)",
+                             [dispatch_id, subscription_id, url, ok, now_utc()])
+
+    def all_subscriptions(self) -> list[dict]:
+        with self._lock:
+            rows = self.con.execute(
+                "SELECT subscription_id, trigger, url, created_at, created_by "
+                "FROM subscriptions ORDER BY created_at").fetchall()
+        return [{"subscription_id": r[0], "trigger": r[1], "url": r[2],
+                 "created_at": r[3], "created_by": r[4]} for r in rows]
+
+    def delivery_stats(self) -> dict:
+        """{url: {"ok": n, "fail": n, "last_at": ts}} across all recorded deliveries."""
+        with self._lock:
+            rows = self.con.execute(
+                "SELECT url, SUM(CASE WHEN ok THEN 1 ELSE 0 END), "
+                "SUM(CASE WHEN ok THEN 0 ELSE 1 END), MAX(delivered_at) "
+                "FROM dispatch_deliveries GROUP BY url").fetchall()
+        return {r[0]: {"ok": int(r[1] or 0), "fail": int(r[2] or 0), "last_at": r[3]} for r in rows}
+
+    def recent_deliveries(self, url: str, limit: int = 20) -> list[dict]:
+        """Latest deliveries to one endpoint, joined with the firing's trigger/entity."""
+        with self._lock:
+            rows = self.con.execute(
+                "SELECT d.delivered_at, d.ok, l.trigger, l.key_value, d.dispatch_id "
+                "FROM dispatch_deliveries d LEFT JOIN dispatch_log l ON d.dispatch_id = l.dispatch_id "
+                "WHERE d.url = ? ORDER BY d.delivered_at DESC LIMIT ?", [url, limit]).fetchall()
+        return [{"at": r[0], "ok": bool(r[1]), "trigger": r[2], "key": r[3],
+                 "dispatch_id": r[4]} for r in rows]
 
     # ── API keys (scoped credentials; only the SHA-256 of the secret is stored) ─
     def insert_api_key(self, kid: str, name: str, prefix: str, hash_: str, scopes: list[str]) -> None:

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -31,10 +31,10 @@ const NAV_GROUPS: { section: string; items: NavItem[] }[] = [
     { to: "/explore", label: "Explore", icon: Activity },
   ] },
   { section: "Serve to agents", items: [
-    { to: "/connect", label: "Connect", icon: Terminal },
     { to: "/views", label: "Views", icon: Book },
     { to: "/triggers", label: "Triggers", icon: Bolt },
-    { to: "/activity", label: "Activity", icon: Filter },
+    { to: "/activity", label: "Agents", icon: Filter },
+    { to: "/connect", label: "Connect", icon: Terminal },
   ] },
 ];
 
@@ -43,7 +43,7 @@ const SECTION_LABEL: Record<string, string> = {
   views: "Views",
   triggers: "Triggers",
   connect: "Connect",
-  activity: "Activity",
+  activity: "Agents",
   catalog: "Catalog",
   ask: "Ask",
   security: "Security",

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -1,4 +1,5 @@
 import type {
+  AgentInfo,
   ApiKey,
   CatalogDescribe, CatalogList, ConnectorSpec, DiscoverProposal, DispatchLogEntry, Entity, EnvScan,
   LabelFacet, QueryLogEntry, Source, SourceEvent, SourceFieldsProfile, Subscription, TestResult,
@@ -109,6 +110,13 @@ export const api = {
   updateTrigger: (name: string, body: Trigger) =>
     request(`/api/triggers/${name}`, { method: "PUT", body: JSON.stringify(body) }),
   deleteTrigger: (name: string) => request(`/api/triggers/${name}`, { method: "DELETE" }),
+  agents: () => request<{ agents: AgentInfo[] }>("/api/agents"),
+  unsubscribe: (subscription_id: string) =>
+    request<{ ok: boolean }>("/unsubscribe",
+      { method: "POST", body: JSON.stringify({ subscription_id }) }),
+  subscribe: (trigger: string, url: string) =>
+    request<{ subscription_id: string }>("/subscribe",
+      { method: "POST", body: JSON.stringify({ trigger, url }) }),
 
   queries: (limit = 100) => request<QueryLogEntry[]>(`/api/activity/queries?limit=${limit}`),
   dispatches: (limit = 100) =>

--- a/ui/src/components/TriggerEditor.tsx
+++ b/ui/src/components/TriggerEditor.tsx
@@ -1,0 +1,141 @@
+import { useEffect, useState } from "react";
+
+import { api } from "../api";
+import { Combo } from "./bits";
+import type { Trigger } from "../types";
+
+// The one trigger editor — used in place on /triggers/new and /triggers/<name>.
+// The condition's `field` is suggested from the selected view's sources: their NUMERIC typed
+// fields (from the catalog schema), because that's what aggregates can actually compute over.
+
+const AGGREGATES = ["max", "min", "sum", "avg", "count", "any"];
+
+export default function TriggerEditor({ initial, presetView, onSaved, onCancel }: {
+  initial?: Trigger;            // absent = create
+  presetView?: string;          // create mode: view preselected (e.g. from a view page)
+  onSaved: (name: string) => void;
+  onCancel: () => void;
+}) {
+  const isNew = !initial;
+  const [t, setT] = useState<Trigger>(initial ?? {
+    name: "", view: presetView ?? "",
+    condition: { aggregate: "max", predicate: "> 1.0", window: "1m", field: "" },
+    emit: { kind: "", context_window: "15m" },
+    cooldown: "5m",
+  });
+  const [viewNames, setViewNames] = useState<string[]>([]);
+  const [viewSources, setViewSources] = useState<Record<string, string[]>>({});
+  const [fieldOpts, setFieldOpts] = useState<string[]>([]);
+  const [error, setError] = useState<string>();
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    api.views().then((vs) => {
+      setViewNames(vs.map((v) => v.name));
+      setViewSources(Object.fromEntries(vs.map((v) => [v.name, v.sources])));
+    }).catch(() => {});
+  }, []);
+
+  // numeric fields the selected view's events actually carry — the only valid aggregate targets
+  useEffect(() => {
+    const srcs = viewSources[t.view] ?? [];
+    if (!srcs.length) { setFieldOpts([]); return; }
+    let live = true;
+    Promise.all(srcs.map((s) => api.describe(`source:${s}`).catch(() => null))).then((descs) => {
+      if (!live) return;
+      const nums = new Set<string>();
+      for (const d of descs) {
+        for (const [fname, ftype] of Object.entries(d?.schema?.fields ?? {})) {
+          if (ftype === "number") nums.add(fname);
+        }
+      }
+      setFieldOpts(Array.from(nums).sort());
+    });
+    return () => { live = false; };
+  }, [t.view, Object.keys(viewSources).length]);
+
+  const save = async () => {
+    setBusy(true);
+    setError(undefined);
+    try {
+      if (isNew) await api.createTrigger(t);
+      else await api.updateTrigger(initial!.name, t);
+      onSaved(t.name);
+    } catch (e) { setError(String((e as Error).message ?? e)); }
+    setBusy(false);
+  };
+
+  const cond = (patch: Partial<Trigger["condition"]>) =>
+    setT({ ...t, condition: { ...t.condition, ...patch } });
+
+  return (
+    <div className="panel">
+      {error && <div className="alert error">{error}</div>}
+      <div className="row2">
+        <label className="field">
+          <span className="lbl">name</span>
+          <input type="text" value={t.name} disabled={!isNew} placeholder="e.g. error_spike"
+                 onChange={(e) => setT({ ...t, name: e.target.value })} />
+        </label>
+        <div className="field">
+          <span className="lbl">view</span>
+          <Combo value={t.view} options={viewNames}
+                 placeholder="the view this condition watches"
+                 onChange={(v) => setT({ ...t, view: v })} />
+        </div>
+      </div>
+      <div className="row2">
+        <label className="field">
+          <span className="lbl">aggregate</span>
+          <select value={t.condition.aggregate} onChange={(e) => cond({ aggregate: e.target.value })}>
+            {AGGREGATES.map((a) => <option key={a} value={a}>{a}</option>)}
+          </select>
+        </label>
+        <div className="field">
+          <span className="lbl">field</span>
+          <Combo value={t.condition.field ?? ""} options={fieldOpts}
+                 placeholder={fieldOpts.length ? `e.g. ${fieldOpts[0]}` : "numeric field (empty for count)"}
+                 onChange={(v) => cond({ field: v })} />
+          <span className="help">
+            {t.view
+              ? fieldOpts.length
+                ? `${fieldOpts.length} numeric field${fieldOpts.length === 1 ? "" : "s"} in this view — click the box to pick. Leave empty to count events.`
+                : "no numeric fields found in this view's events yet — leave empty to count events"
+              : "pick a view first — its numeric fields will be suggested here"}
+          </span>
+        </div>
+      </div>
+      <div className="row2">
+        <label className="field">
+          <span className="lbl">predicate</span>
+          <input type="text" value={t.condition.predicate} onChange={(e) => cond({ predicate: e.target.value })} />
+          <span className="help">e.g. &gt; 1.0, &gt;= 100, == 0</span>
+        </label>
+        <label className="field">
+          <span className="lbl">window</span>
+          <input type="text" value={t.condition.window} onChange={(e) => cond({ window: e.target.value })} />
+          <span className="help">detection window, e.g. 1m</span>
+        </label>
+      </div>
+      <div className="row2">
+        <label className="field">
+          <span className="lbl">context window</span>
+          <input type="text" value={String(t.emit.context_window ?? "15m")}
+                 onChange={(e) => setT({ ...t, emit: { ...t.emit, context_window: e.target.value } })} />
+          <span className="help">how much timeline the woken agent receives</span>
+        </label>
+        <label className="field">
+          <span className="lbl">cooldown</span>
+          <input type="text" value={t.cooldown} onChange={(e) => setT({ ...t, cooldown: e.target.value })} />
+          <span className="help">minimum gap between firings per entity</span>
+        </label>
+      </div>
+      <div className="btnrow">
+        <button className="primary" onClick={save} disabled={busy || !t.name.trim() || !t.view.trim()}>
+          {isNew ? "Create trigger" : "Save changes"}
+        </button>
+        <button onClick={onCancel}>Cancel</button>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/ViewEditor.tsx
+++ b/ui/src/components/ViewEditor.tsx
@@ -1,0 +1,165 @@
+import { useEffect, useState } from "react";
+
+import { api } from "../api";
+import { Combo } from "./bits";
+import type { View, ViewFilter } from "../types";
+
+// The one view editor, used in place: on /views/new (create) and on /views/<name> (edit).
+// Sources are picked one at a time — chips above, an add-picker below — so the control scales
+// with any number of sources instead of a wall of checkboxes.
+
+const NUMERIC_OPS = new Set(["gt", "lt", "gte", "lte"]);
+
+export default function ViewEditor({ initial, sourceNames, onSaved, onCancel }: {
+  initial?: View;                     // absent = create
+  sourceNames: string[];
+  onSaved: (name: string) => void;
+  onCancel: () => void;
+}) {
+  const isNew = !initial;
+  const [name, setName] = useState(initial?.name ?? "");
+  const [keyField, setKeyField] = useState(initial?.key_field ?? "");
+  const [sources, setSources] = useState<string[]>(initial?.sources ?? []);
+  const [pick, setPick] = useState("");
+  const [fRows, setFRows] = useState(
+    (initial?.filters ?? []).map((f) => ({ field: f.field, op: f.op as string, value: String(f.value) })));
+  const [labelOpts, setLabelOpts] = useState<string[]>([]);
+  const [fieldOpts, setFieldOpts] = useState<string[]>([]);
+  const [error, setError] = useState<string>();
+  const [busy, setBusy] = useState(false);
+
+  // suggest real field/label names from the selected sources
+  useEffect(() => {
+    if (!sources.length) { setLabelOpts([]); setFieldOpts([]); return; }
+    let live = true;
+    Promise.all(sources.map((s) => api.sourceFields(s).catch(() => null))).then((profiles) => {
+      if (!live) return;
+      const labels = new Set<string>();
+      const names = new Set<string>();
+      for (const p of profiles) for (const f of p?.fields ?? []) {
+        names.add(f.name);
+        if (f.is_label || f.is_key) labels.add(f.name);
+      }
+      setLabelOpts(Array.from(labels.size ? labels : names).sort());
+      setFieldOpts(Array.from(names).sort());
+    });
+    return () => { live = false; };
+  }, [sources.join("|")]);
+
+  const addSource = (s: string) => {
+    if (sourceNames.includes(s) && !sources.includes(s)) setSources([...sources, s]);
+    setPick("");
+  };
+  const remaining = sourceNames.filter((s) => !sources.includes(s));
+
+  const save = async () => {
+    setBusy(true);
+    setError(undefined);
+    const filters: ViewFilter[] = fRows.filter((r) => r.field.trim())
+      .map((r) => ({ field: r.field.trim(), op: r.op as ViewFilter["op"],
+                     value: NUMERIC_OPS.has(r.op) ? Number(r.value) : r.value }));
+    const body: View = { name: name.trim(), key_field: keyField.trim(), sources, filters };
+    try {
+      if (isNew) await api.createView(body);
+      else await api.updateView(initial!.name, body);
+      onSaved(body.name);
+    } catch (e) { setError(String((e as Error).message ?? e)); }
+    setBusy(false);
+  };
+
+  return (
+    <div className="panel">
+      {error && <div className="alert error">{error}</div>}
+
+      <label className="field" style={{ maxWidth: 340 }}>
+        <span className="lbl">name</span>
+        <input type="text" value={name} disabled={!isNew} placeholder="e.g. service_timeline"
+               onChange={(e) => setName(e.target.value)} />
+        <span className="help">agents query it by this name</span>
+      </label>
+
+      <div className="field">
+        <span className="lbl">sources to correlate</span>
+        <span className="help" style={{ display: "block", marginTop: 0, marginBottom: 6 }}>
+          events from every selected source merge into one time-ordered timeline
+        </span>
+        {sources.length > 0 && (
+          <div style={{ marginBottom: 6 }}>
+            {sources.map((s) => (
+              <span className="chip mono" key={s} style={{ paddingRight: 4 }}>
+                {s}{" "}
+                <button type="button" onClick={() => setSources(sources.filter((x) => x !== s))}
+                        style={{ border: "none", background: "none", padding: "0 2px", cursor: "pointer",
+                                 color: "var(--err)" }}
+                        title={`remove ${s}`}>×</button>
+              </span>
+            ))}
+          </div>
+        )}
+        {remaining.length > 0 ? (
+          <Combo style={{ maxWidth: 340 }} value={pick} options={remaining}
+                 placeholder={sources.length ? "add another source…" : "add a source…"}
+                 onChange={(v) => (remaining.includes(v) ? addSource(v) : setPick(v))} />
+        ) : sourceNames.length === 0 ? (
+          <span className="help">no sources yet — add one under Sources first</span>
+        ) : (
+          <span className="help">all sources selected</span>
+        )}
+      </div>
+
+      <div className="field" style={{ marginTop: 14 }}>
+        <span className="lbl">key field</span>
+        <span className="help" style={{ display: "block", marginTop: 0, marginBottom: 6 }}>
+          the label agents look an entity up by — pick one the selected sources share
+        </span>
+        <Combo value={keyField} options={labelOpts} style={{ maxWidth: 340 }}
+               placeholder={labelOpts.length ? `e.g. ${labelOpts[0]}` : "e.g. service"}
+               onChange={setKeyField} />
+        {labelOpts.length > 0 && (
+          <div style={{ marginTop: 6 }}>
+            {labelOpts.map((f) => (
+              <button key={f} type="button" className="chip"
+                      style={{ cursor: "pointer", marginRight: 6,
+                               outline: keyField === f ? "2px solid var(--accent)" : undefined }}
+                      onClick={() => setKeyField(f)}>
+                {f}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="field">
+        <span className="lbl">filters (optional)</span>
+        <span className="help" style={{ display: "block", marginTop: 0, marginBottom: 6 }}>
+          narrow what the view returns — applied on reads and trigger evaluation
+        </span>
+        {fRows.map((r, i) => (
+          <div key={i} className="btnrow" style={{ marginBottom: 6, alignItems: "center" }}>
+            <Combo value={r.field} options={fieldOpts} placeholder="field"
+                   style={{ maxWidth: 200, flex: 1 }}
+                   onChange={(v) => setFRows(fRows.map((x, j) => j === i ? { ...x, field: v } : x))} />
+            <select value={r.op} style={{ maxWidth: 130 }}
+                    onChange={(e) => setFRows(fRows.map((x, j) => j === i ? { ...x, op: e.target.value } : x))}>
+              {["eq", "neq", "contains", "gt", "lt", "gte", "lte"].map((o) => <option key={o} value={o}>{o}</option>)}
+            </select>
+            <input type="text" className="mono" style={{ maxWidth: 180 }} placeholder="value" value={r.value}
+                   onChange={(e) => setFRows(fRows.map((x, j) => j === i ? { ...x, value: e.target.value } : x))} />
+            <button type="button" className="danger" onClick={() => setFRows(fRows.filter((_, j) => j !== i))}>×</button>
+          </div>
+        ))}
+        <button type="button" onClick={() => setFRows([...fRows, { field: "", op: "eq", value: "" }])}>
+          + Add filter
+        </button>
+      </div>
+
+      <div className="btnrow">
+        <button className="primary" onClick={save}
+                disabled={busy || !name.trim() || !keyField.trim() || !sources.length}>
+          {isNew ? "Create view" : "Save changes"}
+        </button>
+        <button onClick={onCancel}>Cancel</button>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -9,6 +9,10 @@ import Ask from "./pages/Ask";
 import Explore from "./pages/Explore";
 import SourceClaudeCode from "./pages/SourceClaudeCode";
 import SourceDetail from "./pages/SourceDetail";
+import ViewDetail from "./pages/ViewDetail";
+import ViewNew from "./pages/ViewNew";
+import TriggerDetail from "./pages/TriggerDetail";
+import TriggerNew from "./pages/TriggerNew";
 import SourceDiscover from "./pages/SourceDiscover";
 import SourceNew from "./pages/SourceNew";
 import Security from "./pages/Security";
@@ -30,7 +34,11 @@ const router = createBrowserRouter([
       { path: "organize", element: <Navigate to="/ask" replace /> },
       { path: "explore", element: <Explore /> },
       { path: "views", element: <ViewsPage /> },
+      { path: "views/new", element: <ViewNew /> },
+      { path: "views/:name", element: <ViewDetail /> },
       { path: "triggers", element: <TriggersPage /> },
+      { path: "triggers/new", element: <TriggerNew /> },
+      { path: "triggers/:name", element: <TriggerDetail /> },
       { path: "connect", element: <ConnectPage /> },
       { path: "activity", element: <AgentActivity /> },
       { path: "agents", element: <Navigate to="/connect" replace /> },

--- a/ui/src/pages/Activity.tsx
+++ b/ui/src/pages/Activity.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useSearchParams } from "react-router-dom";
 
 import { api, auth } from "../api";
 import { Close, Search } from "../components/icons";
@@ -35,18 +35,18 @@ export function ConnectPage() {
   );
 }
 
-type ActivityTab = "queries" | "dispatches";
+type ActivityTab = "agents" | "queries" | "dispatches";
 const ACTIVITY_LABELS: Record<ActivityTab, string> = {
-  queries: "Reads", dispatches: "Trigger dispatches",
+  agents: "Agents", queries: "Reads", dispatches: "Trigger dispatches",
 };
 
 export default function AgentActivity() {
-  const [tab, setTab] = useState<ActivityTab>("queries");
+  const [tab, setTab] = useState<ActivityTab>("agents");
 
   return (
     <>
-      <h1>Activity</h1>
-      <p className="subtitle">what agents have been doing — every read, every trigger dispatch</p>
+      <h1>Agents</h1>
+      <p className="subtitle">who is connected, and what agents have been doing — every wake, read and dispatch</p>
 
       <div className="tabs">
         {(Object.keys(ACTIVITY_LABELS) as ActivityTab[]).map((t) => (
@@ -54,6 +54,7 @@ export default function AgentActivity() {
         ))}
       </div>
 
+      {tab === "agents" && <AgentsRoster />}
       {tab === "queries" && <Queries />}
       {tab === "dispatches" && <Dispatches />}
     </>
@@ -241,14 +242,11 @@ function Connect({ tab }: { tab: ConnectTab }) {
                 <span className="mono">read</span>-scoped <Link to="/security">API key</Link>;
                 revoking the key removes its subscriptions):
               </p>
-              {triggers.length > 1 && (
-                <label className="field" style={{ maxWidth: 300 }}>
-                  <span className="lbl">trigger</span>
-                  <select value={trig} onChange={(e) => setTrig(e.target.value)}>
-                    {triggers.map((t) => <option key={t.name} value={t.name}>{t.name}</option>)}
-                  </select>
-                </label>
-              )}
+              <p className="help" style={{ whiteSpace: "normal" }}>
+                Wiring happens on the trigger itself: open <Link to="/triggers">Triggers</Link>,
+                hit <strong>agents</strong> on the trigger, and paste your endpoint there. From a
+                script, the same action is:
+              </p>
               <CodeBlock title="subscribe your agent's endpoint" code={subscribeCurl(shownTok)} />
             </>
           ) : (
@@ -348,6 +346,87 @@ function Connect({ tab }: { tab: ConnectTab }) {
         </>
       )}
     </div>
+  );
+}
+
+function AgentsRoster() {
+  const { data, error } = usePolling(() => api.agents(), 10000);
+  const [params] = useSearchParams();
+  const [open, setOpen] = useState<string | undefined>(params.get("agent") ?? undefined);
+  const [err, setErr] = useState<string>();
+
+  if (error) return <div className="alert error">{error}</div>;
+  if (!data) return <div className="dim">loading…</div>;
+  if (!data.agents.length) {
+    return (
+      <div className="empty">
+        no agents connected — subscribe one to a trigger on the <Link to="/triggers">Triggers</Link> page
+      </div>
+    );
+  }
+  return (
+    <>
+      {err && <div className="alert error">{err}</div>}
+      <table>
+        <thead><tr><th>agent</th><th>endpoint</th><th>wakes on</th><th className="num">delivered</th><th className="num">failed</th><th>last woken</th><th></th></tr></thead>
+        <tbody>
+          {data.agents.map((a) => (
+            <>
+              <tr key={a.name} className="clickable" onClick={() => setOpen(open === a.name ? undefined : a.name)}>
+                <td><strong>{a.name}</strong></td>
+                <td className="mono">{a.endpoint}</td>
+                <td>{a.triggers.map((t) => <span className="chip mono" key={t}>{t}</span>)}</td>
+                <td className="num">{a.delivered_ok}</td>
+                <td className="num" style={a.delivered_fail ? { color: "var(--err)" } : undefined}>{a.delivered_fail}</td>
+                <td style={{ whiteSpace: "nowrap" }}>{a.last_woken ? <TimeAgo ts={a.last_woken} /> : <span className="help">never</span>}</td>
+                <td className="dim">{open === a.name ? "▾" : "▸"}</td>
+              </tr>
+              {open === a.name && (
+                <tr key={a.name + "-detail"}>
+                  <td colSpan={7} style={{ background: "var(--wash, transparent)" }}>
+                    <div style={{ padding: "8px 4px" }}>
+                      <p className="help" style={{ margin: "0 0 8px", whiteSpace: "normal" }}>
+                        first seen <TimeAgo ts={a.first_seen} />
+                        {a.created_by.length > 0 && <> · wired by <span className="mono">{a.created_by.join(", ")}</span></>}
+                      </p>
+                      {a.subscriptions.map((sub) => (
+                        <div key={sub.subscription_id} className="btnrow" style={{ marginBottom: 6, alignItems: "center" }}>
+                          <span className="chip mono">{sub.trigger}</span>
+                          <span className="help mono">{sub.subscription_id}</span>
+                          <button className="danger" onClick={async (e) => {
+                            e.stopPropagation();
+                            try { await api.unsubscribe(sub.subscription_id); }
+                            catch (ex) { setErr(String((ex as Error).message ?? ex)); }
+                          }}>unsubscribe</button>
+                        </div>
+                      ))}
+                      {a.recent.length > 0 && (
+                        <>
+                          <p className="help" style={{ margin: "10px 0 4px" }}>recent wakes</p>
+                          <table>
+                            <thead><tr><th>when</th><th>trigger</th><th>entity</th><th>delivery</th></tr></thead>
+                            <tbody>
+                              {a.recent.map((r, i) => (
+                                <tr key={i}>
+                                  <td style={{ whiteSpace: "nowrap" }}><TimeAgo ts={r.at} /></td>
+                                  <td className="mono">{r.trigger}</td>
+                                  <td className="mono">{r.key}</td>
+                                  <td>{r.ok ? <span className="badge ok">delivered</span> : <span className="badge error">failed</span>}</td>
+                                </tr>
+                              ))}
+                            </tbody>
+                          </table>
+                        </>
+                      )}
+                    </div>
+                  </td>
+                </tr>
+              )}
+            </>
+          ))}
+        </tbody>
+      </table>
+    </>
   );
 }
 

--- a/ui/src/pages/TriggerDetail.tsx
+++ b/ui/src/pages/TriggerDetail.tsx
@@ -1,0 +1,131 @@
+import { useState } from "react";
+import { Link, useParams, useSearchParams } from "react-router-dom";
+
+import { api } from "../api";
+import TriggerEditor from "../components/TriggerEditor";
+import { TimeAgo, usePolling } from "../components/bits";
+
+// The home of one trigger: condition, the agents it wakes (wire more here), recent firings.
+// Read-only by default; Edit swaps in the editor in place (?edit=1 opens it directly).
+export default function TriggerDetail() {
+  const { name = "" } = useParams();
+  const [params] = useSearchParams();
+  const [editing, setEditing] = useState(params.get("edit") === "1");
+  const { data: triggers, error, reload } = usePolling(() => api.triggers(), 10000);
+  const { data: agents } = usePolling(() => api.agents(), 10000);
+  const { data: dispatches } = usePolling(() => api.dispatches(100), 10000);
+  const [url, setUrl] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [msg, setMsg] = useState<string>();
+
+  if (error) return <div className="alert error">{error}</div>;
+  if (!triggers) return <div className="dim">loading…</div>;
+  const trigger = triggers.find((t) => t.name === name);
+  if (!trigger) {
+    return (
+      <div className="alert error">
+        no trigger named <span className="mono">{name}</span> — see <Link to="/triggers">Triggers</Link>
+      </div>
+    );
+  }
+  const wired = (agents?.agents ?? []).filter((a) => a.triggers.includes(name));
+  const firings = (dispatches ?? []).filter((d) => d.trigger === name).slice(0, 10);
+
+  return (
+    <>
+      <div className="pagehead">
+        <div>
+          <h1><span className="mono">{trigger.name}</span></h1>
+          <p className="subtitle">
+            watches <Link to={`/views/${encodeURIComponent(trigger.view)}`} className="mono">{trigger.view}</Link>
+            {" "}— fires when the condition trips, waking every subscribed agent
+          </p>
+        </div>
+        {!editing && <button className="primary" onClick={() => setEditing(true)}>Edit</button>}
+      </div>
+
+      {editing && (
+        <TriggerEditor initial={trigger}
+                       onSaved={() => { setEditing(false); reload(); }}
+                       onCancel={() => setEditing(false)} />
+      )}
+
+      {!editing && (
+        <div className="panel">
+          <table>
+            <tbody>
+              <tr><td className="help" style={{ width: 150 }}>condition</td>
+                  <td className="mono">
+                    {trigger.condition.aggregate}({trigger.condition.field || "*"}){" "}
+                    {trigger.condition.predicate} over {trigger.condition.window}
+                  </td></tr>
+              <tr><td className="help">context window</td>
+                  <td className="mono">{String(trigger.emit?.context_window ?? "15m")}
+                      <span className="help"> — timeline the woken agent receives</span></td></tr>
+              <tr><td className="help">cooldown</td>
+                  <td className="mono">{trigger.cooldown}
+                      <span className="help"> — minimum gap between firings per entity</span></td></tr>
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <h2>Agents woken by this trigger</h2>
+      {wired.length > 0 ? (
+        <table style={{ marginBottom: 10 }}>
+          <thead><tr><th>agent</th><th>endpoint</th><th className="num">delivered</th><th className="num">failed</th></tr></thead>
+          <tbody>
+            {wired.map((a) => (
+              <tr key={a.name}>
+                <td><Link to={`/activity?agent=${encodeURIComponent(a.name)}`}><strong>{a.name}</strong></Link></td>
+                <td className="mono">{a.endpoint}</td>
+                <td className="num">{a.delivered_ok}</td>
+                <td className="num" style={a.delivered_fail ? { color: "var(--err)" } : undefined}>{a.delivered_fail}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      ) : (
+        <p className="help" style={{ whiteSpace: "normal" }}>
+          none yet — every firing is still logged below
+        </p>
+      )}
+      <p className="help" style={{ margin: "4px 0" }}>
+        add an agent — its endpoint gets POSTed the timeline on every firing:
+      </p>
+      <div className="btnrow" style={{ alignItems: "center", maxWidth: 720 }}>
+        <input type="text" className="mono" style={{ flex: 1 }}
+               placeholder="https://your-agent.example.com/hook" value={url}
+               onChange={(e) => setUrl(e.target.value)} />
+        <button className="primary" disabled={!url.trim() || busy} onClick={async () => {
+          setBusy(true); setMsg(undefined);
+          try {
+            const r = await api.subscribe(name, url.trim());
+            setMsg(`✓ subscribed (${r.subscription_id})`);
+            setUrl("");
+          } catch (e) { setMsg(`⚠️ ${String((e as Error).message ?? e)}`); }
+          setBusy(false);
+        }}>Subscribe</button>
+      </div>
+      {msg && <p className="help">{msg}</p>}
+
+      <h2>Recent firings</h2>
+      {firings.length === 0 && <p className="help">none yet</p>}
+      {firings.length > 0 && (
+        <table>
+          <thead><tr><th>fired</th><th>entity</th><th className="num">subscribers</th><th className="num">delivered</th></tr></thead>
+          <tbody>
+            {firings.map((d) => (
+              <tr key={d.dispatch_id}>
+                <td style={{ whiteSpace: "nowrap" }}><TimeAgo ts={d.fired_at} /></td>
+                <td className="mono">{d.key}</td>
+                <td className="num">{d.subscribers}</td>
+                <td className="num">{d.delivered}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </>
+  );
+}

--- a/ui/src/pages/TriggerNew.tsx
+++ b/ui/src/pages/TriggerNew.tsx
@@ -1,0 +1,21 @@
+import { useNavigate, useSearchParams } from "react-router-dom";
+
+import TriggerEditor from "../components/TriggerEditor";
+
+export default function TriggerNew() {
+  const nav = useNavigate();
+  const [params] = useSearchParams();
+
+  return (
+    <>
+      <h1>New trigger</h1>
+      <p className="subtitle">
+        a condition NavFlow evaluates continuously over a view — when it trips, subscribed agents
+        are woken with the correlated timeline
+      </p>
+      <TriggerEditor presetView={params.get("view") ?? undefined}
+                     onSaved={(name) => nav(`/triggers/${encodeURIComponent(name)}`)}
+                     onCancel={() => nav("/triggers")} />
+    </>
+  );
+}

--- a/ui/src/pages/ViewDetail.tsx
+++ b/ui/src/pages/ViewDetail.tsx
@@ -1,0 +1,106 @@
+import { useState } from "react";
+import { Link, useParams, useSearchParams } from "react-router-dom";
+
+import { api } from "../api";
+import ViewEditor from "../components/ViewEditor";
+import { TimeAgo, usePolling } from "../components/bits";
+
+// The home of one view: read-only by default (definition, usage, watching triggers), with
+// in-place editing via the Edit button (?edit=1 opens it directly, e.g. from the list).
+export default function ViewDetail() {
+  const { name = "" } = useParams();
+  const [params] = useSearchParams();
+  const [editing, setEditing] = useState(params.get("edit") === "1");
+  const { data: views, error, reload } = usePolling(() => api.views(), 10000);
+  const { data: triggers } = usePolling(() => api.triggers(), 10000);
+  const { data: sources } = usePolling(() => api.sources(), 15000);
+
+  if (error) return <div className="alert error">{error}</div>;
+  if (!views) return <div className="dim">loading…</div>;
+  const view = views.find((v) => v.name === name);
+  if (!view) {
+    return (
+      <div className="alert error">
+        no view named <span className="mono">{name}</span> — see <Link to="/views">Views</Link>
+      </div>
+    );
+  }
+  const watchers = (triggers ?? []).filter((t) => t.view === name);
+
+  return (
+    <>
+      <div className="pagehead">
+        <div>
+          <h1><span className="mono">{view.name}</span></h1>
+          <p className="subtitle">
+            one read returns the correlated timeline of a <span className="mono">{view.key_field}</span>
+          </p>
+        </div>
+        <span className="btnrow">
+          <Link className="btn" to={`/triggers/new?view=${encodeURIComponent(view.name)}`}>+ trigger</Link>
+          {!editing && <button className="primary" onClick={() => setEditing(true)}>Edit</button>}
+        </span>
+      </div>
+
+      {editing && (
+        <ViewEditor initial={view} sourceNames={(sources ?? []).map((x) => x.name)}
+                    onSaved={() => { setEditing(false); reload(); }}
+                    onCancel={() => setEditing(false)} />
+      )}
+
+      {!editing && (
+      <div className="panel">
+        <table>
+          <tbody>
+            <tr><td className="help" style={{ width: 140 }}>key field</td>
+                <td className="mono">{view.key_field}</td></tr>
+            <tr><td className="help">sources</td>
+                <td>{view.sources.map((s) => (
+                  <Link key={s} to={`/sources/${s}`} className="chip mono">{s}</Link>))}</td></tr>
+            <tr><td className="help">filters</td>
+                <td className="mono">
+                  {(view.filters ?? []).length
+                    ? (view.filters ?? []).map((f, i) => (
+                        <span className="chip" key={i}>{f.field} {f.op} {String(f.value)}</span>))
+                    : <span className="help">none — everything the sources carry</span>}
+                </td></tr>
+            <tr><td className="help">author</td>
+                <td>{(view.created_by ?? "human").startsWith("agent")
+                      ? <span className="badge agent">agent</span>
+                      : <span className="badge starting">human</span>}</td></tr>
+            <tr><td className="help">usage</td>
+                <td>{view.usage?.queries
+                      ? <>{view.usage.queries} quer{view.usage.queries === 1 ? "y" : "ies"}
+                          {view.usage.last_used_at && <> · last <TimeAgo ts={view.usage.last_used_at} /></>}</>
+                      : <span className="help">never queried</span>}</td></tr>
+          </tbody>
+        </table>
+      </div>
+      )}
+
+      <h2>Triggers watching this view</h2>
+      {watchers.length === 0 && (
+        <p className="help" style={{ whiteSpace: "normal" }}>
+          none — <Link to={`/triggers/new?view=${encodeURIComponent(view.name)}`}>create one</Link> to
+          wake agents when a condition trips on this timeline
+        </p>
+      )}
+      {watchers.length > 0 && (
+        <table>
+          <thead><tr><th>trigger</th><th>condition</th><th>cooldown</th></tr></thead>
+          <tbody>
+            {watchers.map((t) => (
+              <tr key={t.name}>
+                <td className="mono"><Link to={`/triggers/${encodeURIComponent(t.name)}`}>{t.name}</Link></td>
+                <td className="mono">
+                  {t.condition.aggregate}({t.condition.field ?? "*"}) {t.condition.predicate} over {t.condition.window}
+                </td>
+                <td className="mono">{t.cooldown}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </>
+  );
+}

--- a/ui/src/pages/ViewNew.tsx
+++ b/ui/src/pages/ViewNew.tsx
@@ -1,0 +1,22 @@
+import { useNavigate } from "react-router-dom";
+
+import { api } from "../api";
+import ViewEditor from "../components/ViewEditor";
+import { usePolling } from "../components/bits";
+
+export default function ViewNew() {
+  const nav = useNavigate();
+  const { data: sources } = usePolling(() => api.sources(), 15000);
+
+  return (
+    <>
+      <h1>New view</h1>
+      <p className="subtitle">
+        pick the sources to correlate and the label agents will look entities up by
+      </p>
+      <ViewEditor sourceNames={(sources ?? []).map((s) => s.name)}
+                  onSaved={(name) => nav(`/views/${encodeURIComponent(name)}`)}
+                  onCancel={() => nav("/views")} />
+    </>
+  );
+}

--- a/ui/src/pages/ViewsTriggers.tsx
+++ b/ui/src/pages/ViewsTriggers.tsx
@@ -1,26 +1,23 @@
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 
 import { api } from "../api";
 import ConfirmDialog from "../components/ConfirmDialog";
 import { Search } from "../components/icons";
-import { Combo, TimeAgo, usePolling } from "../components/bits";
-import type { Trigger, View, ViewFilter } from "../types";
-
-const AGGREGATES = ["max", "min", "sum", "avg", "count", "any"];
+import { TimeAgo, usePolling } from "../components/bits";
+import type { Trigger, View } from "../types";
 
 // Views and Triggers are two acts of "serve to agents": a view is a saved read; a trigger wakes
 // an agent when that read crosses a line. They are separate pages so each concept stands alone.
 
 export function ViewsPage() {
   const { data: views, reload } = usePolling(() => api.views(), 10000);
-  const { data: sources } = usePolling(() => api.sources(), 10000);
 
   return (
     <>
       <h1>Views</h1>
       <p className="subtitle">saved reads — <em>the queries you hand agents</em></p>
-      <ViewsSection views={views ?? []} sourceNames={(sources ?? []).map((s) => s.name)} onChange={reload} />
+      <ViewsSection views={views ?? []} onChange={reload} />
     </>
   );
 }
@@ -33,7 +30,8 @@ export function TriggersPage() {
     <>
       <h1>Triggers</h1>
       <p className="subtitle">conditions that <em>wake an agent</em> with a timeline</p>
-      <TriggersSection triggers={triggers ?? []} viewNames={(views ?? []).map((v) => v.name)} onChange={reload} />
+      <TriggersSection triggers={triggers ?? []} viewNames={(views ?? []).map((v) => v.name)}
+                       onChange={reload} />
     </>
   );
 }
@@ -54,16 +52,6 @@ function FilterBar({ q, setQ, placeholder, shown, total }: {
   );
 }
 
-/** Esc-to-close for an open editor sheet. */
-function useEscape(active: boolean, close: () => void) {
-  useEffect(() => {
-    if (!active) return;
-    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") close(); };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [active, close]);
-}
-
 // ── views ────────────────────────────────────────────────────────────────────
 
 function AuthorBadge({ createdBy }: { createdBy?: string }) {
@@ -76,40 +64,11 @@ function AuthorBadge({ createdBy }: { createdBy?: string }) {
   );
 }
 
-function ViewsSection({ views, sourceNames, onChange }:
-  { views: View[]; sourceNames: string[]; onChange: () => void }) {
-  const [editing, setEditing] = useState<View | null>(null);
-  const [isNew, setIsNew] = useState(false);
+function ViewsSection({ views, onChange }:
+  { views: View[]; onChange: () => void }) {
   const [error, setError] = useState<string>();
-  const [fRows, setFRows] = useState<Array<{ field: string; op: string; value: string }>>([]);
-  const [labelOpts, setLabelOpts] = useState<string[]>([]);   // entity labels/keys — key_field candidates
-  const [fieldOpts, setFieldOpts] = useState<string[]>([]);   // every field — for filter rows
   const [q, setQ] = useState("");
   const [confirmDelName, setConfirmDelName] = useState<string | null>(null);
-
-  // Suggest real field/label names from the selected sources, so key_field and filters are
-  // picked rather than guessed.
-  useEffect(() => {
-    if (!editing?.sources.length) { setLabelOpts([]); setFieldOpts([]); return; }
-    let live = true;
-    Promise.all(editing.sources.map((s) => api.sourceFields(s).catch(() => null)))
-      .then((profiles) => {
-        if (!live) return;
-        const labels = new Set<string>();
-        const names = new Set<string>();
-        for (const p of profiles) {
-          for (const f of p?.fields ?? []) {
-            names.add(f.name);
-            if (f.is_label || f.is_key) labels.add(f.name);   // only entity axes fit key_field
-          }
-        }
-        // sources created without declared labels flag nothing — fall back to every field
-        // rather than suggesting nothing at all
-        setLabelOpts(Array.from(labels.size ? labels : names).sort());
-        setFieldOpts(Array.from(names).sort());
-      });
-    return () => { live = false; };
-  }, [editing?.sources.join("|")]);
 
   const shown = useMemo(() => {
     const needle = q.trim().toLowerCase();
@@ -118,35 +77,6 @@ function ViewsSection({ views, sourceNames, onChange }:
       v.key_field.toLowerCase().includes(needle) ||
       v.sources.join(" ").toLowerCase().includes(needle));
   }, [views, q]);
-
-  const close = () => { setEditing(null); setError(undefined); };
-  useEscape(!!editing, close);
-
-  const openEditor = (v: View, fresh: boolean) => {
-    setEditing({ ...v });
-    setIsNew(fresh);
-    setError(undefined);
-    setFRows((v.filters ?? []).map((f) => ({ field: f.field, op: f.op, value: String(f.value) })));
-  };
-
-  const NUMERIC_OPS = new Set(["gt", "lt", "gte", "lte"]);
-  const buildFilters = (): ViewFilter[] =>
-    fRows.filter((r) => r.field.trim())
-      .map((r) => ({ field: r.field.trim(), op: r.op as ViewFilter["op"],
-                     value: NUMERIC_OPS.has(r.op) ? Number(r.value) : r.value }));
-
-  const save = async () => {
-    if (!editing) return;
-    setError(undefined);
-    const filters = buildFilters();
-    const body = { ...editing, filters };
-    try {
-      if (isNew) await api.createView(body);
-      else await api.updateView(editing.name, body);
-      close();
-      onChange();
-    } catch (e) { setError(String((e as Error).message ?? e)); }
-  };
 
   const del = async (name: string) => {
     setError(undefined);
@@ -158,106 +88,11 @@ function ViewsSection({ views, sourceNames, onChange }:
     <>
       <div className="pagehead">
         <span />
-        <button disabled={!!editing}
-                onClick={() => openEditor({ name: "", key_field: "", sources: [] }, true)}>
-          Add view
-        </button>
+        <Link className="btn primary" to="/views/new">Add view</Link>
       </div>
-      {error && !editing && <div className="alert error">{error}</div>}
+      {error && <div className="alert error">{error}</div>}
 
-      {editing && (
-        <div className="panel" style={{ marginBottom: 18 }}>
-          <div className="pagehead" style={{ marginBottom: 8 }}>
-            <h2 style={{ margin: 0 }}>{isNew ? "New view" : <>Edit <span className="mono">{editing.name}</span></>}</h2>
-            <button onClick={close}>Cancel</button>
-          </div>
-          {error && <div className="alert error">{error}</div>}
-
-          <label className="field" style={{ maxWidth: 340 }}>
-            <span className="lbl">name</span>
-            <input type="text" value={editing.name} disabled={!isNew} placeholder="e.g. service_timeline"
-                   onChange={(e) => setEditing({ ...editing, name: e.target.value })} />
-            <span className="help">agents query it by this name</span>
-          </label>
-
-          <div className="field">
-            <span className="lbl">sources to correlate</span>
-            <span className="help" style={{ display: "block", marginTop: 0, marginBottom: 6 }}>
-              events from every ticked source merge into one time-ordered timeline
-            </span>
-            {sourceNames.length === 0 && <span className="help">no sources yet — add one under Sources first</span>}
-            {sourceNames.map((s) => (
-              <label key={s} style={{ display: "inline-flex", gap: 6, marginRight: 16, marginBottom: 4, alignItems: "center" }}>
-                <input type="checkbox" checked={editing.sources.includes(s)}
-                       onChange={(e) => setEditing({
-                         ...editing,
-                         sources: e.target.checked
-                           ? [...editing.sources, s]
-                           : editing.sources.filter((x) => x !== s),
-                       })} />
-                <span className="mono">{s}</span>
-              </label>
-            ))}
-          </div>
-
-          <div className="field" style={{ marginTop: 14 }}>
-            <span className="lbl">key field</span>
-            <span className="help" style={{ display: "block", marginTop: 0, marginBottom: 6 }}>
-              the label agents look an entity up by — pick one the ticked sources share
-            </span>
-            <Combo value={editing.key_field} options={labelOpts}
-                   style={{ maxWidth: 340 }}
-                   placeholder={labelOpts.length ? `e.g. ${labelOpts[0]}` : "e.g. service"}
-                   onChange={(v) => setEditing({ ...editing, key_field: v })} />
-            {labelOpts.length > 0 && (
-              <div style={{ marginTop: 6 }}>
-                {labelOpts.map((f) => (
-                  <button key={f} type="button" className="chip"
-                          style={{ cursor: "pointer", marginRight: 6,
-                                   outline: editing.key_field === f ? "2px solid var(--accent)" : undefined }}
-                          onClick={() => setEditing({ ...editing, key_field: f })}>
-                    {f}
-                  </button>
-                ))}
-              </div>
-            )}
-          </div>
-
-          <div className="field">
-            <span className="lbl">filters (optional)</span>
-            <span className="help" style={{ display: "block", marginTop: 0, marginBottom: 6 }}>
-              narrow what the view returns — applied on reads and trigger evaluation
-            </span>
-            {fRows.map((r, i) => (
-              <div key={i} className="btnrow" style={{ marginBottom: 6, alignItems: "center" }}>
-                <Combo value={r.field} options={fieldOpts} placeholder="field"
-                       style={{ maxWidth: 200, flex: 1 }}
-                       onChange={(v) => setFRows(fRows.map((x, j) => j === i ? { ...x, field: v } : x))} />
-                <select value={r.op} style={{ maxWidth: 130 }}
-                        onChange={(e) => setFRows(fRows.map((x, j) => j === i ? { ...x, op: e.target.value } : x))}>
-                  {["eq", "neq", "contains", "gt", "lt", "gte", "lte"].map((o) => <option key={o} value={o}>{o}</option>)}
-                </select>
-                <input type="text" className="mono" style={{ maxWidth: 180 }} placeholder="value" value={r.value}
-                       onChange={(e) => setFRows(fRows.map((x, j) => j === i ? { ...x, value: e.target.value } : x))} />
-                <button type="button" className="danger" onClick={() => setFRows(fRows.filter((_, j) => j !== i))}>×</button>
-              </div>
-            ))}
-            <button type="button" onClick={() => setFRows([...fRows, { field: "", op: "eq", value: "" }])}>
-              + Add filter
-            </button>
-          </div>
-
-          <div className="btnrow">
-            <button className="primary" onClick={save}
-                    disabled={!editing.name.trim() || !editing.key_field.trim() || !editing.sources.length}>
-              {isNew ? "Create view" : "Save"}
-            </button>
-            <button onClick={close}>Cancel</button>
-          </div>
-        </div>
-      )}
-
-      {!views.length && !editing && <div className="empty">no views — agents have nothing to query yet</div>}
+      {!views.length && <div className="empty">no views — agents have nothing to query yet</div>}
       {!!views.length && (
         <>
           <FilterBar q={q} setQ={setQ} placeholder="Filter by name, key, source…" shown={shown.length} total={views.length} />
@@ -266,7 +101,7 @@ function ViewsSection({ views, sourceNames, onChange }:
             <tbody>
               {shown.map((v) => (
                 <tr key={v.name}>
-                  <td className="mono">{v.name}</td>
+                  <td className="mono"><Link to={`/views/${encodeURIComponent(v.name)}`}>{v.name}</Link></td>
                   <td><AuthorBadge createdBy={v.created_by} /></td>
                   <td className="mono">{v.key_field}</td>
                   <td>{v.sources.map((s) => <span className="chip" key={s}>{s}</span>)}</td>
@@ -283,7 +118,9 @@ function ViewsSection({ views, sourceNames, onChange }:
                   </td>
                   <td style={{ textAlign: "right", whiteSpace: "nowrap" }}>
                     <span className="btnrow" style={{ justifyContent: "flex-end" }}>
-                      <button onClick={() => openEditor(v, false)}>edit</button>
+                      <Link className="btn" to={`/triggers/new?view=${encodeURIComponent(v.name)}`}
+                            title="create a trigger watching this view">+ trigger</Link>
+                      <Link className="btn" to={`/views/${encodeURIComponent(v.name)}?edit=1`}>edit</Link>
                       <button className="danger" onClick={() => setConfirmDelName(v.name)}>delete</button>
                     </span>
                   </td>
@@ -310,17 +147,8 @@ function ViewsSection({ views, sourceNames, onChange }:
 
 // ── triggers ─────────────────────────────────────────────────────────────────
 
-const emptyTrigger = (view: string): Trigger => ({
-  name: "", view,
-  condition: { aggregate: "max", predicate: "> 1.0", window: "1m", field: "" },
-  emit: { kind: "", context_window: "15m" },
-  cooldown: "5m",
-});
-
 function TriggersSection({ triggers, viewNames, onChange }:
   { triggers: Trigger[]; viewNames: string[]; onChange: () => void }) {
-  const [editing, setEditing] = useState<Trigger | null>(null);
-  const [isNew, setIsNew] = useState(false);
   const [error, setError] = useState<string>();
   const [q, setQ] = useState("");
   const [confirmDelName, setConfirmDelName] = useState<string | null>(null);
@@ -330,27 +158,8 @@ function TriggersSection({ triggers, viewNames, onChange }:
     return triggers.filter((t) => !needle ||
       t.name.toLowerCase().includes(needle) ||
       t.view.toLowerCase().includes(needle) ||
-      `${t.condition.aggregate} ${t.condition.field ?? ""} ${t.condition.predicate}`.toLowerCase().includes(needle));
+      `${t.condition.aggregate}${t.condition.field ?? ""}${t.condition.predicate}`.toLowerCase().includes(needle));
   }, [triggers, q]);
-
-  const close = () => { setEditing(null); setError(undefined); };
-  useEscape(!!editing, close);
-
-  const save = async () => {
-    if (!editing) return;
-    setError(undefined);
-    const body: Trigger = {
-      ...editing,
-      condition: { ...editing.condition, field: editing.condition.field || null },
-      emit: { ...editing.emit, kind: editing.emit.kind || editing.name },
-    };
-    try {
-      if (isNew) await api.createTrigger(body);
-      else await api.updateTrigger(editing.name, body);
-      close();
-      onChange();
-    } catch (e) { setError(String((e as Error).message ?? e)); }
-  };
 
   const del = async (name: string) => {
     setError(undefined);
@@ -362,95 +171,22 @@ function TriggersSection({ triggers, viewNames, onChange }:
     <>
       <div className="pagehead">
         <span />
-        <button disabled={!viewNames.length}
-                title={viewNames.length ? undefined : "a trigger watches a view — create a view first"}
-                onClick={() => { setEditing(emptyTrigger(viewNames[0])); setIsNew(true); setError(undefined); }}>
+        <Link className="btn primary" to="/triggers/new"
+              style={!viewNames.length ? { pointerEvents: "none", opacity: 0.5 } : undefined}
+              title={viewNames.length ? undefined : "a trigger watches a view — create a view first"}>
           Add trigger
-        </button>
+        </Link>
       </div>
-      {error && !editing && <div className="alert error">{error}</div>}
+      {error && <div className="alert error">{error}</div>}
 
       {!viewNames.length && (
         <div className="alert">
           A trigger is a condition evaluated over a <strong>view</strong>, and this instance has no
-          views yet — <Link to="/views">create a view</Link> first (pick the sources and the entity
-          key it correlates by), then come back and add a trigger on it.
+          views yet — <Link to="/views/new">create a view</Link> first (pick the sources and the
+          entity key it correlates by), then come back and add a trigger on it.
         </div>
       )}
-
-      {editing && (
-        <div className="panel" style={{ marginBottom: 18 }}>
-          <div className="pagehead" style={{ marginBottom: 8 }}>
-            <h2 style={{ margin: 0 }}>{isNew ? "New trigger" : <>Edit <span className="mono">{editing.name}</span></>}</h2>
-            <button onClick={close}>Cancel</button>
-          </div>
-          {error && <div className="alert error">{error}</div>}
-          <div className="row2">
-            <label className="field">
-              <span className="lbl">name</span>
-              <input type="text" value={editing.name} disabled={!isNew} placeholder="e.g. error_spike"
-                     onChange={(e) => setEditing({ ...editing, name: e.target.value })} />
-            </label>
-            <label className="field">
-              <span className="lbl">view</span>
-              <select value={editing.view} onChange={(e) => setEditing({ ...editing, view: e.target.value })}>
-                {viewNames.map((v) => <option key={v} value={v}>{v}</option>)}
-              </select>
-            </label>
-          </div>
-          <div className="row2">
-            <label className="field">
-              <span className="lbl">aggregate</span>
-              <select value={editing.condition.aggregate}
-                      onChange={(e) => setEditing({ ...editing, condition: { ...editing.condition, aggregate: e.target.value } })}>
-                {AGGREGATES.map((a) => <option key={a} value={a}>{a}</option>)}
-              </select>
-            </label>
-            <label className="field">
-              <span className="lbl">field</span>
-              <input type="text" value={editing.condition.field ?? ""}
-                     placeholder="e.g. rate_5xx (empty for count)"
-                     onChange={(e) => setEditing({ ...editing, condition: { ...editing.condition, field: e.target.value } })} />
-            </label>
-          </div>
-          <div className="row2">
-            <label className="field">
-              <span className="lbl">predicate</span>
-              <input type="text" value={editing.condition.predicate}
-                     onChange={(e) => setEditing({ ...editing, condition: { ...editing.condition, predicate: e.target.value } })} />
-              <span className="help">e.g. &gt; 1.0, &gt;= 100, == 0</span>
-            </label>
-            <label className="field">
-              <span className="lbl">window</span>
-              <input type="text" value={editing.condition.window}
-                     onChange={(e) => setEditing({ ...editing, condition: { ...editing.condition, window: e.target.value } })} />
-              <span className="help">detection window, e.g. 1m</span>
-            </label>
-          </div>
-          <div className="row2">
-            <label className="field">
-              <span className="lbl">context window</span>
-              <input type="text" value={String(editing.emit.context_window ?? "15m")}
-                     onChange={(e) => setEditing({ ...editing, emit: { ...editing.emit, context_window: e.target.value } })} />
-              <span className="help">how much timeline the woken agent receives</span>
-            </label>
-            <label className="field">
-              <span className="lbl">cooldown</span>
-              <input type="text" value={editing.cooldown}
-                     onChange={(e) => setEditing({ ...editing, cooldown: e.target.value })} />
-              <span className="help">minimum gap between firings per key</span>
-            </label>
-          </div>
-          <div className="btnrow">
-            <button className="primary" onClick={save} disabled={!editing.name.trim()}>
-              {isNew ? "Create trigger" : "Save"}
-            </button>
-            <button onClick={close}>Cancel</button>
-          </div>
-        </div>
-      )}
-
-      {!triggers.length && !!viewNames.length && !editing && <div className="empty">no triggers — nothing wakes agents yet</div>}
+      {!triggers.length && !!viewNames.length && <div className="empty">no triggers — nothing wakes agents yet</div>}
       {!!triggers.length && (
         <>
           <FilterBar q={q} setQ={setQ} placeholder="Filter by name, view, condition…" shown={shown.length} total={triggers.length} />
@@ -459,19 +195,16 @@ function TriggersSection({ triggers, viewNames, onChange }:
             <tbody>
               {shown.map((t) => (
                 <tr key={t.name}>
-                  <td className="mono">{t.name}</td>
-                  <td className="mono">{t.view}</td>
+                  <td className="mono"><Link to={`/triggers/${encodeURIComponent(t.name)}`}>{t.name}</Link></td>
+                  <td className="mono"><Link to={`/views/${encodeURIComponent(t.view)}`}>{t.view}</Link></td>
                   <td className="mono">
                     {t.condition.aggregate}({t.condition.field ?? "*"}) {t.condition.predicate} over {t.condition.window}
                   </td>
                   <td className="mono">{t.cooldown}</td>
                   <td style={{ textAlign: "right", whiteSpace: "nowrap" }}>
                     <span className="btnrow" style={{ justifyContent: "flex-end" }}>
-                      <button onClick={() => {
-                        setEditing({ ...t, condition: { ...t.condition }, emit: { ...t.emit } });
-                        setIsNew(false);
-                        setError(undefined);
-                      }}>edit</button>
+                      <Link className="btn" to={`/triggers/${encodeURIComponent(t.name)}`}>agents</Link>
+                      <Link className="btn" to={`/triggers/${encodeURIComponent(t.name)}?edit=1`}>edit</Link>
                       <button className="danger" onClick={() => setConfirmDelName(t.name)}>delete</button>
                     </span>
                   </td>

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -280,6 +280,19 @@ td .dim, .dim { color: var(--ink-faint); }
 .badge.agent { background: var(--accent-soft); color: var(--accent-deep); }   /* agent / MCP provenance */
 .badge.starting { background: var(--starting-bg); color: var(--ink-soft); }
 
+/* content links — editorial, never browser-blue and never alarm-red: ink text with a faint
+   underline; the accent only appears on hover. Element-level, so every classed link
+   (.btn, .chip, sidebar, crumbs) keeps its own styling by specificity. */
+a {
+  color: var(--ink);
+  text-decoration: underline;
+  text-decoration-color: var(--line);
+  text-underline-offset: 3px;
+}
+a:hover { text-decoration-color: var(--accent); }
+a.chip { text-decoration: none; }
+a.chip:hover { border-color: var(--accent); }
+
 .chip {
   display: inline-block;
   font-family: var(--mono);

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -119,6 +119,20 @@ export interface DiscoverProposal {
   proposed_config: { url: string; default_key: string; queries: unknown[]; labels: { name: string; field: string }[] };
 }
 
+// A connected agent: subscriptions grouped by endpoint, named deterministically server-side.
+export interface AgentInfo {
+  name: string;
+  endpoint: string;   // masked — the last path segment may carry a secret
+  subscriptions: { subscription_id: string; trigger: string; created_at: string | null }[];
+  triggers: string[];
+  created_by: string[];
+  first_seen: string | null;
+  delivered_ok: number;
+  delivered_fail: number;
+  last_woken: string | null;
+  recent: { at: string | null; ok: boolean; trigger: string | null; key: string | null }[];
+}
+
 export interface ApiKey {
   id: string;
   name: string;


### PR DESCRIPTION
The section becomes a pipeline (nav: Views → Triggers → Agents → Connect), every noun gets a page, and connected agents get identity:

**Named agents + delivery history**
- New `dispatch_deliveries` table: the dispatcher records every per-subscriber outcome (previously only aggregates — a dead endpoint was invisible).
- `GET /api/agents`: subscriptions grouped by endpoint into named agents — deterministic nautical names hashed from the normalized URL, secrets in hook paths masked server-side (raw subscriber URLs no longer reach the browser).
- Agents page (formerly Activity): roster tab first — name, endpoint, trigger chips, wiring credential, delivered/failed, last woken; expand for per-subscription unsubscribe and recent wakes. Reads/Dispatches tabs unchanged. Deep-linkable (?agent=).

**Dedicated pages with in-place editing**
- `/views/<name>`: read-only home (definition, usage, watching triggers) with Edit swapping the editor in place; `/views/new` for creation. Source selection is now chips + an add-picker (scales past checkbox walls).
- `/triggers/<name>`: condition, the agents it wakes + subscribe form, recent firings; in-place Edit; `/triggers/new` honoring ?view= from every "+ trigger" hand-off.
- Views/Triggers list pages are now purely lists; shared ViewEditor/TriggerEditor components.

**Trigger condition field is finally usable**
- Suggested from the selected view's sources' NUMERIC typed fields (catalog schema — the namespace aggregates actually compute over), with honest empty states.
- store.aggregate: quoted JSON path so dotted fields (http.status_code) work in conditions; field name validated (closes an interpolation hole).

**Plus**: editorial link styling (ink + faint underline, accent on hover — no browser-blue, no alarm-red), full cross-linking (source ↔ view ↔ trigger ↔ agent), Connect demoted to pure documentation.