### PR TITLE
View filters: resolve labels, allow dotted raw fields

### DIFF
--- a/navflow/config.py
+++ b/navflow/config.py
@@ -287,7 +287,7 @@ def validate_source_dict(s: dict) -> None:
 
 
 _FILTER_OPS = {"eq", "neq", "contains", "gt", "lt", "gte", "lte"}
-_FILTER_FIELD_RE = re.compile(r"^[A-Za-z0-9_]+$")
+_FILTER_FIELD_RE = re.compile(r"^[A-Za-z0-9_.]+$")   # dots: raw payload fields (OTLP et al.)
 
 
 def validate_view_dict(v: dict, source_names: set) -> None:
@@ -305,7 +305,7 @@ def validate_view_dict(v: dict, source_names: set) -> None:
                 f"view {v['name']!r}: each filter needs field, op and value (got {f!r})")
         if not _FILTER_FIELD_RE.match(str(f["field"])):
             raise CatalogError(
-                f"view {v['name']!r}: filter field {f['field']!r} must be alphanumeric/_")
+                f"view {v['name']!r}: filter field {f['field']!r} must be alphanumeric/_/.")
         if f["op"] not in _FILTER_OPS:
             raise CatalogError(
                 f"view {v['name']!r}: filter op must be one of {sorted(_FILTER_OPS)}")

--- a/navflow/connectors/claude_code.py
+++ b/navflow/connectors/claude_code.py
@@ -13,6 +13,7 @@ the plugin, which covers both local and remote NavFlow with one path.
 """
 from __future__ import annotations
 
+import json
 import re
 from datetime import datetime
 from pathlib import Path

--- a/navflow/store.py
+++ b/navflow/store.py
@@ -123,6 +123,7 @@ _MIGRATIONS = [
 _FILTER_COLS = {"event_type", "source", "text", "key_value"}
 _FILTER_OPS = {"eq": "=", "neq": "!=", "gt": ">", "lt": "<", "gte": ">=", "lte": "<="}
 _FIELD_RE = re.compile(r"^[A-Za-z0-9_]+$")
+_DOTTED_FIELD_RE = re.compile(r"^[A-Za-z0-9_.]+$")
 
 
 def _label_expr(name: str) -> str:
@@ -145,18 +146,22 @@ def _where_sql(where) -> tuple[str, list]:
 
 
 def _filter_sql(filters) -> tuple[str, list]:
-    """View filters -> ('AND ...' SQL fragment, params). Non-envelope fields read fields.<name>;
-    numeric ops cast to DOUBLE (TRY_CAST: rows without the field simply don't match)."""
+    """View filters -> ('AND ...' SQL fragment, params). A field name resolves against the
+    extracted labels first, then the raw payload fields (COALESCE) — so `service` matches the
+    label a user defined even when the raw event only carries `resourceAttributes.service.name`.
+    JSON paths are quoted so dotted names address one flat key, not a nested object. Numeric ops
+    cast to DOUBLE (TRY_CAST: rows without the field simply don't match)."""
     clauses, params = [], []
     for f in filters or []:
         name, op, value = f["field"], f["op"], f["value"]
-        if not _FIELD_RE.match(name):
+        if not _DOTTED_FIELD_RE.match(name):
             raise ValueError(f"bad filter field {name!r}")
         numeric = op in ("gt", "lt", "gte", "lte")
         if name in _FILTER_COLS:
             expr = f"TRY_CAST({name} AS DOUBLE)" if numeric else name
         else:
-            expr = f"json_extract_string(fields, '$.{name}')"
+            expr = (f"COALESCE(json_extract_string(labels, '$.\"{name}\"'), "
+                    f"json_extract_string(fields, '$.\"{name}\"'))")
             if numeric:
                 expr = f"TRY_CAST({expr} AS DOUBLE)"
         if op == "contains":

--- a/ui/src/components/ViewEditor.tsx
+++ b/ui/src/components/ViewEditor.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 
 import { api } from "../api";
 import { Combo } from "./bits";
-import type { View, ViewFilter } from "../types";
+import type { ConnectorSpec, View, ViewFilter } from "../types";
 
 // The one view editor, used in place: on /views/new (create) and on /views/<name> (edit).
 // Sources are picked one at a time — chips above, an add-picker below — so the control scales
@@ -28,20 +28,35 @@ export default function ViewEditor({ initial, sourceNames, onSaved, onCancel }: 
   const [error, setError] = useState<string>();
   const [busy, setBusy] = useState(false);
 
-  // suggest real field/label names from the selected sources
+  // The key field must be a LABEL name (what extract_labels produces), never a raw payload
+  // field — so suggest labels from the source definitions: config.labels plus any labels the
+  // connector synthesizes (`provides`). Keys should be shared, so intersect across the selected
+  // sources (ignoring sources that declare no labels rather than zeroing the intersection).
+  // Filters accept both namespaces (label first, raw field second) — list labels, then raw names.
   useEffect(() => {
     if (!sources.length) { setLabelOpts([]); setFieldOpts([]); return; }
     let live = true;
-    Promise.all(sources.map((s) => api.sourceFields(s).catch(() => null))).then((profiles) => {
+    Promise.all([
+      api.sources().catch(() => []),
+      api.connectors().catch(() => ({}) as Record<string, ConnectorSpec>),
+      Promise.all(sources.map((s) => api.sourceFields(s).catch(() => null))),
+    ]).then(([all, specs, profiles]) => {
       if (!live) return;
-      const labels = new Set<string>();
-      const names = new Set<string>();
-      for (const p of profiles) for (const f of p?.fields ?? []) {
-        names.add(f.name);
-        if (f.is_label || f.is_key) labels.add(f.name);
-      }
-      setLabelOpts(Array.from(labels.size ? labels : names).sort());
-      setFieldOpts(Array.from(names).sort());
+      const perSource = sources.map((name) => {
+        const src = all.find((s) => s.name === name);
+        const declared = ((src?.config?.labels as { name?: string }[] | undefined) ?? [])
+          .map((l) => l.name).filter((n): n is string => !!n);
+        const provided = (src && specs[src.connector]?.provides?.map((p) => p.name)) ?? [];
+        return new Set([...declared, ...provided]);
+      }).filter((s) => s.size > 0);
+      const shared = perSource.length
+        ? [...perSource[0]].filter((n) => perSource.every((s) => s.has(n)))
+        : [];
+      const union = new Set(perSource.flatMap((s) => [...s]));
+      const raw = new Set<string>();
+      for (const p of profiles) for (const f of p?.fields ?? []) raw.add(f.name);
+      setLabelOpts((shared.length ? shared : [...union]).sort());
+      setFieldOpts([...[...union].sort(), ...[...raw].filter((n) => !union.has(n)).sort()]);
     });
     return () => { live = false; };
   }, [sources.join("|")]);

--- a/ui/src/pages/Activity.tsx
+++ b/ui/src/pages/Activity.tsx
@@ -261,19 +261,14 @@ function Connect({ tab }: { tab: ConnectTab }) {
           <p className="help" style={{ whiteSpace: "normal" }}>
             From now on every firing wakes your agent with the timeline attached; it can query back
             over MCP or REST if it needs more, and <span className="mono">remember</span> its
-            conclusion so the next dispatch arrives with prior findings included. Watch real
-            deliveries under <Link to="/activity">Activity → Trigger dispatches</Link> (every
-            firing is logged there, even with no subscribers — useful to test a trigger before
-            wiring the agent). Full walkthrough and a runnable incident-response example:{" "}
+            conclusion so the next dispatch arrives with prior findings included. Every wired
+            endpoint shows up under <Link to="/activity">Agents</Link> with its delivery history
+            (firings are logged even with no subscribers — useful to test a trigger before wiring
+            the agent). Full walkthrough and a runnable incident-response example:{" "}
             <a href="https://www.navflow.ai/docs/agents" target="_blank" rel="noreferrer">
               navflow.ai/docs/agents</a>.
           </p>
 
-          <h3 style={{ marginTop: 22 }}>Subscribed agents</h3>
-          <p className="help" style={{ whiteSpace: "normal" }}>
-            The endpoints currently wired to be woken — one row per <span className="mono">subscribe</span>.
-          </p>
-          <Subscriptions />
         </>
       )}
 
@@ -571,35 +566,3 @@ function Dispatches() {
   );
 }
 
-function Subscriptions() {
-  const { data, error } = usePolling(() => api.subscriptions());
-  const [q, setQ] = useState("");
-
-  const shown = useMemo(() => {
-    const needle = q.trim().toLowerCase();
-    return (data ?? []).filter((s) =>
-      !needle || s.trigger.toLowerCase().includes(needle) || s.url.toLowerCase().includes(needle));
-  }, [data, q]);
-
-  if (error) return <div className="alert error">{error}</div>;
-  if (!data?.length) return <div className="empty">no webhook subscriptions — agents subscribe via the MCP `subscribe` tool</div>;
-  return (
-    <>
-      <Toolbar q={q} setQ={setQ} placeholder="Filter by trigger, url…" shown={shown.length} total={data.length} />
-      <table>
-        <thead><tr><th>id</th><th>trigger</th><th>webhook url</th><th>created</th></tr></thead>
-        <tbody>
-          {shown.map((s) => (
-            <tr key={s.subscription_id}>
-              <td className="mono">{s.subscription_id}</td>
-              <td className="mono">{s.trigger}</td>
-              <td className="mono">{s.url}</td>
-              <td><TimeAgo ts={s.created_at} /></td>
-            </tr>
-          ))}
-          {!shown.length && <tr><td colSpan={4} className="dim" style={{ textAlign: "center", padding: 24 }}>no subscriptions match “{q}”</td></tr>}
-        </tbody>
-      </table>
-    </>
-  );
-}

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -392,12 +392,14 @@ pre.payload {
 .combo { position: relative; }
 .combo input { width: 100%; font-family: var(--mono); }
 .combo-list {
-  position: absolute; top: calc(100% + 4px); left: 0; right: 0; z-index: 30;
+  /* width grows with the longest option (long dotted OTLP names), never narrower than the input */
+  position: absolute; top: calc(100% + 4px); left: 0; z-index: 30;
+  min-width: 100%; width: max-content; max-width: min(560px, 85vw);
   background: var(--input-bg); border: 1px solid var(--line); border-radius: 8px;
   box-shadow: 0 8px 24px var(--sheet-shadow); max-height: 240px; overflow-y: auto; padding: 4px;
 }
 .combo-item {
-  padding: 6px 10px; border-radius: 6px; cursor: pointer;
+  padding: 6px 10px; border-radius: 6px; cursor: pointer; white-space: nowrap;
   font-family: var(--mono); font-size: 12.5px;
 }
 .combo-item:hover, .combo-item.active { background: var(--row-hover); }


### PR DESCRIPTION
Dogfooding the agent-wake flow surfaced a silent failure: a view filtering on `service = ingress-nginx` never matched anything, so its trigger never fired — filters only read the raw `fields` JSON, where OTLP events carry `resourceAttributes.service.name`, not `service` (that's a label).

- `_filter_sql`: a filter field resolves against extracted labels first, then raw payload fields (COALESCE); JSON paths quoted so dotted names address one flat key.
- Filter-field validation now allows dots (the editor suggested raw OTLP names the API then rejected).
- ViewEditor: key-field suggestions come from the sources' label specs (config labels + connector-provided), intersected across selected sources — not raw profiler fields, which produced invalid configs. Filter suggestions list labels first, then raw fields.
- Combo dropdown sizes to its content instead of clipping long dotted names.
- claude_code connector: missing `json` import crashed every ingest.
- Connect page: drop the leftover "Subscribed agents" table (redundant with the Agents roster, and it showed unmasked hook URLs).