### PR TITLE
views/triggers: AI edit, detail-page delete, MCP create/edit

### DIFF
--- a/navflow/mcp_server.py
+++ b/navflow/mcp_server.py
@@ -93,6 +93,36 @@ async def read(selector: dict, window: str = "15m", include_payload: bool = Fals
 
 
 @writable()
+async def create_trigger(name: str, view: str, condition: dict,
+                         emit: dict | None = None, cooldown: str = "5m") -> str:
+    """Create a trigger — a condition NavFlow evaluates continuously over a view; when it trips,
+    subscribed agents are woken with the correlated timeline. `condition` is
+    {aggregate: any|avg|count|max|min|sum, field: numeric field to aggregate (omit for count),
+    predicate: e.g. '> 1.0' / '>= 5' / '== 0', window: detection window e.g. '1m'}. `emit` is
+    {kind: what a firing is called e.g. error_spike, context_window: timeline the woken agent
+    receives e.g. '15m'}. The view must exist (catalog_describe it to confirm the numeric field).
+    Wire agents to it with subscribe()."""
+    body = {"name": name, "view": view, "condition": condition,
+            "emit": emit or {}, "cooldown": cooldown}
+    async with _cx(10) as cx:
+        r = await cx.post(f"{NAVFLOWD}/api/triggers", json=body)
+    return r.text
+
+
+@writable()
+async def update_trigger(name: str, view: str, condition: dict,
+                         emit: dict | None = None, cooldown: str = "5m") -> str:
+    """Edit an EXISTING trigger in place: replace its view, condition, emit, and cooldown. Create
+    new triggers with create_trigger() — this only updates one that already exists (renaming isn't
+    supported, so keep `name` the same). See create_trigger for the condition/emit shape."""
+    body = {"name": name, "view": view, "condition": condition,
+            "emit": emit or {}, "cooldown": cooldown}
+    async with _cx(10) as cx:
+        r = await cx.put(f"{NAVFLOWD}/api/triggers/{name}", json=body)
+    return r.text
+
+
+@writable()
 async def subscribe(trigger: str, url: str) -> str:
     """Register a webhook to be woken (pushed) when a trigger fires. Returns a subscription id."""
     async with _cx(10) as cx:
@@ -132,6 +162,19 @@ async def derive(sources: list[str], key_field: str, name: str = "",
         body["name"] = name
     async with _cx(10) as cx:
         r = await cx.post(f"{NAVFLOWD}/derive", json=body)
+    return r.text
+
+
+@writable()
+async def update_view(name: str, sources: list[str], key_field: str = "",
+                      filters: list[dict] | None = None) -> str:
+    """Edit an EXISTING view in place: replace its sources, key_field, and filters. Create new
+    views with derive() — this only updates one that already exists (renaming isn't supported, so
+    keep `name` the same). filters are [{field, op, value}] (ops: eq, neq, contains, gt, lt, gte,
+    lte). Use catalog_describe first to learn the available fields."""
+    body = {"name": name, "key_field": key_field, "sources": sources, "filters": filters or []}
+    async with _cx(10) as cx:
+        r = await cx.put(f"{NAVFLOWD}/api/views/{name}", json=body)
     return r.text
 
 

--- a/ui/src/components/proposals.tsx
+++ b/ui/src/components/proposals.tsx
@@ -29,15 +29,23 @@ export async function applyProposal(p: Proposal): Promise<void> {
       config: { ...src.config, labels: p.labels },
     });
   } else if (p.kind === "view") {
-    await api.createView({ name: p.name, key_field: p.key_field,
-                           sources: p.sources, filters: (p.filters ?? []) as never });
+    // Upsert: the agent proposes the same way for a new view and an edit to an existing one —
+    // apply as an update when the name already exists (create-only 409'd with "already exists").
+    const body = { name: p.name, key_field: p.key_field,
+                   sources: p.sources, filters: (p.filters ?? []) as never };
+    const exists = (await api.views()).some((v) => v.name === p.name);
+    if (exists) await api.updateView(p.name, body);
+    else await api.createView(body);
   } else {
-    await api.createTrigger({
+    const t = {
       name: p.name, view: p.view,
       condition: p.condition,
       emit: { kind: p.emit?.kind ?? p.name, context_window: p.emit?.context_window ?? "15m" },
       cooldown: p.cooldown ?? "5m",
-    } as Trigger);
+    } as Trigger;
+    const exists = (await api.triggers()).some((x) => x.name === p.name);
+    if (exists) await api.updateTrigger(p.name, t);
+    else await api.createTrigger(t);
   }
 }
 

--- a/ui/src/pages/TriggerDetail.tsx
+++ b/ui/src/pages/TriggerDetail.tsx
@@ -1,7 +1,8 @@
 import { useState } from "react";
-import { Link, useParams, useSearchParams } from "react-router-dom";
+import { Link, useNavigate, useParams, useSearchParams } from "react-router-dom";
 
 import { api } from "../api";
+import ConfirmDialog from "../components/ConfirmDialog";
 import TriggerEditor from "../components/TriggerEditor";
 import { TimeAgo, usePolling } from "../components/bits";
 
@@ -9,8 +10,11 @@ import { TimeAgo, usePolling } from "../components/bits";
 // Read-only by default; Edit swaps in the editor in place (?edit=1 opens it directly).
 export default function TriggerDetail() {
   const { name = "" } = useParams();
+  const nav = useNavigate();
   const [params] = useSearchParams();
   const [editing, setEditing] = useState(params.get("edit") === "1");
+  const [confirmDel, setConfirmDel] = useState(false);
+  const [delErr, setDelErr] = useState<string>();
   const { data: triggers, error, reload } = usePolling(() => api.triggers(), 10000);
   const { data: agents } = usePolling(() => api.agents(), 10000);
   const { data: dispatches } = usePolling(() => api.dispatches(100), 10000);
@@ -41,8 +45,15 @@ export default function TriggerDetail() {
             {" "}— fires when the condition trips, waking every subscribed agent
           </p>
         </div>
-        {!editing && <button className="primary" onClick={() => setEditing(true)}>Edit</button>}
+        {!editing && (
+          <span className="btnrow">
+            <button className="primary" onClick={() => setEditing(true)}>Edit</button>
+            <button className="danger" onClick={() => setConfirmDel(true)}>Delete</button>
+          </span>
+        )}
       </div>
+
+      {delErr && <div className="alert error">{delErr}</div>}
 
       {editing && (
         <TriggerEditor initial={trigger}
@@ -125,6 +136,23 @@ export default function TriggerDetail() {
             ))}
           </tbody>
         </table>
+      )}
+
+      {confirmDel && (
+        <ConfirmDialog
+          title={`Delete trigger ${trigger.name}?`}
+          message={wired.length
+            ? `${wired.length} agent(s) are woken by this trigger and will stop receiving it. This can't be undone.`
+            : "This stops the condition from being evaluated. This can't be undone."}
+          confirmLabel="Delete"
+          danger
+          onCancel={() => setConfirmDel(false)}
+          onConfirm={async () => {
+            setDelErr(undefined);
+            try { await api.deleteTrigger(trigger.name); nav("/triggers"); }
+            catch (e) { setDelErr(String((e as Error).message ?? e)); setConfirmDel(false); }
+          }}
+        />
       )}
     </>
   );

--- a/ui/src/pages/ViewDetail.tsx
+++ b/ui/src/pages/ViewDetail.tsx
@@ -1,7 +1,8 @@
 import { useState } from "react";
-import { Link, useParams, useSearchParams } from "react-router-dom";
+import { Link, useNavigate, useParams, useSearchParams } from "react-router-dom";
 
 import { api } from "../api";
+import ConfirmDialog from "../components/ConfirmDialog";
 import ViewEditor from "../components/ViewEditor";
 import { TimeAgo, usePolling } from "../components/bits";
 
@@ -9,8 +10,11 @@ import { TimeAgo, usePolling } from "../components/bits";
 // in-place editing via the Edit button (?edit=1 opens it directly, e.g. from the list).
 export default function ViewDetail() {
   const { name = "" } = useParams();
+  const nav = useNavigate();
   const [params] = useSearchParams();
   const [editing, setEditing] = useState(params.get("edit") === "1");
+  const [confirmDel, setConfirmDel] = useState(false);
+  const [delErr, setDelErr] = useState<string>();
   const { data: views, error, reload } = usePolling(() => api.views(), 10000);
   const { data: triggers } = usePolling(() => api.triggers(), 10000);
   const { data: sources } = usePolling(() => api.sources(), 15000);
@@ -39,8 +43,11 @@ export default function ViewDetail() {
         <span className="btnrow">
           <Link className="btn" to={`/triggers/new?view=${encodeURIComponent(view.name)}`}>+ trigger</Link>
           {!editing && <button className="primary" onClick={() => setEditing(true)}>Edit</button>}
+          {!editing && <button className="danger" onClick={() => setConfirmDel(true)}>Delete</button>}
         </span>
       </div>
+
+      {delErr && <div className="alert error">{delErr}</div>}
 
       {editing && (
         <ViewEditor initial={view} sourceNames={(sources ?? []).map((x) => x.name)}
@@ -100,6 +107,23 @@ export default function ViewDetail() {
             ))}
           </tbody>
         </table>
+      )}
+
+      {confirmDel && (
+        <ConfirmDialog
+          title={`Delete view ${view.name}?`}
+          message={watchers.length
+            ? `${watchers.length} trigger(s) watch this view and will stop working. Agents querying it will start failing.`
+            : "Agents querying this view will start failing. This can't be undone."}
+          confirmLabel="Delete"
+          danger
+          onCancel={() => setConfirmDel(false)}
+          onConfirm={async () => {
+            setDelErr(undefined);
+            try { await api.deleteView(view.name); nav("/views"); }
+            catch (e) { setDelErr(String((e as Error).message ?? e)); setConfirmDel(false); }
+          }}
+        />
       )}
     </>
   );


### PR DESCRIPTION
Fixes editing/deleting views & triggers surfaced while dogfooding.

- **Built-in AI edits existing views/triggers**: `applyProposal` now upserts — it updates (PUT) when a view/trigger by that name exists, creates (POST) otherwise. Previously an "edit" proposal always POSTed → "already exists".
- **Delete on detail pages**: View and Trigger detail pages get a Delete button (with a confirm dialog that warns about watching triggers / wired agents). Delete already existed on the list; the detail pages only had Edit.
- **External MCP surface**: adds `update_view`, `create_trigger`, `update_trigger` so external agents can create and edit views + triggers (no delete — deliberately). All `@writable()`, so the daemon still enforces scope per call.

UI typechecks clean; MCP compiles clean.