### PR TITLE
Redact connector secrets; never expose tokens to agents

### DIFF
--- a/navflow/connectors/__init__.py
+++ b/navflow/connectors/__init__.py
@@ -99,6 +99,55 @@ def full_schema(connector: str) -> dict | None:
     return {**schema, **UNIVERSAL_CONFIG} if schema is not None else None
 
 
+# Placeholder returned in place of a stored secret (a connector token/DSN). Chosen so it can never
+# be a real credential; the update path treats a field still equal to this as "unchanged".
+REDACTED_SECRET = "••••••••"
+
+
+def secret_field_names(connector: str) -> set:
+    """Config keys a connector marks `secret: True` in its CONFIG_SCHEMA (e.g. github `token`,
+    postgres `dsn`). These must never be serialized to a client — including the built-in agent and
+    MCP, which read source config over /api/sources."""
+    schema = full_schema(connector)
+    if not schema:
+        return set()
+    return {k for k, spec in schema.items() if isinstance(spec, dict) and spec.get("secret")}
+
+
+def redact_config(connector: str, config: dict) -> dict:
+    """A copy of `config` with secret fields masked, for any response leaving the daemon. The stored
+    catalog keeps the real values (the connector reads those at runtime); only the wire form is
+    redacted. Empty secrets stay empty so the UI can tell 'not set' from 'set'."""
+    secrets = secret_field_names(connector)
+    if not secrets or not isinstance(config, dict):
+        return config
+    return {k: (REDACTED_SECRET if k in secrets and v not in (None, "") else v)
+            for k, v in config.items()}
+
+
+def restore_secrets(connector: str, new_config: dict, existing_config: dict | None) -> dict:
+    """Reconcile a saved config with the stored secrets a client never saw. Blank-to-keep semantics:
+      • secret OMITTED (or echoed back as the redaction placeholder) → keep the stored value
+      • secret present and EMPTY ("")                                → clear it (explicit remove)
+      • secret present and non-empty                                 → replace with the new value
+    So editing other fields never wipes a token, and clearing one is an explicit act."""
+    secrets = secret_field_names(connector)
+    if not secrets or not isinstance(new_config, dict):
+        return new_config
+    out = dict(new_config)
+    for k in secrets:
+        if k not in new_config or out.get(k) == REDACTED_SECRET:   # omitted / placeholder → keep
+            existing = (existing_config or {}).get(k)
+            if existing not in (None, ""):
+                out[k] = existing
+            else:
+                out.pop(k, None)
+        elif out.get(k) in (None, ""):                             # explicit empty → clear
+            out.pop(k, None)
+        # else: a real new value → replace (passes through)
+    return out
+
+
 _LABEL_NAME = _re.compile(r"^[A-Za-z0-9_]+$")
 
 

--- a/navflow/daemon.py
+++ b/navflow/daemon.py
@@ -24,7 +24,8 @@ from pydantic import BaseModel
 from .config import (CatalogError, export_db_to_yaml, import_yaml_to_db,
                      validate_source_dict, validate_trigger_dict, validate_view_dict,
                      _source_from_dict)
-from .connectors import SPECS, normalize_config, source_type_for
+from .connectors import (SPECS, normalize_config, redact_config, restore_secrets,
+                         source_type_for)
 from .dispatch import Dispatcher
 from .envelope import now_utc
 from .runtime import Runtime
@@ -416,6 +417,7 @@ def make_app() -> FastAPI:
             entry = next((s for s in store.list_catalog_sources() if s["name"] == name), None)
             if entry is None:
                 _err(KeyError(f"unknown source {name!r}"), 404)
+            entry = {**entry, "config": redact_config(entry["connector"], entry["config"])}
             health = runtime.health_snapshot().get(name) or {}
             names = _source_label_names(entry)
             if names:
@@ -745,13 +747,15 @@ def make_app() -> FastAPI:
     @app.get("/api/sources")
     async def list_sources():
         health = runtime.health_snapshot()
-        return [{**s, "health": health.get(s["name"])} for s in store.list_catalog_sources()]
+        return [{**s, "config": redact_config(s["connector"], s["config"]),
+                 "health": health.get(s["name"])} for s in store.list_catalog_sources()]
 
     @app.get("/api/sources/{name}")
     async def get_source(name: str):
         for s in store.list_catalog_sources():
             if s["name"] == name:
-                return {**s, "health": runtime.health_snapshot().get(name)}
+                return {**s, "config": redact_config(s["connector"], s["config"]),
+                        "health": runtime.health_snapshot().get(name)}
         _err(KeyError(f"unknown source {name!r}"), 404)
 
     @app.post("/api/sources", status_code=201)
@@ -778,7 +782,10 @@ def make_app() -> FastAPI:
             _err(ValueError("renaming a source is not supported; delete and recreate"), 400)
         try:
             validate_source_dict(body.model_dump())
-            config = normalize_config(body.connector, body.config)
+            # A client edits with the secret masked; if it saves the placeholder back unchanged,
+            # keep the stored secret instead of overwriting it (see connectors.redact_config).
+            config = normalize_config(
+                body.connector, restore_secrets(body.connector, body.config, existing["config"]))
         except CatalogError as e:
             _err(e)
         store.upsert_catalog_source(name, source_type_for(body.connector), body.connector,

--- a/ui/src/components/SourceForm.tsx
+++ b/ui/src/components/SourceForm.tsx
@@ -42,10 +42,15 @@ export default function SourceForm({ connector, spec, initial, lockName, submitL
   const [name, setName] = useState(initial?.name ?? "");
   const type = initial?.type ?? "event_stream";  // ignored by the daemon; derived from connector
   const [poll, setPoll] = useState(initial?.poll ?? spec.poll ?? "5s");
+  // A secret that's already stored comes back from the API as a redaction placeholder, never its
+  // real value. Show which secrets are set, but never prefill one — blank means "keep it" (below).
+  const secretSet = (f: ConnectorField) => !!f.secret && !!initial?.config?.[f.name];
+  const [cleared, setCleared] = useState<Record<string, boolean>>({});
   const [values, setValues] = useState<Record<string, string>>(() => {
     const v: Record<string, string> = {};
     for (const f of spec.fields) {
       if (f.type === "list") continue;   // list fields use `rows`, below
+      if (f.secret) { v[f.name] = ""; continue; }   // never prefill a secret
       const cur = initial?.config?.[f.name];
       if (cur === undefined || cur === null) v[f.name] = "";
       else if (f.type === "json") v[f.name] = JSON.stringify(cur, null, 2);
@@ -135,6 +140,13 @@ export default function SourceForm({ connector, spec, initial, lockName, submitL
         continue;
       }
       const raw = values[f.name]?.trim();
+      // A secret that's already set: blank = keep (omit), typed = replace, Remove = clear ("").
+      if (secretSet(f)) {
+        if (cleared[f.name]) config[f.name] = "";       // explicit remove
+        else if (raw) config[f.name] = raw;             // replace
+        // else omit → the daemon keeps the stored secret
+        continue;
+      }
       if (!raw) {
         if (f.required) throw new Error(`${f.name} is required`);
         continue;
@@ -260,9 +272,22 @@ export default function SourceForm({ connector, spec, initial, lockName, submitL
         ) : (
           <input type={f.secret ? "password" : f.type === "number" ? "number" : "text"}
                  value={values[f.name]} autoComplete={f.secret ? "off" : undefined}
+                 disabled={secretSet(f) && cleared[f.name]}
+                 placeholder={secretSet(f) ? (cleared[f.name] ? "" : "leave blank to keep") : undefined}
                  onChange={(e) => setValues({ ...values, [f.name]: e.target.value })} />
         )}
-        <span className="help">{jsonErrors[f.name] ?? f.help}</span>
+        {secretSet(f) ? (
+          <span className="help">
+            {cleared[f.name]
+              ? <>will be removed on save — <button type="button" className="linklike"
+                    onClick={() => setCleared({ ...cleared, [f.name]: false })}>undo</button></>
+              : <>a value is set — type to replace, or leave blank to keep ·{" "}
+                  <button type="button" className="linklike"
+                    onClick={() => { setCleared({ ...cleared, [f.name]: true }); setValues({ ...values, [f.name]: "" }); }}>remove</button></>}
+          </span>
+        ) : (
+          <span className="help">{jsonErrors[f.name] ?? f.help}</span>
+        )}
       </label>
     );
 

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -324,6 +324,13 @@ button.primary:hover, .btn.primary:hover { background: var(--btn-primary-bg-hove
 button.danger { color: var(--err); border-color: var(--danger-border); }
 button.danger:hover { background: var(--err-soft); }
 button:disabled { opacity: 0.45; cursor: default; }
+/* inline text button (e.g. remove/undo inside help text) — looks like a link, not a button */
+button.linklike {
+  padding: 0; border: none; background: none; font: inherit; font-weight: 500;
+  color: var(--accent, var(--ink)); text-decoration: underline; cursor: pointer;
+  display: inline; border-radius: 0;
+}
+button.linklike:hover { border: none; opacity: 0.8; }
 .btnrow { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
 
 label.field { display: block; margin-bottom: 14px; }


### PR DESCRIPTION
Connector config secrets (`github.token`, `postgres.dsn`) were flagged `secret: True` in the schema but never redacted on output — so an agent reading source config via `/api/sources` (which the built-in agent and MCP both do) saw the credential in **plaintext**.

## Backend
- **`redact_config`** on every read path (`/api/sources`, `/api/sources/{name}`, `/catalog/source:*`) — the stored catalog keeps the real value (the connector reads it at runtime); only the wire form is masked.
- **`restore_secrets`** on save, **blank-to-keep**: omitted/placeholder → keep stored, empty `""` → clear, non-empty → replace. Editing other fields never wipes a token.

## Frontend
- Secret fields render **empty** (never prefilled) with *"a value is set — type to replace, or leave blank to keep"* and an explicit **remove / undo** control. Three unambiguous intents: leave blank = keep · type = replace · Remove = clear.

## Scope
`postgres.dsn` covered by the same marker. Deliberately unchanged: `/api/catalog/export` (admin round-trip re-import) and at-rest plaintext storage.

## Tests
9/9 (restore_secrets four intents + redact set/unset + endpoint keep/clear round-trips) plus 11/11 redaction coverage. Full suite green except two pre-existing failures. UI typechecks + builds.