### PR TITLE
Triggers: record cooldown before dispatch

### DIFF
--- a/navflow/triggers.py
+++ b/navflow/triggers.py
@@ -64,6 +64,13 @@ async def eval_triggers(store, catalog: Catalog, dispatcher, affected_sources=No
             last = store.last_fired(trig.name, fire_key)
             if last and (now_utc() - _aware(last)).total_seconds() < trig.cooldown_seconds:
                 continue
+            # Record the firing decision BEFORE rendering/delivering. Both store calls above and
+            # this one are synchronous — no await between check and set — so on the single event
+            # loop the cooldown check is an atomic critical section. Recording after delivery
+            # left the whole delivery await as a window where a concurrent ingest re-evaluated
+            # and double-fired. Cooldown rate-limits decisions; delivery outcomes are the
+            # dispatcher's ledger (dispatch_deliveries).
+            store.set_fired(trig.name, fire_key, now_utc())
 
             # Detection uses the (narrow) condition window; the attached context is wider so the
             # woken agent gets the correlating deploy/config, not just the spike that tripped it.
@@ -72,7 +79,6 @@ async def eval_triggers(store, catalog: Catalog, dispatcher, affected_sources=No
                                     key=(fire_key if legacy else None),
                                     window=ctx_window, where=where)
             await dispatcher.fire(trig, fire_key, payload)
-            store.set_fired(trig.name, fire_key, now_utc())
             fired.append((trig.name, fire_key))
 
     return fired

--- a/tests/test_otlp.py
+++ b/tests/test_otlp.py
@@ -35,7 +35,7 @@ async def main():
         srcs={s["name"]:s for s in (await cx.get("/api/sources")).json()}
         ck("auto-provisioned 'otlp' source (push)", "otlp" in srcs and (srcs["otlp"]["health"] or {}).get("status")=="push", str(list(srcs)))
         ck("otlp default labels: service primary",
-           srcs["otlp"]["config"]["labels"]==[{"name":"service","field":"service.name","primary":True}], str(srcs["otlp"]["config"]))
+           srcs["otlp"]["config"]["labels"]==[{"name":"service","field":"resourceAttributes.service.name","primary":True}], str(srcs["otlp"]["config"]))
         ck("3 events ingested", (srcs["otlp"]["health"] or {}).get("events_total")==3, str((srcs["otlp"]["health"] or {})))
 
         # entities: service is the primary facet, keyed per service from resource attrs


### PR DESCRIPTION
Observed live on the dev cell: the same trigger fired twice for the same entity 25ms apart, waking the subscribed agent twice for one incident.

The cooldown was recorded only after `await dispatcher.fire(...)` returned. Delivery is a long await, so any ingest landing during it re-evaluated the trigger, saw no cooldown, and fired again.

Now the firing decision is recorded immediately after the cooldown check — both synchronous store calls, no await between them, so the check-and-set is atomic on the event loop. Cooldown rate-limits firing decisions; delivery outcomes stay in the dispatcher's per-subscriber ledger (`dispatch_deliveries`).

Also updates the OTLP default-label test expectation missed in #24.