### PR TITLE
Dispatch detail pages, linked from the Agents tab

### DIFF
--- a/navflow/daemon.py
+++ b/navflow/daemon.py
@@ -1049,6 +1049,21 @@ def make_app() -> FastAPI:
     async def activity_dispatches(limit: int = 100):
         return store.list_dispatches(limit=min(limit, 500))
 
+    @app.get("/api/activity/dispatches/{dispatch_id}")
+    async def activity_dispatch(dispatch_id: str):
+        """One firing, deep. Fetch-by-id so a linked dispatch page never dead-ends (unlike the
+        capped list). Includes the per-subscriber delivery attempts with masked endpoints + agent
+        names, so the failure is attributable to a specific agent."""
+        d = store.get_dispatch(dispatch_id)
+        if d is None:
+            _err(KeyError(f"unknown dispatch {dispatch_id!r}"), 404)
+        deliveries = []
+        for dv in store.deliveries_for(dispatch_id):
+            name, masked = _agent_identity(dv["url"].rstrip("/"))
+            deliveries.append({"agent": name, "endpoint": masked, "ok": dv["ok"],
+                               "error": dv["error"], "delivered_at": dv["delivered_at"]})
+        return {**d, "deliveries": deliveries}
+
     # ── connected agents: subscriptions grouped by endpoint, named deterministically ──
     _AGENT_ADJ = ["brisk", "quiet", "amber", "bold", "calm", "deft", "eager", "fleet",
                   "keen", "lucid", "merry", "noble", "prime", "swift", "vivid", "wry"]

--- a/navflow/store.py
+++ b/navflow/store.py
@@ -673,6 +673,30 @@ class Store:
             for r in rows
         ]
 
+    def get_dispatch(self, dispatch_id: str) -> dict | None:
+        """One firing by id, with the same failure-reason as list_dispatches. None if unknown."""
+        with self._lock:
+            r = self.con.execute(
+                "SELECT l.dispatch_id, l.trigger, l.key_value, l.kind, l.fired_at, "
+                "l.subscribers, l.delivered, l.payload, "
+                "(SELECT arg_max(d.error, d.delivered_at) FROM dispatch_deliveries d "
+                " WHERE d.dispatch_id = l.dispatch_id AND NOT d.ok) AS error "
+                "FROM dispatch_log l WHERE l.dispatch_id = ?", [dispatch_id]).fetchone()
+        if r is None:
+            return None
+        return {"dispatch_id": r[0], "trigger": r[1], "key": r[2], "kind": r[3],
+                "fired_at": r[4], "subscribers": r[5], "delivered": r[6], "payload": r[7],
+                "error": r[8]}
+
+    def deliveries_for(self, dispatch_id: str) -> list[dict]:
+        """Per-subscriber delivery attempts for one firing — the detail behind 'delivered X of N'."""
+        with self._lock:
+            rows = self.con.execute(
+                "SELECT subscription_id, url, ok, error, delivered_at FROM dispatch_deliveries "
+                "WHERE dispatch_id = ? ORDER BY delivered_at", [dispatch_id]).fetchall()
+        return [{"subscription_id": r[0], "url": r[1], "ok": bool(r[2]),
+                 "error": r[3], "delivered_at": r[4]} for r in rows]
+
     def log_dispatch(self, dispatch_id: str, trigger: str, key: str, kind: str,
                      subscribers: int, delivered: int, payload: str) -> None:
         with self._lock:

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -1,7 +1,7 @@
 import type {
   AgentInfo,
   ApiKey,
-  CatalogDescribe, CatalogList, ConnectorSpec, DiscoverProposal, DispatchLogEntry, Entity, EnvScan,
+  CatalogDescribe, CatalogList, ConnectorSpec, DiscoverProposal, DispatchDetail, DispatchLogEntry, Entity, EnvScan,
   LabelFacet, QueryLogEntry, Source, SourceEvent, SourceFieldsProfile, Subscription, TestResult,
   TimelineEventRow, Trigger, View,
 } from "./types";
@@ -123,6 +123,7 @@ export const api = {
   queries: (limit = 100) => request<QueryLogEntry[]>(`/api/activity/queries?limit=${limit}`),
   dispatches: (limit = 100) =>
     request<DispatchLogEntry[]>(`/api/activity/dispatches?limit=${limit}`),
+  dispatch: (id: string) => request<DispatchDetail>(`/api/activity/dispatches/${id}`),
   subscriptions: () => request<Subscription[]>("/api/subscriptions"),
   mcpTools: () => request<{ name: string; description: string }[]>("/api/mcp/tools"),
 

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -6,6 +6,7 @@ import App from "./App";
 import AuthGate from "./components/AuthGate";
 import AgentActivity, { ConnectPage } from "./pages/Activity";
 import Ask from "./pages/Ask";
+import DispatchDetail from "./pages/DispatchDetail";
 import Explore from "./pages/Explore";
 import SourceClaudeCode from "./pages/SourceClaudeCode";
 import SourceDetail from "./pages/SourceDetail";
@@ -41,6 +42,7 @@ const router = createBrowserRouter([
       { path: "triggers/:name", element: <TriggerDetail /> },
       { path: "connect", element: <ConnectPage /> },
       { path: "activity", element: <AgentActivity /> },
+      { path: "dispatches/:id", element: <DispatchDetail /> },
       { path: "agents", element: <Navigate to="/connect" replace /> },
       { path: "ask", element: <Ask /> },
       { path: "security", element: <Security /> },

--- a/ui/src/pages/Activity.tsx
+++ b/ui/src/pages/Activity.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useMemo, useState } from "react";
-import { Link, useSearchParams } from "react-router-dom";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
 
 import { api, auth } from "../api";
-import { Close, Search } from "../components/icons";
+import { Search } from "../components/icons";
 import { TimeAgo, usePolling } from "../components/bits";
 import type { DispatchLogEntry } from "../types";
 
@@ -41,7 +41,14 @@ const ACTIVITY_LABELS: Record<ActivityTab, string> = {
 };
 
 export default function AgentActivity() {
-  const [tab, setTab] = useState<ActivityTab>("agents");
+  const [params, setParams] = useSearchParams();
+  const tab = (["agents", "queries", "dispatches"].includes(params.get("tab") ?? "")
+    ? params.get("tab") : "agents") as ActivityTab;
+  const setTab = (t: ActivityTab) => {
+    const next = new URLSearchParams(params);
+    next.set("tab", t);
+    setParams(next);
+  };
 
   return (
     <>
@@ -345,6 +352,7 @@ function Connect({ tab }: { tab: ConnectTab }) {
 }
 
 function AgentsRoster() {
+  const nav = useNavigate();
   const { data, error } = usePolling(() => api.agents(), 10000);
   const [params] = useSearchParams();
   const [open, setOpen] = useState<string | undefined>(params.get("agent") ?? undefined);
@@ -400,14 +408,15 @@ function AgentsRoster() {
                       ))}
                       {a.recent.length > 0 && (
                         <>
-                          <p className="help" style={{ margin: "10px 0 4px" }}>recent wakes</p>
+                          <p className="help" style={{ margin: "10px 0 4px" }}>recent wakes — open one for the full dispatch</p>
                           <table>
                             <thead><tr><th>when</th><th>trigger</th><th>entity</th><th>delivery</th></tr></thead>
                             <tbody>
                               {a.recent.map((r, i) => (
-                                <tr key={i}>
+                                <tr key={i} className={r.dispatch_id ? "clickable" : undefined}
+                                    onClick={r.dispatch_id ? () => nav(`/dispatches/${encodeURIComponent(r.dispatch_id!)}`) : undefined}>
                                   <td style={{ whiteSpace: "nowrap" }}><TimeAgo ts={r.at} /></td>
-                                  <td className="mono">{r.trigger}</td>
+                                  <td className="mono">{r.dispatch_id ? <Link to={`/dispatches/${encodeURIComponent(r.dispatch_id)}`}>{r.trigger}</Link> : r.trigger}</td>
                                   <td className="mono">{r.key}</td>
                                   <td>{r.ok ? <span className="badge ok">delivered</span> : <span className="badge error" title={r.error ?? undefined}>failed{r.error ? `: ${r.error}` : ""}</span>}</td>
                                 </tr>
@@ -498,9 +507,9 @@ function deliveryBadge(d: DispatchLogEntry) {
 }
 
 function Dispatches() {
+  const nav = useNavigate();
   const { data, error } = usePolling(() => api.dispatches(150));
   const [q, setQ] = useState("");
-  const [sel, setSel] = useState<DispatchLogEntry | null>(null);
 
   const shown = useMemo(() => {
     const needle = q.trim().toLowerCase();
@@ -508,13 +517,6 @@ function Dispatches() {
       !needle || d.trigger.toLowerCase().includes(needle) || d.key.toLowerCase().includes(needle) ||
       d.kind.toLowerCase().includes(needle));
   }, [data, q]);
-
-  useEffect(() => {
-    if (!sel) return;
-    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setSel(null); };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [sel]);
 
   if (error) return <div className="alert error">{error}</div>;
   if (!data?.length) return <div className="empty">no trigger firings yet</div>;
@@ -525,13 +527,10 @@ function Dispatches() {
         <thead><tr><th>fired</th><th>trigger</th><th>key</th><th>kind</th><th>delivery</th></tr></thead>
         <tbody>
           {shown.map((d) => (
-            <tr
-              key={d.dispatch_id}
-              className={"clickable" + (sel?.dispatch_id === d.dispatch_id ? " sel" : "")}
-              onClick={() => setSel(d)}
-            >
+            <tr key={d.dispatch_id} className="clickable"
+                onClick={() => nav(`/dispatches/${encodeURIComponent(d.dispatch_id)}`)}>
               <td style={{ whiteSpace: "nowrap" }}><TimeAgo ts={d.fired_at} /></td>
-              <td className="mono">{d.trigger}</td>
+              <td className="mono"><Link to={`/dispatches/${encodeURIComponent(d.dispatch_id)}`}>{d.trigger}</Link></td>
               <td className="mono">{d.key}</td>
               <td className="mono">{d.kind}</td>
               <td>{deliveryBadge(d)}</td>
@@ -540,32 +539,6 @@ function Dispatches() {
           {!shown.length && <tr><td colSpan={5} className="dim" style={{ textAlign: "center", padding: 24 }}>no dispatches match “{q}”</td></tr>}
         </tbody>
       </table>
-
-      {sel && (
-        <>
-          <div className="sheet-overlay" onClick={() => setSel(null)} />
-          <aside className="sheet" role="dialog" aria-label="Dispatch detail">
-            <div className="sheet-head">
-              <div className="sheet-title">
-                <h2><span className="mono">{sel.trigger}</span></h2>
-                <span className="subtitle" style={{ margin: 0 }}>fired for <span className="mono">{sel.key}</span></span>
-              </div>
-              <button className="sheet-close" onClick={() => setSel(null)} aria-label="Close"><Close /></button>
-            </div>
-            <div className="sheet-body">
-              <div className="kv">
-                <span className="k">fired</span><span><TimeAgo ts={sel.fired_at} /></span>
-                <span className="k">kind</span><span className="mono">{sel.kind}</span>
-                <span className="k">delivery</span><span>{deliveryBadge(sel)}</span>
-                {sel.error && <><span className="k">error</span><span className="mono" style={{ color: "var(--err)" }}>{sel.error}</span></>}
-                <span className="k">dispatch id</span><span className="mono">{sel.dispatch_id}</span>
-              </div>
-              <h3 style={{ margin: "18px 0 6px" }}>Payload</h3>
-              <pre className="payload">{sel.payload}</pre>
-            </div>
-          </aside>
-        </>
-      )}
     </>
   );
 }

--- a/ui/src/pages/DispatchDetail.tsx
+++ b/ui/src/pages/DispatchDetail.tsx
@@ -1,0 +1,88 @@
+import { Link, useParams } from "react-router-dom";
+
+import { api } from "../api";
+import { TimeAgo, usePolling } from "../components/bits";
+
+// One firing, deep — the page behind a dispatch_id. Fetched by id so links from the Agents tab
+// (or anywhere) always resolve, unlike the capped dispatches list. Shows the per-subscriber
+// delivery attempts (who got it, who failed and why) plus the full payload the agent received.
+export default function DispatchDetail() {
+  const { id = "" } = useParams();
+  const { data: d, error } = usePolling(() => api.dispatch(id), 10000);
+
+  if (error) {
+    return (
+      <div className="alert error">
+        {/unknown dispatch/i.test(error) ? <>no dispatch <span className="mono">{id}</span></> : error}
+        {" "}— see <Link to="/activity?tab=dispatches">Trigger dispatches</Link>
+      </div>
+    );
+  }
+  if (!d) return <div className="dim">loading…</div>;
+
+  const failed = d.subscribers > d.delivered;
+  let payload = d.payload;
+  try { payload = JSON.stringify(JSON.parse(d.payload), null, 2); } catch { /* keep raw */ }
+
+  return (
+    <>
+      <div className="pagehead">
+        <div>
+          <p className="subtitle" style={{ marginBottom: 4 }}>
+            <Link to="/activity?tab=dispatches">Trigger dispatches</Link> ›
+          </p>
+          <h1>
+            <Link to={`/triggers/${encodeURIComponent(d.trigger)}`} className="mono">{d.trigger}</Link>
+          </h1>
+          <p className="subtitle">
+            fired for <span className="mono">{d.key}</span> · <TimeAgo ts={d.fired_at} />
+          </p>
+        </div>
+      </div>
+
+      <div className="kv" style={{ marginBottom: 18 }}>
+        <span className="k">kind</span><span className="mono">{d.kind}</span>
+        <span className="k">delivery</span>
+        <span>
+          {d.subscribers === 0
+            ? <span className="badge starting">no subscribers</span>
+            : <span className={`badge ${failed ? "error" : "ok"}`}>{d.delivered}/{d.subscribers} delivered</span>}
+        </span>
+        {d.error && <><span className="k">error</span><span className="mono" style={{ color: "var(--err)" }}>{d.error}</span></>}
+        <span className="k">dispatch id</span><span className="mono">{d.dispatch_id}</span>
+      </div>
+
+      <h2>Deliveries</h2>
+      {d.deliveries.length === 0 ? (
+        <p className="help" style={{ whiteSpace: "normal" }}>
+          no subscribers were attached when this fired — nothing was delivered (the firing is still
+          logged; wire an agent on the <Link to={`/triggers/${encodeURIComponent(d.trigger)}`}>trigger</Link>).
+        </p>
+      ) : (
+        <table style={{ marginBottom: 18 }}>
+          <thead><tr><th>agent</th><th>endpoint</th><th>status</th><th>when</th></tr></thead>
+          <tbody>
+            {d.deliveries.map((dv, i) => (
+              <tr key={i}>
+                <td><Link to={`/activity?agent=${encodeURIComponent(dv.agent)}`}><strong>{dv.agent}</strong></Link></td>
+                <td className="mono">{dv.endpoint}</td>
+                <td>
+                  {dv.ok
+                    ? <span className="badge ok">delivered</span>
+                    : <span className="badge error" title={dv.error ?? undefined}>failed{dv.error ? `: ${dv.error}` : ""}</span>}
+                </td>
+                <td style={{ whiteSpace: "nowrap" }}><TimeAgo ts={dv.delivered_at} /></td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      <h2>Payload</h2>
+      <p className="help" style={{ margin: "0 0 6px", whiteSpace: "normal" }}>
+        the timeline POSTed to each subscriber — the agent boots holding this.
+      </p>
+      <pre className="payload">{payload}</pre>
+    </>
+  );
+}

--- a/ui/src/pages/TriggerDetail.tsx
+++ b/ui/src/pages/TriggerDetail.tsx
@@ -134,8 +134,9 @@ export default function TriggerDetail() {
             {firings.map((d) => {
               const failed = d.subscribers > d.delivered;
               return (
-              <tr key={d.dispatch_id}>
-                <td style={{ whiteSpace: "nowrap" }}><TimeAgo ts={d.fired_at} /></td>
+              <tr key={d.dispatch_id} className="clickable"
+                  onClick={() => nav(`/dispatches/${encodeURIComponent(d.dispatch_id)}`)}>
+                <td style={{ whiteSpace: "nowrap" }}><Link to={`/dispatches/${encodeURIComponent(d.dispatch_id)}`}><TimeAgo ts={d.fired_at} /></Link></td>
                 <td className="mono">{d.key}</td>
                 <td className="num">{d.subscribers}</td>
                 <td className="num" style={failed ? { color: "var(--err)" } : undefined}>{d.delivered}</td>

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -143,7 +143,7 @@ export interface AgentInfo {
   last_woken: string | null;
   unhealthy?: boolean;          // the most recent delivery to this endpoint failed
   last_error?: string | null;   // why, when unhealthy
-  recent: { at: string | null; ok: boolean; trigger: string | null; key: string | null; error?: string | null }[];
+  recent: { at: string | null; ok: boolean; trigger: string | null; key: string | null; error?: string | null; dispatch_id?: string }[];
 }
 
 export interface ApiKey {
@@ -236,6 +236,20 @@ export interface DispatchLogEntry {
   delivered: number;
   payload: string;
   error?: string | null;   // most recent failed delivery's reason, when delivered < subscribers
+}
+
+// One delivery attempt to a specific subscriber, for the dispatch detail page.
+export interface DispatchDelivery {
+  agent: string;
+  endpoint: string;   // masked
+  ok: boolean;
+  error?: string | null;
+  delivered_at: string | null;
+}
+
+// A single firing, deep — fetched by id so a linked dispatch page never dead-ends.
+export interface DispatchDetail extends DispatchLogEntry {
+  deliveries: DispatchDelivery[];
 }
 
 export interface Subscription {


### PR DESCRIPTION
Trigger dispatches were a cramped sidebar sheet with no path in from the Agents view. This gives each firing a real page keyed by `dispatch_id`, and links into it from everywhere a dispatch appears.

## Backend
- **store** — `get_dispatch(id)` + `deliveries_for(id)` (per-subscriber attempts).
- **daemon** — `GET /api/activity/dispatches/{id}`: **fetch by id** so a linked page never dead-ends (unlike the capped list). Returns the firing plus `deliveries[]` with **masked endpoints + deterministic agent names** (no secret leak) and per-delivery error; 404 on unknown id.

## Frontend
- **New `/dispatches/:id` page** — delivery summary, a per-agent **Deliveries** table (who got it, who failed and why), and the full payload pretty-printed; links back to the trigger and each agent.
- **Trigger dispatches** rows navigate to the page (sidebar sheet removed); no-subscriber firings still listed.
- **The connection**: each agent's **recent wakes** row links to its dispatch page (via `dispatch_id`); **Trigger detail → recent firings** too. Activity tabs are URL-driven (`?tab=`).

## Tests
11/11 backend (by-id fetch, delivered 0/1, top-level + per-delivery errors, endpoint masking, agent name, 404). Full suite green except two pre-existing failures. UI typechecks and production-builds clean.