### PR TITLE
labels: Fields profiling, OTLP text/attributes, $1 + extraction-omit

### DIFF
--- a/navflow/config.py
+++ b/navflow/config.py
@@ -209,14 +209,36 @@ def _compiled(pattern: str):
     return re.compile(pattern)
 
 
-def _normalize_value(spec: dict, raw: str) -> str:
+# Group-reference styles accepted in a label's `replace`: sed/Python (\1, \g<1>) and JS/PCRE
+# ($1, ${1}). The $-forms are translated to Python before substituting.
+_DOLLAR_GROUP = re.compile(r"\$\{(\d+)\}|\$(\d+)")
+_GROUP_REF = re.compile(r"\$\{?\d|\\g?<?\d")
+
+
+def _to_py_replace(replace: str) -> str:
+    """Accept JS/PCRE `$1`/`${1}` (and `$$` → a literal `$`) in a replacement, alongside `\\1`."""
+    protected = replace.replace("$$", "\x00")
+    subbed = _DOLLAR_GROUP.sub(lambda m: f"\\g<{m.group(1) or m.group(2)}>", protected)
+    return subbed.replace("\x00", "$")
+
+
+def _normalize_value(spec: dict, raw: str) -> str | None:
     """Value normalization for one field label: regex substitution first, exact-alias map second
     (map keys are written against the cleaned form). Fail-open: any error keeps the raw value —
-    the lossless payload always preserves the original, so normalization is never destructive."""
+    the lossless payload always preserves the original, so normalization is never destructive.
+
+    A `replace` that references a capture group (`\\1` or `$1`) is treated as an EXTRACTION: if the
+    pattern doesn't match this value, the label doesn't apply, so return None (the label is dropped
+    for this event). A `replace` with no group reference is a plain substitution/cleanup and keeps
+    the original value on no-match, as before."""
     v = raw
     try:
-        if spec.get("pattern"):
-            v = _compiled(spec["pattern"]).sub(spec.get("replace", ""), v)
+        pattern = spec.get("pattern")
+        if pattern:
+            raw_replace = spec.get("replace", "")
+            v, n = _compiled(pattern).subn(_to_py_replace(raw_replace), v)
+            if n == 0 and _GROUP_REF.search(raw_replace):
+                return None                       # extraction whose pattern didn't match → omit
         m = spec.get("map")
         if m:
             v = m.get(v, v)
@@ -250,7 +272,9 @@ def extract_labels(specs, context: dict | None = None) -> dict:
                 if isinstance(sub, dict):
                     v = sub.get(tail)
             if v is not None:
-                out[name] = _normalize_value(spec, str(v))
+                nv = _normalize_value(spec, str(v))
+                if nv is not None:               # extraction that didn't match drops the label
+                    out[name] = nv
     return out
 
 

--- a/navflow/connectors/otlp.py
+++ b/navflow/connectors/otlp.py
@@ -127,16 +127,30 @@ class OtlpConnector(Connector):
         return []  # push-only: records arrive via map_otlp from POST /v1/{signal}
 
     @staticmethod
-    def _label_ctx(res: dict) -> dict:
-        """Label-extraction context for one record's resource attributes. The canonical field
-        namespace is the STORED payload shape — the names the profiler shows and the UI suggests
-        (`resourceAttributes.service.name`). Bare wire names (`service.name`) stay resolvable as
-        a compatibility alias for specs written before this was normalized."""
-        return {**res, "resourceAttributes": res}
+    def _label_ctx(res: dict, text=None, attributes: dict | None = None) -> dict:
+        """Canonical label-extraction context for one record. Fields are addressed by their STORED
+        payload path: `resourceAttributes.<k>` (resource attributes), `text` (the rendered log
+        line — regex a status/level out of it, same string shown in the UI), and `attributes.<k>`
+        (record / span / datapoint attributes). No bare-name alias — specs use the canonical name
+        the profiler shows."""
+        ctx: dict = {"resourceAttributes": res or {}}
+        if isinstance(text, str) and text:
+            ctx["text"] = text
+        if attributes:
+            ctx["attributes"] = attributes
+        return ctx
 
     def label_context(self, payload: dict | None) -> dict:
-        # retroactive relabel must reproduce ingest exactly: same context, both namespaces
-        return self._label_ctx((payload or {}).get("resourceAttributes") or {})
+        # Retroactive relabel must reproduce ingest exactly — rebuild the SAME context from the
+        # stored payload. `text` is the rendered log body; `attributes` is a raw KV list on logs
+        # (spread via **rec) but already a flat dict on spans/metrics — normalize both.
+        payload = payload or {}
+        body_val = _anyvalue(payload.get("body", {}))
+        text = body_val if isinstance(body_val, str) else (
+            json.dumps(body_val, default=str) if body_val not in (None, {}, "") else None)
+        attrs = payload.get("attributes")
+        attrs = attrs if isinstance(attrs, dict) else _attrs(attrs or [])
+        return self._label_ctx(payload.get("resourceAttributes") or {}, text=text, attributes=attrs)
 
     def map_otlp(self, signal: str, body) -> list[Envelope]:
         if not isinstance(body, dict):
@@ -151,13 +165,15 @@ class OtlpConnector(Connector):
         raise ValueError(f"OTLP signal {signal!r} is not supported")
 
     def _log_envelope(self, res: dict, scope: dict, rec: dict) -> Envelope:
-        # labels (and the key) come from the resource attributes, e.g. service.name → service
-        labels, key = self.keyed(self._label_ctx(res), fallback="unknown")
         body_val = _anyvalue(rec.get("body", {}))
         text = body_val if isinstance(body_val, str) else json.dumps(body_val, default=str)
+        rec_attrs = _attrs(rec.get("attributes", []))
+        # labels (and the key) come from the resource attributes (service.name → service), the log
+        # body (regex a status/level out of the line), and the record's own attributes.
+        labels, key = self.keyed(self._label_ctx(res, text=text, attributes=rec_attrs),
+                                 fallback="unknown")
         event_time = (_ns_to_dt(rec.get("timeUnixNano"))
                       or _ns_to_dt(rec.get("observedTimeUnixNano")) or now_utc())
-        rec_attrs = _attrs(rec.get("attributes", []))
         # numeric record attributes become trigger-usable fields; the rest stay lossless in payload
         fields = {k: v for k, v in rec_attrs.items()
                   if isinstance(v, (int, float)) and not isinstance(v, bool)}
@@ -172,7 +188,8 @@ class OtlpConnector(Connector):
         )
 
     def _span_envelope(self, res: dict, scope: dict, span: dict) -> Envelope:
-        labels, key = self.keyed(self._label_ctx(res), fallback="unknown")
+        labels, key = self.keyed(self._label_ctx(res, attributes=_attrs(span.get("attributes", []))),
+                                 fallback="unknown")
         name = span.get("name", "span")
         start, end = span.get("startTimeUnixNano"), span.get("endTimeUnixNano")
         try:
@@ -200,7 +217,8 @@ class OtlpConnector(Connector):
         )
 
     def _metric_envelope(self, res: dict, scope: dict, metric: dict, dp: dict, kind: str) -> Envelope:
-        labels, key = self.keyed(self._label_ctx(res), fallback="unknown")
+        labels, key = self.keyed(self._label_ctx(res, attributes=_attrs(dp.get("attributes", []))),
+                                 fallback="unknown")
         name = metric.get("name", "metric")
         unit = metric.get("unit", "")
         value = _dp_value(dp)

--- a/navflow/daemon.py
+++ b/navflow/daemon.py
@@ -852,7 +852,10 @@ def make_app() -> FastAPI:
         key_names = {(s.get("field") or s.get("name")) for s in label_specs if s.get("primary")}
         key_names.discard(None)
 
+        from .config import extract_labels
+
         counts: dict[str, Counter] = {}
+        label_counts: dict[str, Counter] = {}   # the EXTRACTED value of each declared label
         sampled = 0
         for payload in store.recent_payloads(name, min(limit, 2000)):
             ctx = conn.label_context(payload)
@@ -866,6 +869,12 @@ def make_app() -> FastAPI:
                             counts.setdefault(f"{k}.{sk}", Counter())[str(sv)] += 1
                 elif v not in (None, ""):
                     counts.setdefault(k, Counter())[str(v)] += 1
+            # Profile the actual EXTRACTED labels too (the same extraction ingest uses), so a
+            # derived label (regex/const/map over a raw field) is visible with its real coverage
+            # and values — not just the raw field it reads from.
+            for lname, lval in extract_labels(label_specs, ctx).items():
+                if lval not in (None, ""):
+                    label_counts.setdefault(lname, Counter())[str(lval)] += 1
 
         def entry(fname, help_="", primary_default=False):
             vals = counts.get(fname, Counter())
@@ -885,7 +894,22 @@ def make_app() -> FastAPI:
                 fields.append(entry(fname))
         # entity axes first (key, then label), then the rest — lead with what you'd actually key on.
         fields.sort(key=lambda f: (0 if f["is_key"] else 1 if f["is_label"] else 2))
-        return {"sampled": sampled, "fields": fields}
+
+        # Declared labels, profiled by their EXTRACTED value — the curated axes you read/alert by,
+        # surfaced whether they map to a raw field (service) or are derived (http_status). Coverage
+        # of 0 means the extraction matched nothing (e.g. a bad regex) — useful on its own.
+        labels = []
+        for s in label_specs:
+            lname = s.get("name")
+            if not lname:
+                continue
+            vals = label_counts.get(lname, Counter())
+            labels.append({"name": lname, "is_key": bool(s.get("primary")),
+                           "coverage": sum(vals.values()), "distinct": len(vals),
+                           "values": [{"value": val, "events": c} for val, c in vals.most_common(8)]})
+        labels.sort(key=lambda l: 0 if l["is_key"] else 1)
+
+        return {"sampled": sampled, "fields": fields, "labels": labels}
 
     # ── in-app agent (the Ask view) — server-side chat loop over the read API ──
     @app.post("/api/agent/chat")

--- a/ui/src/pages/SourceDetail.tsx
+++ b/ui/src/pages/SourceDetail.tsx
@@ -201,7 +201,62 @@ function FieldsPanel({ name }: { name: string }) {
     (a.is_key ? 0 : a.is_label ? 1 : 2) - (b.is_key ? 0 : b.is_label ? 1 : 2)
     || b.coverage - a.coverage || a.name.localeCompare(b.name));
   const shown = showAll ? sorted : sorted.slice(0, FIELDS_PAGE);
+  const labels = data.labels ?? [];
+  const allLabelsFull = labels.every((l) => l.coverage === data.sampled);
   return (
+    <>
+    {labels.length > 0 && (
+      <div className="panel">
+        <h2 style={{ marginTop: 0 }}>Labels <small className="dim">· {data.sampled} events sampled</small></h2>
+        <p className="subtitle">
+          The curated axes you read and alert by — each label with its coverage and top values,
+          including derived ones (regex / const / map over a raw field). <span className="badge ok">key</span>{" "}
+          is the primary; <strong>0 coverage</strong> means the extraction matched nothing (e.g. a bad field or regex).
+        </p>
+        <table>
+          <thead><tr>
+            <th>label</th>
+            {!allLabelsFull && <th style={{ width: 180 }}>coverage</th>}
+            <th className="num">distinct</th>
+            <th>top values</th>
+          </tr></thead>
+          <tbody>
+            {labels.map((l) => (
+              <tr key={l.name} style={l.coverage === 0 ? { opacity: 0.55 } : undefined}>
+                <td className="mono">
+                  {l.name}
+                  {l.is_key ? <span className="badge ok" style={{ marginLeft: 6 }}>key</span>
+                    : <span className="badge starting" style={{ marginLeft: 6 }}>label</span>}
+                  {l.coverage === 0 && (
+                    <div className="help" style={{ fontFamily: "inherit" }}>
+                      no sampled event carries this label — check the field mapping / regex
+                    </div>
+                  )}
+                </td>
+                {!allLabelsFull && (
+                  <td>
+                    <div className="cov"><div className="cov-bar" style={{ width: `${(l.coverage / Math.max(1, data.sampled)) * 100}%` }} /></div>
+                    <small className="dim">{l.coverage} / {data.sampled}</small>
+                  </td>
+                )}
+                <td className="num">{l.distinct}</td>
+                <td>
+                  {l.values.length
+                    ? <span className="row" style={{ gap: 6, flexWrap: "wrap" }}>
+                        {l.values.slice(0, 6).map((v) => (
+                          <span className="chip" key={v.value} title={`${v.value} · ${v.events} events`}>
+                            {fmt(v.value)} <span className="dim">({v.events})</span>
+                          </span>
+                        ))}
+                      </span>
+                    : <span className="help">—</span>}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    )}
     <div className="panel">
       <h2 style={{ marginTop: 0 }}>Fields <small className="dim">· {data.sampled} events sampled</small></h2>
       <p className="subtitle">
@@ -261,6 +316,7 @@ function FieldsPanel({ name }: { name: string }) {
       )}
       {allFull && <p className="help" style={{ marginTop: 8 }}>Every field is present in all {data.sampled} sampled events.</p>}
     </div>
+    </>
   );
 }
 

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -52,7 +52,18 @@ export interface SourceField {
   is_key?: boolean;
   values: SourceFieldValue[];
 }
-export interface SourceFieldsProfile { sampled: number; fields: SourceField[]; }
+export interface SourceLabelProfile {
+  name: string;
+  is_key: boolean;
+  coverage: number;
+  distinct: number;
+  values: SourceFieldValue[];
+}
+export interface SourceFieldsProfile {
+  sampled: number;
+  fields: SourceField[];
+  labels?: SourceLabelProfile[];
+}
 
 // One event in a correlated read: its time offset, source, rendered text, and the labels it
 // carries (endpoint, status, …) — so the timeline shows the dimensions you filtered/sliced by.


### PR DESCRIPTION
Surfaced while dogfooding: making a derived label (regex an HTTP status out of an OTLP log) actually work end-to-end.

- **Labels in the Fields tab**: the source fields profiler now also runs the real `extract_labels` over sampled events and returns a `labels` block (each declared label's *extracted* coverage / distinct / top values). The source detail shows a Labels section on top — so a derived label is visible with what it produces, and 0 coverage flags a bad field/regex. (`daemon.py`, `SourceDetail.tsx`, `types.ts`)
- **OTLP: `text` + `attributes` labelable, canonical names only**: `_label_ctx` now exposes `text` (the rendered log line — regex a status/level out of it) and `attributes.<k>`, alongside `resourceAttributes.<k>`. The bare-name alias (`service.name` beside `resourceAttributes.service.name`) is removed — canonical only. Ingest == backfill verified. (`otlp.py`)
- **Regex `replace` fixes** (`config.py`): accept JS/PCRE `$1`/`${1}` group refs (not just Python `\1`); and when a `replace` references a capture group, treat the label as an *extraction* — if the pattern doesn't match, drop the label instead of returning the whole line. Plain substitution/cleanup labels are unchanged.

Verified: OTLP 17/17, labels 29/29, catalog_sync 3/3, ingest_key 12/12; UI typechecks. Real dev labels (`http_status_nginx`/`http_status_argus`, `replace:$1`) now extract 307/200 and omit on non-match.