### PR TITLE
Agent authoring guidance: labels from real fields, views on labels, no rename

### DIFF
--- a/claude-plugin/skills/navflow/SKILL.md
+++ b/claude-plugin/skills/navflow/SKILL.md
@@ -1,23 +1,67 @@
 ---
 name: navflow
-description: Use when you need cross-source context about what's happening in this project's systems — recent deploys, logs, metrics, entities, or correlated timelines. NavFlow is the data plane; query it via the navflow MCP tools to read one correlated, time-ordered timeline for an entity (service, customer, session, …) instead of guessing.
+description: Use when you need cross-source context about this project's systems (recent deploys, logs, metrics, entities, correlated timelines), OR when organizing NavFlow itself — creating sources, labels, and views. NavFlow is the data plane; read it via the navflow MCP tools for one correlated timeline per entity, and author its catalog with the create/derive tools following the rules below.
 ---
 
 # NavFlow
 
 NavFlow is a data plane for agents: it ingests many sources (logs, metrics, deploys, database rows,
-agent sessions) and serves **one correlated, time-ordered timeline per entity**.
+agent sessions) and serves **one correlated, time-ordered timeline per entity** (a service, customer,
+session, …). The **navflow** MCP server is connected (this plugin registers it).
 
-When a question needs real context about this project's running systems — "what changed before this
-error", "is this service healthy", "what has this customer done recently" — prefer reading NavFlow
-over guessing.
+## Reading
 
-How to use it:
-- The **navflow** MCP server is connected (this plugin registers it). Use its tools to list views and
-  query an entity's timeline. Pick the entity key (e.g. a service name, customer id, or session id)
-  and a time window, then read the returned timeline.
-- Start by discovering what's available (sources, views, entities) before querying.
+When a question needs real context about running systems — "what changed before this error", "is
+this service healthy", "what has this customer done recently" — read NavFlow instead of guessing:
+
+- Start by discovering what's there: `list_sources`, `catalog_list`, `entities`.
+- Read a timeline with `query` (a view + an entity key) or `read` (a `{label: value}` selector).
 - Treat the timeline as ground truth for *what happened and when*; cite specific events.
 
 This plugin also streams the current Claude Code session into NavFlow (the `claude_code` source) when
-session streaming is enabled, so prior sessions are themselves queryable as a source.
+session streaming is enabled, so prior sessions are queryable as a source.
+
+## Authoring: sources, labels, and views
+
+NavFlow's data model has three layers — get them right and correlation just works; guess and it
+silently doesn't:
+
+- **Fields** — the *candidate menu*. A source's raw payload is stored losslessly; `source_fields`
+  (and `discover_source` for a new source) profiles the fields it actually contains, with coverage
+  and top values. Fields are not queryable on their own.
+- **Labels** — the *declared axes* you promote from fields (or a const, or a regex over a field).
+  Labels are what you filter, group, key, and correlate by. One label is the **primary key**.
+- **Views** — correlate one or more sources into a per-entity timeline, keyed by a **label** the
+  sources share.
+
+### Rule 1 — Labels must come from real fields (never invent one)
+
+Before choosing a source's labels, call **`source_fields`** (existing source) or use
+**`discover_source`**'s `proposed_config` (new source) to see the fields that actually exist. A
+label reads from one of three things, all grounded in real data:
+
+- `field`: a profiled field name — must match a field `source_fields` shows, exactly.
+- `const`: a fixed value stamped on every event (for a source with no natural field for an axis).
+- a **regex** over a field — set `pattern` + `replace` (and/or `map`) on the label to normalize
+  messy values. Regex/alias normalization is a first-class feature: use it instead of guessing at a
+  clean field. `type: "number"` makes a label aggregatable (for triggers); the primary key must be a
+  string.
+
+Never name a `field` that isn't in the profile — it extracts nothing. Set labels by creating the
+source (`create_source`) or updating its config with the full `labels` list.
+
+### Rule 2 — Views key/filter on LABELS only, never raw fields
+
+A view's `key_field` (and any filters) must be a **label the chosen sources expose** — not an
+arbitrary payload field. If you want to correlate on something that isn't a label yet, **promote it
+to a label first** (Rule 1), then `derive` the view keyed by that label. Confirm a source's current
+labels with `catalog_describe("source:<name>")` before deriving.
+
+### Rule 3 — To match a label across sources, add a NEW label — don't rename
+
+To join source B to source A on a shared axis (say `service`), source B needs a label **named
+`service`** too. Declare a **new** label on B (reading B's matching field) — do **not** try to
+rename B's field or existing label. There is no rename; a source's label set is declared whole, so
+add the shared-named label to B and keep its others. The values must agree **literally** across
+sources for correlation to work — if B's raw values differ (e.g. `checkout-svc` vs `checkout`),
+normalize them with `pattern`/`replace`/`map` on B's label so they match A's.

--- a/navflow/agent.py
+++ b/navflow/agent.py
@@ -214,20 +214,27 @@ labels, keys, and views. Work in one pass:
 2. Judge entity-ness from evidence: a good KEY identifies a durable entity (a service, a session,
    a tenant) — moderate distinct count, high coverage, stable values. Dimensions (http_method,
    level, status) make good secondary labels but bad keys. Sparse or constant fields are weak.
-3. FIRST check each source's existing labels (list_sources shows config.labels). If a source's
-   current labels already match what you would propose, do NOT call propose_labels — state in
-   text that its labels look right and why. Propose only for sources whose labels are missing or
-   should change, calling propose_labels ONCE with the complete label set it should have (the
-   proposal replaces, not appends). Only fields the profile shows are extractable — never invent
-   field names. Same discipline for views: if an existing view already covers it, say so instead
-   of proposing a duplicate.
+3. Labels come from REAL fields — never invent one. A label's `field` MUST be a field name
+   source_fields actually showed for that source; anything else extracts nothing. A label reads a
+   `field`, a `const`, or a regex over a field (`pattern`/`replace`, plus `map` for aliases) — reach
+   for the regex to clean messy values rather than guessing at a tidy field that isn't there.
+   FIRST check each source's existing labels (list_sources shows config.labels): if they already
+   match what you'd propose, say so in text and do NOT call propose_labels. Otherwise call it ONCE
+   with the COMPLETE label set (the proposal replaces, not appends). Same for views — don't propose
+   a duplicate of one that already covers it.
 3b. Watch the top values for VARIANTS of one entity (checkout / checkout-svc / checkout-service):
    correlation needs values to agree literally, so propose value normalization on the label —
    `pattern`/`replace` for whole families, `map` for irregular aliases (pattern runs first, map
    applies to its result). This is often the highest-value fix you can propose.
-4. Then propose views: prefer a natural shared label across sources; when sources share nothing
-   but belong together, propose const labels (same name+value) on each source first, then the
-   view keyed by that label. Call propose_view for each view (1–3 views, not a zoo).
+4. Views key and filter on LABELS only — never a raw field. A view's `key_field` (and filters) must
+   be a label the chosen sources EXPOSE. If you want to correlate on something that isn't a label
+   yet, promote it to a label first (propose_labels), then the view. Prefer a natural shared label;
+   when sources share nothing but belong together, propose const labels (same name+value) on each,
+   then key the view by that label. propose_view for each (1–3 views, not a zoo).
+4b. To match a label across sources, add a NEW label — don't rename. If source B should join source
+   A on `service` but B has no such label, propose a NEW label named `service` on B (reading B's
+   matching field) — there is no rename, and a source's label set is declared whole, so add it and
+   keep B's others. Normalize B's values (pattern/map) so they agree literally with A's.
 5. When the user's goal involves alerting or waking agents on a condition (errors, spikes,
    thresholds), also propose triggers on the views you proposed: a numeric field the view's
    events carry, an aggregate + predicate + detection window, a sensible cooldown.

--- a/navflow/mcp_server.py
+++ b/navflow/mcp_server.py
@@ -254,6 +254,17 @@ async def list_sources() -> str:
     return r.text
 
 
+@mcp.tool()
+async def source_fields(name: str, limit: int = 500) -> str:
+    """Profile a source's real fields from recent events: every candidate field with its coverage,
+    distinct count, and top values, plus which are already declared as labels/keys. Call this BEFORE
+    choosing labels for a source — a label's `field` MUST be one of these exact field names (never
+    invent one). The `labels` block echoes the source's current declared axes."""
+    async with _cx(15) as cx:
+        r = await cx.get(f"{NAVFLOWD}/api/sources/{name}/fields", params={"limit": limit})
+    return r.text
+
+
 class _BearerGate:
     """Pure-ASGI middleware: every HTTP request to the MCP server must carry *a* bearer token —
     the root auth token or a scoped API key. The token is forwarded to navflowd per-request, which


### PR DESCRIPTION
Guides both agents when they **author** the catalog (label/view creation), so they don't hallucinate field names or misuse the model.

## Built-in agent (organize prompt) + external agents (plugin SKILL.md)
- **Rule 1** — a label's `field` must be a **real profiled field** (`source_fields` / `discover_source`); never invented. Regex normalization (`pattern`/`replace`/`map`) is a first-class option — normalize messy values instead of guessing at a tidy field.
- **Rule 2** — views `key_field`/filters use **exposed labels only**, never raw fields; promote a field to a label first.
- **Rule 3** — to match a label across sources, declare a **new** label (there is no rename); normalize values so they agree literally.

## New MCP tool: `source_fields`
External agents (Claude Code) had no way to profile an existing source's fields — only the built-in agent did. Added the tool so 'look at all the fields' is actionable; SKILL.md points to it.

MCP tests pass; both prompts carry the rules; imports clean.