### PR TITLE
OTLP labels: stored-payload namespace is canonical

### DIFF
--- a/navflow/connectors/otlp.py
+++ b/navflow/connectors/otlp.py
@@ -126,6 +126,18 @@ class OtlpConnector(Connector):
     async def poll(self):
         return []  # push-only: records arrive via map_otlp from POST /v1/{signal}
 
+    @staticmethod
+    def _label_ctx(res: dict) -> dict:
+        """Label-extraction context for one record's resource attributes. The canonical field
+        namespace is the STORED payload shape — the names the profiler shows and the UI suggests
+        (`resourceAttributes.service.name`). Bare wire names (`service.name`) stay resolvable as
+        a compatibility alias for specs written before this was normalized."""
+        return {**res, "resourceAttributes": res}
+
+    def label_context(self, payload: dict | None) -> dict:
+        # retroactive relabel must reproduce ingest exactly: same context, both namespaces
+        return self._label_ctx((payload or {}).get("resourceAttributes") or {})
+
     def map_otlp(self, signal: str, body) -> list[Envelope]:
         if not isinstance(body, dict):
             raise ValueError("OTLP body must be a JSON object")
@@ -140,7 +152,7 @@ class OtlpConnector(Connector):
 
     def _log_envelope(self, res: dict, scope: dict, rec: dict) -> Envelope:
         # labels (and the key) come from the resource attributes, e.g. service.name → service
-        labels, key = self.keyed(res, fallback="unknown")
+        labels, key = self.keyed(self._label_ctx(res), fallback="unknown")
         body_val = _anyvalue(rec.get("body", {}))
         text = body_val if isinstance(body_val, str) else json.dumps(body_val, default=str)
         event_time = (_ns_to_dt(rec.get("timeUnixNano"))
@@ -160,7 +172,7 @@ class OtlpConnector(Connector):
         )
 
     def _span_envelope(self, res: dict, scope: dict, span: dict) -> Envelope:
-        labels, key = self.keyed(res, fallback="unknown")
+        labels, key = self.keyed(self._label_ctx(res), fallback="unknown")
         name = span.get("name", "span")
         start, end = span.get("startTimeUnixNano"), span.get("endTimeUnixNano")
         try:
@@ -188,7 +200,7 @@ class OtlpConnector(Connector):
         )
 
     def _metric_envelope(self, res: dict, scope: dict, metric: dict, dp: dict, kind: str) -> Envelope:
-        labels, key = self.keyed(res, fallback="unknown")
+        labels, key = self.keyed(self._label_ctx(res), fallback="unknown")
         name = metric.get("name", "metric")
         unit = metric.get("unit", "")
         value = _dp_value(dp)

--- a/navflow/daemon.py
+++ b/navflow/daemon.py
@@ -189,7 +189,8 @@ def make_app() -> FastAPI:
             store.upsert_catalog_source(
                 "otlp", source_type_for("otlp"), "otlp", "5s",
                 normalize_config("otlp", {"labels": [
-                    {"name": "service", "field": "service.name", "primary": True}]}))
+                    {"name": "service", "field": "resourceAttributes.service.name",
+                     "primary": True}]}))
             runtime.reload_catalog()
             print("navflowd: auto-provisioned OTLP source 'otlp'")
             return "otlp"

--- a/ui/src/components/SourceForm.tsx
+++ b/ui/src/components/SourceForm.tsx
@@ -9,7 +9,7 @@ import type { ColumnsProposal, ConnectorField, ConnectorSpec, DiscoverProposal, 
 const DEFAULT_LABELS: Record<string, Array<Record<string, unknown>>> = {
   vercel: [{ name: "project", field: "project", primary: true },
            { name: "environment", field: "environment" }, { name: "source", field: "source" }],
-  otlp: [{ name: "service", field: "service.name", primary: true }],
+  otlp: [{ name: "service", field: "resourceAttributes.service.name", primary: true }],
 };
 
 // Connector-appropriate example names; the generic fallback suits metric-ish sources.


### PR DESCRIPTION
Label extraction ran over the bare wire attributes (`service.name`), while the profiler and every UI suggestion speak the stored-payload paths (`resourceAttributes.service.name`). Picking the suggested name in the Labels & key editor silently broke extraction — every event ingested as `key=unknown` with no labels, so views, triggers and dispatches all went dark.

- OTLP extraction context is now the stored shape (what users see), with bare wire names kept as a compatibility alias — both spellings extract identically.
- `label_context` override so retroactive relabel reproduces ingest exactly.
- Default OTLP provisioning (daemon + console) writes the canonical `resourceAttributes.service.name`.