### PR TITLE
Pass dispatch_id through the agent panel so recent-wake rows link

### DIFF
--- a/navflow/daemon.py
+++ b/navflow/daemon.py
@@ -1109,7 +1109,7 @@ def make_app() -> FastAPI:
                     "unhealthy": st.get("fail", 0) > 0 and not st.get("last_ok", True),
                     "last_error": None if st.get("last_ok", True) else st.get("last_error"),
                     "recent": [{"at": d["at"], "ok": d["ok"], "trigger": d["trigger"],
-                                "key": d["key"], "error": d["error"]}
+                                "key": d["key"], "error": d["error"], "dispatch_id": d["dispatch_id"]}
                                for d in store.recent_deliveries(sub["url"], 10)],
                 }
             a["subscriptions"].append({"subscription_id": sub["subscription_id"],


### PR DESCRIPTION
Follow-up to the dispatch detail pages (#32). `store.recent_deliveries` returns `dispatch_id` and the UI renders the recent-wake link conditionally on it, but the daemon's agent panel dropped the field when building `recent` — so the **Agents → recent wake → dispatch page** link never appeared.

One-line fix: include `dispatch_id` in the `recent` mapping. No UI or schema change.

Verified end-to-end: agent `recent[0]` now carries `dispatch_id`, and it resolves via `GET /api/activity/dispatches/{id}`.