### PR TITLE
Surface trigger dispatch delivery failures

### DIFF
--- a/navflow/daemon.py
+++ b/navflow/daemon.py
@@ -1090,8 +1090,12 @@ def make_app() -> FastAPI:
                     "first_seen": sub["created_at"],
                     "delivered_ok": st.get("ok", 0), "delivered_fail": st.get("fail", 0),
                     "last_woken": st.get("last_at"),
+                    # currently failing: the most recent delivery to this endpoint did not succeed.
+                    "unhealthy": st.get("fail", 0) > 0 and not st.get("last_ok", True),
+                    "last_error": None if st.get("last_ok", True) else st.get("last_error"),
                     "recent": [{"at": d["at"], "ok": d["ok"], "trigger": d["trigger"],
-                                "key": d["key"]} for d in store.recent_deliveries(sub["url"], 10)],
+                                "key": d["key"], "error": d["error"]}
+                               for d in store.recent_deliveries(sub["url"], 10)],
                 }
             a["subscriptions"].append({"subscription_id": sub["subscription_id"],
                                        "trigger": sub["trigger"], "created_at": sub["created_at"]})

--- a/navflow/dispatch.py
+++ b/navflow/dispatch.py
@@ -31,24 +31,33 @@ class Dispatcher:
         }
         delivered = 0
         for sid, _trig, url in subs:
-            ok = await self._post(url, body)
-            self.store.log_delivery(dispatch_id, sid, url, ok)   # per-agent delivery history
+            ok, error = await self._post(url, body)
+            self.store.log_delivery(dispatch_id, sid, url, ok, error)   # per-agent delivery history
             if ok:
                 delivered += 1
         # log every firing, even with zero subscribers — the UI shows what would have woken agents
         self.store.log_dispatch(dispatch_id, trigger.name, key, kind,
                                 len(subs), delivered, payload)
 
-    async def _post(self, url: str, body: dict, attempts: int = 5) -> bool:
+    async def _post(self, url: str, body: dict, attempts: int = 5) -> tuple[bool, str | None]:
+        """Deliver to one subscriber. Returns (ok, error): ok only on a 2xx. A 4xx is a definitive
+        failure (bad secret / wrong path / gone) — recorded, not retried. 5xx and transport errors
+        (unreachable, timeout, DNS) are retried with backoff; the last error is returned so the UI
+        can say WHY a delivery shows 0, instead of a silent failure."""
         delay = 1.0
+        error = None
         async with httpx.AsyncClient(timeout=10) as cx:
-            for _ in range(attempts):
+            for attempt in range(attempts):
                 try:
                     r = await cx.post(url, json=body)
-                    if r.status_code < 500:
-                        return True
-                except Exception:
-                    pass
-                await asyncio.sleep(delay)
-                delay = min(delay * 2, 30)
-        return False
+                    if 200 <= r.status_code < 300:
+                        return True, None
+                    error = f"HTTP {r.status_code}"
+                    if r.status_code < 500:       # client error — won't self-heal, don't retry
+                        return False, error
+                except Exception as e:            # transport failure — unreachable / timeout / DNS
+                    error = (type(e).__name__ + (f": {e}" if str(e).strip() else ""))[:200]
+                if attempt < attempts - 1:        # no point sleeping after the final attempt
+                    await asyncio.sleep(delay)
+                    delay = min(delay * 2, 30)
+        return False, error

--- a/navflow/store.py
+++ b/navflow/store.py
@@ -69,7 +69,8 @@ CREATE TABLE IF NOT EXISTS dispatch_deliveries (
   subscription_id TEXT,
   url             TEXT,
   ok              BOOLEAN,
-  delivered_at    TIMESTAMPTZ
+  delivered_at    TIMESTAMPTZ,
+  error           TEXT
 );
 CREATE TABLE IF NOT EXISTS api_keys (
   id           TEXT PRIMARY KEY,
@@ -143,6 +144,7 @@ _MIGRATIONS = [
     # the column already exists, which would reset paused=TRUE back to FALSE each restart. Existing
     # rows get NULL (read as False); the upsert always writes an explicit value going forward.
     "ALTER TABLE catalog_triggers ADD COLUMN IF NOT EXISTS paused BOOLEAN",
+    "ALTER TABLE dispatch_deliveries ADD COLUMN IF NOT EXISTS error TEXT",
     # Retired: navflow no longer auto-extracts numeric fields. Numbers you aggregate are declared
     # as number-typed labels (stored in `labels`); the raw values remain in `payload`. Metadata-only
     # drop in DuckDB, so this is instant even on a large table.
@@ -680,14 +682,20 @@ class Store:
             )
 
     def list_dispatches(self, limit: int = 100) -> list[dict]:
+        # `error` = the most recent failed delivery's reason for this dispatch (NULL if all delivered
+        # or there were no subscribers), so a "delivered 0 of N" row can show WHY.
         with self._lock:
             rows = self.con.execute(
-                "SELECT dispatch_id, trigger, key_value, kind, fired_at, subscribers, delivered, payload "
-                "FROM dispatch_log ORDER BY fired_at DESC LIMIT ?", [int(limit)],
+                "SELECT l.dispatch_id, l.trigger, l.key_value, l.kind, l.fired_at, "
+                "l.subscribers, l.delivered, l.payload, "
+                "(SELECT arg_max(d.error, d.delivered_at) FROM dispatch_deliveries d "
+                " WHERE d.dispatch_id = l.dispatch_id AND NOT d.ok) AS error "
+                "FROM dispatch_log l ORDER BY l.fired_at DESC LIMIT ?", [int(limit)],
             ).fetchall()
         return [
             {"dispatch_id": r[0], "trigger": r[1], "key": r[2], "kind": r[3],
-             "fired_at": r[4], "subscribers": r[5], "delivered": r[6], "payload": r[7]}
+             "fired_at": r[4], "subscribers": r[5], "delivered": r[6], "payload": r[7],
+             "error": r[8]}
             for r in rows
         ]
 
@@ -903,10 +911,14 @@ class Store:
         with self._lock:
             self.con.execute("DELETE FROM subscriptions WHERE subscription_id = ?", [sid])
 
-    def log_delivery(self, dispatch_id: str, subscription_id: str, url: str, ok: bool) -> None:
+    def log_delivery(self, dispatch_id: str, subscription_id: str, url: str, ok: bool,
+                     error: str | None = None) -> None:
+        # Explicit column list: `error` was appended by migration, so positional VALUES no longer match.
         with self._lock:
-            self.con.execute("INSERT INTO dispatch_deliveries VALUES (?, ?, ?, ?, ?)",
-                             [dispatch_id, subscription_id, url, ok, now_utc()])
+            self.con.execute(
+                "INSERT INTO dispatch_deliveries "
+                "(dispatch_id, subscription_id, url, ok, delivered_at, error) VALUES (?, ?, ?, ?, ?, ?)",
+                [dispatch_id, subscription_id, url, ok, now_utc(), error])
 
     def all_subscriptions(self) -> list[dict]:
         with self._lock:
@@ -917,23 +929,27 @@ class Store:
                  "created_at": r[3], "created_by": r[4]} for r in rows]
 
     def delivery_stats(self) -> dict:
-        """{url: {"ok": n, "fail": n, "last_at": ts}} across all recorded deliveries."""
+        """{url: {ok, fail, last_at, last_ok, last_error}} across all recorded deliveries. `last_ok`
+        / `last_error` describe the MOST RECENT delivery, so the UI can flag an endpoint that's
+        currently failing and say why (arg_max picks the value at the latest delivered_at)."""
         with self._lock:
             rows = self.con.execute(
                 "SELECT url, SUM(CASE WHEN ok THEN 1 ELSE 0 END), "
-                "SUM(CASE WHEN ok THEN 0 ELSE 1 END), MAX(delivered_at) "
+                "SUM(CASE WHEN ok THEN 0 ELSE 1 END), MAX(delivered_at), "
+                "arg_max(ok, delivered_at), arg_max(error, delivered_at) "
                 "FROM dispatch_deliveries GROUP BY url").fetchall()
-        return {r[0]: {"ok": int(r[1] or 0), "fail": int(r[2] or 0), "last_at": r[3]} for r in rows}
+        return {r[0]: {"ok": int(r[1] or 0), "fail": int(r[2] or 0), "last_at": r[3],
+                       "last_ok": bool(r[4]), "last_error": r[5]} for r in rows}
 
     def recent_deliveries(self, url: str, limit: int = 20) -> list[dict]:
         """Latest deliveries to one endpoint, joined with the firing's trigger/entity."""
         with self._lock:
             rows = self.con.execute(
-                "SELECT d.delivered_at, d.ok, l.trigger, l.key_value, d.dispatch_id "
+                "SELECT d.delivered_at, d.ok, l.trigger, l.key_value, d.dispatch_id, d.error "
                 "FROM dispatch_deliveries d LEFT JOIN dispatch_log l ON d.dispatch_id = l.dispatch_id "
                 "WHERE d.url = ? ORDER BY d.delivered_at DESC LIMIT ?", [url, limit]).fetchall()
         return [{"at": r[0], "ok": bool(r[1]), "trigger": r[2], "key": r[3],
-                 "dispatch_id": r[4]} for r in rows]
+                 "dispatch_id": r[4], "error": r[5]} for r in rows]
 
     # ── API keys (scoped credentials; only the SHA-256 of the secret is stored) ─
     def insert_api_key(self, kid: str, name: str, prefix: str, hash_: str, scopes: list[str]) -> None:

--- a/ui/src/pages/Activity.tsx
+++ b/ui/src/pages/Activity.tsx
@@ -368,7 +368,10 @@ function AgentsRoster() {
           {data.agents.map((a) => (
             <>
               <tr key={a.name} className="clickable" onClick={() => setOpen(open === a.name ? undefined : a.name)}>
-                <td><strong>{a.name}</strong></td>
+                <td>
+                  <strong>{a.name}</strong>
+                  {a.unhealthy && <span className="badge error" style={{ marginLeft: 8 }} title={a.last_error ?? "last delivery failed"}>failing</span>}
+                </td>
                 <td className="mono">{a.endpoint}</td>
                 <td>{a.triggers.map((t) => <span className="chip mono" key={t}>{t}</span>)}</td>
                 <td className="num">{a.delivered_ok}</td>
@@ -406,7 +409,7 @@ function AgentsRoster() {
                                   <td style={{ whiteSpace: "nowrap" }}><TimeAgo ts={r.at} /></td>
                                   <td className="mono">{r.trigger}</td>
                                   <td className="mono">{r.key}</td>
-                                  <td>{r.ok ? <span className="badge ok">delivered</span> : <span className="badge error">failed</span>}</td>
+                                  <td>{r.ok ? <span className="badge ok">delivered</span> : <span className="badge error" title={r.error ?? undefined}>failed{r.error ? `: ${r.error}` : ""}</span>}</td>
                                 </tr>
                               ))}
                             </tbody>
@@ -554,6 +557,7 @@ function Dispatches() {
                 <span className="k">fired</span><span><TimeAgo ts={sel.fired_at} /></span>
                 <span className="k">kind</span><span className="mono">{sel.kind}</span>
                 <span className="k">delivery</span><span>{deliveryBadge(sel)}</span>
+                {sel.error && <><span className="k">error</span><span className="mono" style={{ color: "var(--err)" }}>{sel.error}</span></>}
                 <span className="k">dispatch id</span><span className="mono">{sel.dispatch_id}</span>
               </div>
               <h3 style={{ margin: "18px 0 6px" }}>Payload</h3>

--- a/ui/src/pages/TriggerDetail.tsx
+++ b/ui/src/pages/TriggerDetail.tsx
@@ -84,7 +84,7 @@ export default function TriggerDetail() {
       <h2>Agents woken by this trigger</h2>
       {wired.length > 0 ? (
         <table style={{ marginBottom: 10 }}>
-          <thead><tr><th>agent</th><th>endpoint</th><th className="num">delivered</th><th className="num">failed</th></tr></thead>
+          <thead><tr><th>agent</th><th>endpoint</th><th className="num">delivered</th><th className="num">failed</th><th>status</th></tr></thead>
           <tbody>
             {wired.map((a) => (
               <tr key={a.name}>
@@ -92,6 +92,11 @@ export default function TriggerDetail() {
                 <td className="mono">{a.endpoint}</td>
                 <td className="num">{a.delivered_ok}</td>
                 <td className="num" style={a.delivered_fail ? { color: "var(--err)" } : undefined}>{a.delivered_fail}</td>
+                <td>
+                  {a.unhealthy
+                    ? <span className="badge error" title={a.last_error ?? "last delivery failed"}>failing{a.last_error ? `: ${a.last_error}` : ""}</span>
+                    : a.delivered_ok > 0 ? <span className="badge ok">ok</span> : <span className="dim">—</span>}
+                </td>
               </tr>
             ))}
           </tbody>
@@ -124,16 +129,19 @@ export default function TriggerDetail() {
       {firings.length === 0 && <p className="help">none yet</p>}
       {firings.length > 0 && (
         <table>
-          <thead><tr><th>fired</th><th>entity</th><th className="num">subscribers</th><th className="num">delivered</th></tr></thead>
+          <thead><tr><th>fired</th><th>entity</th><th className="num">subscribers</th><th className="num">delivered</th><th>error</th></tr></thead>
           <tbody>
-            {firings.map((d) => (
+            {firings.map((d) => {
+              const failed = d.subscribers > d.delivered;
+              return (
               <tr key={d.dispatch_id}>
                 <td style={{ whiteSpace: "nowrap" }}><TimeAgo ts={d.fired_at} /></td>
                 <td className="mono">{d.key}</td>
                 <td className="num">{d.subscribers}</td>
-                <td className="num">{d.delivered}</td>
+                <td className="num" style={failed ? { color: "var(--err)" } : undefined}>{d.delivered}</td>
+                <td className="mono" style={{ color: "var(--err)" }} title={d.error ?? undefined}>{failed ? (d.error ?? "delivery failed") : ""}</td>
               </tr>
-            ))}
+            ); })}
           </tbody>
         </table>
       )}

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -141,7 +141,9 @@ export interface AgentInfo {
   delivered_ok: number;
   delivered_fail: number;
   last_woken: string | null;
-  recent: { at: string | null; ok: boolean; trigger: string | null; key: string | null }[];
+  unhealthy?: boolean;          // the most recent delivery to this endpoint failed
+  last_error?: string | null;   // why, when unhealthy
+  recent: { at: string | null; ok: boolean; trigger: string | null; key: string | null; error?: string | null }[];
 }
 
 export interface ApiKey {
@@ -233,6 +235,7 @@ export interface DispatchLogEntry {
   subscribers: number;
   delivered: number;
   payload: string;
+  error?: string | null;   // most recent failed delivery's reason, when delivered < subscribers
 }
 
 export interface Subscription {


### PR DESCRIPTION
A failed delivery to an agent's endpoint was a silent `delivered 0` with no cause. This captures and surfaces the reason, and makes `delivered` honest.

## Backend
- **dispatch** — `_post` returns `(ok, error)`: `ok` only on a **2xx**. A **4xx is a definitive failure and is not retried** (bad secret / wrong path / gone won't self-heal), so `delivered` now means the agent actually accepted it. 5xx + transport errors (unreachable / timeout / DNS) retry with backoff; the last error (e.g. `ConnectError: Connection refused`) is captured.
- **store** — `error` column on `dispatch_deliveries` (+ migration, no DEFAULT); `recent_deliveries`, `delivery_stats` (`last_ok`/`last_error`), and `list_dispatches` surface it.
- **daemon** — agents panel flags an endpoint whose most recent delivery failed (`unhealthy` + `last_error`, per-delivery `error`).

## UI
- **Trigger detail** — agents table gains a **status** column (`failing: <error>` / `ok`); Recent firings show an **error** column when `delivered < subscribers`.
- **Activity** — a **"failing"** badge on unhealthy agents, the error on each failed recent wake, and the reason in the dispatch detail panel.

## Tests
13/13 unit (2xx ok · 4xx fail-no-retry · 5xx+ConnectError retry+capture · store round-trip · migration on a pre-existing DB · `list_dispatches` error) + 7/7 end-to-end (unreachable endpoint → `delivered 0 of 1` with the ConnectError, agent flagged unhealthy). Full suite green except two pre-existing failures. UI typechecks.