### PR TITLE
Fix DuckDB OOM crashloop (bound memory to container) + small UI fixes

### DIFF
--- a/navflow/store.py
+++ b/navflow/store.py
@@ -6,6 +6,7 @@ through here; the MCP server never touches the DB directly.
 from __future__ import annotations
 
 import json
+import os
 import re
 import secrets
 import threading
@@ -175,12 +176,50 @@ def _filter_sql(filters) -> tuple[str, list]:
     return (" AND " + " AND ".join(clauses)) if clauses else "", params
 
 
+def _cgroup_mem_bytes() -> int | None:
+    """The container's memory limit in bytes (cgroup v2, then v1), or None if unlimited/unknown."""
+    for p in ("/sys/fs/cgroup/memory.max", "/sys/fs/cgroup/memory/memory.limit_in_bytes"):
+        try:
+            raw = open(p).read().strip()
+        except OSError:
+            continue
+        if raw.isdigit():
+            n = int(raw)
+            if 0 < n < (1 << 62):        # "max" or a huge sentinel = effectively unlimited
+                return n
+    return None
+
+
+def _bound_duckdb_memory(con, path: str) -> None:
+    """Bound DuckDB to the CONTAINER, not the host. Without a memory_limit DuckDB sizes itself to
+    the node's RAM, so one heavy scan over a grown dataset blows past the cgroup limit and the
+    process is OOMKilled (this took the dev cell down at ~1M events). With a limit set, DuckDB
+    spills intermediates to temp_directory (on the data volume) instead of dying. Override with
+    NAVFLOW_DUCKDB_MEMORY_LIMIT (e.g. "800MB"); no-op locally when there's no cgroup limit."""
+    limit = os.getenv("NAVFLOW_DUCKDB_MEMORY_LIMIT")
+    if not limit:
+        cg = _cgroup_mem_bytes()
+        if cg:
+            limit = f"{max(256, int(cg * 0.6) // (1024 * 1024))}MB"   # 60% of the container
+    if not limit:
+        return
+    try:
+        con.execute(f"PRAGMA memory_limit='{limit}'")
+        con.execute(f"PRAGMA threads={os.getenv('NAVFLOW_DUCKDB_THREADS', '2')}")
+        tmp = os.path.join(os.path.dirname(os.path.abspath(path)) or ".", ".duckdb_tmp")
+        os.makedirs(tmp, exist_ok=True)
+        con.execute(f"PRAGMA temp_directory='{tmp}'")
+    except Exception as e:                 # never let tuning block startup
+        print(f"navflowd: could not bound DuckDB memory ({e})")
+
+
 class Store:
     def __init__(self, path: str = "navflow.duckdb"):
         # All access is from navflowd's event loop thread; the lock is belt-and-suspenders since
         # FastAPI may run sync work in a threadpool.
         self._lock = threading.Lock()
         self.con = duckdb.connect(path)
+        _bound_duckdb_memory(self.con, path)
         for stmt in _SCHEMA.strip().split(";"):
             if stmt.strip():
                 self.con.execute(stmt)

--- a/ui/src/pages/SourceDetail.tsx
+++ b/ui/src/pages/SourceDetail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
 import { api } from "../api";
@@ -16,6 +16,15 @@ export default function SourceDetail() {
   const [actionError, setActionError] = useState<string>();
   const [confirmDel, setConfirmDel] = useState(false);
   const [purge, setPurge] = useState(false);
+  const tabsRef = useRef<HTMLDivElement>(null);
+
+  // Editing labels opens the Configuration tab, which renders below the fold — scroll to it so it's
+  // obvious something opened (otherwise the page looks unchanged).
+  const openConfig = () => {
+    setTab("config");
+    requestAnimationFrame(() =>
+      tabsRef.current?.scrollIntoView({ behavior: "smooth", block: "start" }));
+  };
 
   const { data: source, error, reload } = usePolling(() => api.source(name));
   const { data: events } = usePolling(() => api.sourceEvents(name, 30));
@@ -67,9 +76,9 @@ export default function SourceDetail() {
         </div>
       )}
 
-      <LabelsSummary source={source} onEdit={() => setTab("config")} />
+      <LabelsSummary source={source} onEdit={openConfig} />
 
-      <div className="tabs" style={{ marginTop: 16 }}>
+      <div className="tabs" style={{ marginTop: 16, scrollMarginTop: 60 }} ref={tabsRef}>
         <button className={tab === "fields" ? "active" : ""} onClick={() => setTab("fields")}>Fields</button>
         <button className={tab === "events" ? "active" : ""} onClick={() => setTab("events")}>Recent events</button>
         <button className={tab === "config" ? "active" : ""} onClick={() => setTab("config")}>Configuration</button>

--- a/ui/src/pages/ViewsTriggers.tsx
+++ b/ui/src/pages/ViewsTriggers.tsx
@@ -117,7 +117,7 @@ function ViewsSection({ views, onChange }:
                       : <span className="help">never queried</span>}
                   </td>
                   <td style={{ textAlign: "right", whiteSpace: "nowrap" }}>
-                    <span className="btnrow" style={{ justifyContent: "flex-end" }}>
+                    <span className="btnrow" style={{ justifyContent: "flex-end", flexWrap: "nowrap" }}>
                       <Link className="btn" to={`/triggers/new?view=${encodeURIComponent(v.name)}`}
                             title="create a trigger watching this view">+ trigger</Link>
                       <Link className="btn" to={`/views/${encodeURIComponent(v.name)}?edit=1`}>edit</Link>
@@ -202,7 +202,7 @@ function TriggersSection({ triggers, viewNames, onChange }:
                   </td>
                   <td className="mono">{t.cooldown}</td>
                   <td style={{ textAlign: "right", whiteSpace: "nowrap" }}>
-                    <span className="btnrow" style={{ justifyContent: "flex-end" }}>
+                    <span className="btnrow" style={{ justifyContent: "flex-end", flexWrap: "nowrap" }}>
                       <Link className="btn" to={`/triggers/${encodeURIComponent(t.name)}`}>agents</Link>
                       <Link className="btn" to={`/triggers/${encodeURIComponent(t.name)}?edit=1`}>edit</Link>
                       <button className="danger" onClick={() => setConfirmDelName(t.name)}>delete</button>


### PR DESCRIPTION
**Incident fix.** The dev cell went into an OOMKilled crashloop: `duckdb.connect()` set no `memory_limit`, so DuckDB sized queries to the *node's* RAM (~4GB) and a heavy scan over the grown dataset (~1M events) allocated past the 1536Mi container cgroup → OOMKilled. Bumping the pod limit can't fix it (4GB node).

- **`store.py`**: on connect, bound DuckDB to the container — `memory_limit` = 60% of the cgroup limit (or `NAVFLOW_DUCKDB_MEMORY_LIMIT`), `threads=2`, and `temp_directory` on the data volume so heavy queries **spill to disk instead of OOMing**. No-op locally (no cgroup limit). Reads cgroup v2 then v1.
- UI: Labels & key "Edit" scrolls the Configuration into view; Views/Triggers action buttons no longer wrap (`delete` stays on one line).

Verified: memory_limit applied from env, labels 29/29, otlp 17/17, UI typechecks.