### PR TITLE
Postgres connector: bundled driver, simpler config, redesigned setup form

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -16,7 +16,7 @@ WORKDIR /src
 COPY pyproject.toml README.md LICENSE ./
 COPY navflow/ ./navflow/
 COPY --from=ui /ui/dist ./ui/dist
-RUN pip install --no-cache-dir ".[postgres,otlp-grpc,agent]"
+RUN pip install --no-cache-dir ".[otlp-grpc]"
 
 # Run as a non-root user. Own /data before declaring the VOLUME so a first-mount Docker named
 # volume inherits the ownership; on k8s an empty PVC needs fsGroup: 1000 (set in the cell chart).

--- a/navflow/connectors/postgres.py
+++ b/navflow/connectors/postgres.py
@@ -6,9 +6,9 @@ metrics, logs and deploys, so "what happened to tenant=acme" includes the row th
 
 Mode is the honest MVP collapse of CDC: each poll runs `SELECT * FROM <table> WHERE <cursor_column>
 > <last> ORDER BY <cursor_column> LIMIT <limit>`, advancing a cursor over a monotonic column —
-an autoincrement id (cursor_type=int) or an updated_at timestamp (cursor_type=timestamp). Logical
-replication is the expand path. Mutable rows are captured on each update only if you cursor by
-updated_at; an int id cursor is append-only (inserts).
+an autoincrement id or an updated_at timestamp (int vs timestamp is inferred from the value, no
+config). Logical replication is the expand path. Mutable rows are captured on each update only if
+you cursor by updated_at; an int id cursor is append-only (inserts).
 
 Keyed by `key_column` (e.g. tenant_id) — that column's value becomes the primary label, so rows
 auto-shard per entity. Declare more `labels` to facet by status/region/etc. The driver (asyncpg)
@@ -47,17 +47,21 @@ def _ident(name: str, what: str, pat=_IDENT) -> str:
     return name
 
 
-def _cursor_param(cursor: str, cursor_type: str | None):
-    """The stored cursor (a string) back to the column's native type for binding."""
-    if cursor_type == "timestamp":
-        try:
-            return datetime.fromisoformat(cursor)
-        except ValueError:
-            return cursor
+def _cursor_param(cursor: str | None):
+    """The stored cursor (a string) back to the column's native type for binding, inferred from the
+    value: a timestamp binds as a datetime (asyncpg rejects a string), else an int, else the raw
+    string. No cursor_type config needed — the value itself says what it is."""
+    if cursor is None:
+        return None
+    s = str(cursor)
     try:
-        return int(cursor)
+        return datetime.fromisoformat(s)
+    except ValueError:
+        pass
+    try:
+        return int(s)
     except (TypeError, ValueError):
-        return cursor
+        return s
 
 
 def _connect(dsn: str):
@@ -94,8 +98,12 @@ def _select_clause(config: dict, cursor_column: str) -> str:
     raw = str(config.get("columns") or "").strip()
     if not raw:
         return "*"
+    # always keep the cursor/time columns AND any column a label reads (incl. the primary/key label),
+    # so a column subset never breaks the cursor, timestamps, or label/key extraction.
+    label_fields = [l.get("field") for l in (config.get("labels") or [])
+                    if isinstance(l, dict) and l.get("field")]
     cols, seen = [], set()
-    for name in [*raw.split(","), cursor_column, config.get("key_column"), config.get("time_column")]:
+    for name in [*raw.split(","), cursor_column, config.get("time_column"), *label_fields]:
         if not name or not str(name).strip():
             continue
         ident = _ident(str(name).strip(), "column")
@@ -123,11 +131,6 @@ class PostgresConnector(Connector):
                                   "each poll: an autoincrement id (captures inserts only) or "
                                   "updated_at (also captures row updates) — Discover picks this "
                                   "for you"},
-        "cursor_type": {"type": "string", "default": "int",
-                        "help": "int (autoincrement id) or timestamp (updated_at)"},
-        "key_column": {"type": "string",
-                       "help": "column whose value is the entity key, e.g. tenant_id (the primary "
-                               "label). Declare it as a primary label to name the axis."},
         "time_column": {"type": "string",
                         "help": "timestamp column for event_time (default: the cursor column if it "
                                 "is a timestamp, else ingest time)"},
@@ -150,7 +153,7 @@ class PostgresConnector(Connector):
         # bind the cursor as its native type (asyncpg infers $1 from the column) — not as a string
         where = f"WHERE {cursor_col} > $1 " if cursor is not None else ""
         sql = f"SELECT {select} FROM {table} {where}ORDER BY {cursor_col} ASC LIMIT {limit}"
-        params = [_cursor_param(cursor, c.get("cursor_type"))] if cursor is not None else []
+        params = [_cursor_param(cursor)] if cursor is not None else []
 
         conn = await _connect(_dsn(c))
         try:
@@ -179,8 +182,9 @@ class PostgresConnector(Connector):
         db, tname = _db_and_table(c)
         ctx.setdefault("database", db)   # synthetic fields — a real column of the same name wins
         ctx.setdefault("table", tname)
-        key_col = c.get("key_column")
-        labels, key = self.keyed(ctx, fallback=ctx.get(key_col or "", "") or table.split(".")[-1])
+        # The key is the value of the label marked primary (declared in `labels`); with none, it
+        # falls back to the table name. There is no separate key_column — a primary label is the key.
+        labels, key = self.keyed(ctx, fallback=table.split(".")[-1])
 
         return Envelope(
             source=self.cfg.name, source_type=self.cfg.type, key_value=key,
@@ -204,7 +208,9 @@ class PostgresConnector(Connector):
         return (f"{key} {head}".strip() or _compact(row))[:300]
 
     def _event_time(self, row: dict, c: dict) -> datetime:
-        col = c.get("time_column") or (c["cursor_column"] if c.get("cursor_type") == "timestamp" else None)
+        # event_time from time_column, else the cursor column when it's actually a timestamp value
+        # (the isinstance checks below decide that — no cursor_type needed).
+        col = c.get("time_column") or c.get("cursor_column")
         val = row.get(col) if col else None
         if isinstance(val, datetime):
             return val
@@ -265,10 +271,8 @@ class PostgresConnector(Connector):
                 labels.append({"name": dim, "field": dim})
                 break
 
-        proposed = {"table": table, "cursor_column": cursor_col, "cursor_type": cursor_type}
-        if key_col:
-            proposed["key_column"] = key_col
-        if labels:
+        proposed = {"table": table, "cursor_column": cursor_col}   # type is inferred at poll time
+        if labels:   # the entity column is proposed as the PRIMARY label (which is the key)
             proposed["labels"] = labels
         return {
             "connector": "postgres",

--- a/navflow/connectors/postgres.py
+++ b/navflow/connectors/postgres.py
@@ -12,14 +12,13 @@ updated_at; an int id cursor is append-only (inserts).
 
 Keyed by `key_column` (e.g. tenant_id) — that column's value becomes the primary label, so rows
 auto-shard per entity. Declare more `labels` to facet by status/region/etc. The driver (asyncpg)
-is an optional extra: `pip install navflow[postgres]`.
+ships with navflow.
 
-Secret note: a `dsn` carries the password and would export to YAML — prefer leaving `dsn` empty and
-setting PG_DSN (or DATABASE_URL) in the daemon's environment (kept out of the catalog).
+Secret note: the `dsn` carries the password. It's a per-source parameter (config only — no env
+fallback), stored as a secret: redacted in API responses and omitted from catalog exports by default.
 """
 from __future__ import annotations
 
-import os
 import re
 from datetime import datetime
 
@@ -34,9 +33,11 @@ _TABLE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)?$")
 
 
 def _dsn(config: dict) -> str:
-    dsn = config.get("dsn") or os.getenv("PG_DSN") or os.getenv("DATABASE_URL")
+    # The connection URL is a per-source parameter (you may have several Postgres sources), so it
+    # comes only from the source's config — there is no daemon-level env fallback.
+    dsn = config.get("dsn")
     if not dsn:
-        raise CatalogError("no Postgres DSN — set config `dsn` or the PG_DSN / DATABASE_URL env var")
+        raise CatalogError("no Postgres DSN — set the source's `dsn` connection URL")
     return dsn
 
 
@@ -63,20 +64,58 @@ def _connect(dsn: str):
     try:
         import asyncpg
     except ImportError:
-        raise CatalogError("the postgres connector needs asyncpg — pip install navflow[postgres]")
+        raise CatalogError("the postgres connector needs asyncpg (it ships with navflow — reinstall if missing)")
     # bounded connect: an unreachable host (firewalled DB, wrong IP) should fail in seconds with a
     # clear error, not sit on asyncpg's 60s default while the console appears hung
     return asyncpg.connect(dsn, timeout=10)
 
 
+def _db_and_table(config: dict) -> tuple[str, str]:
+    """The synthetic `database` and `table` label fields for a Postgres source. Derived from config
+    (not from a column), so they're always available to label/key on and reproduce on relabel with
+    no DB round-trip. `table` is the bare table name (matches event_type); `database` is parsed from
+    the DSN path (empty when the DSN omits it — Postgres then defaults to the user's db)."""
+    tname = str(config.get("table") or "").split(".")[-1]
+    db = ""
+    dsn = config.get("dsn") or ""
+    try:
+        from urllib.parse import urlsplit
+        db = urlsplit(dsn).path.lstrip("/").split("?", 1)[0]
+    except Exception:
+        db = ""
+    return db, tname
+
+
+def _select_clause(config: dict, cursor_column: str) -> str:
+    """The SELECT list. Empty `columns` config -> '*' (all columns). Otherwise the listed columns,
+    ALWAYS including the cursor/key/time columns the connector reads from each row (else the cursor
+    can't advance and the key/time can't be resolved). Every name is validated as a safe identifier
+    (it's interpolated into SQL)."""
+    raw = str(config.get("columns") or "").strip()
+    if not raw:
+        return "*"
+    cols, seen = [], set()
+    for name in [*raw.split(","), cursor_column, config.get("key_column"), config.get("time_column")]:
+        if not name or not str(name).strip():
+            continue
+        ident = _ident(str(name).strip(), "column")
+        if ident not in seen:
+            seen.add(ident)
+            cols.append(ident)
+    return ", ".join(cols)
+
+
 class PostgresConnector(Connector):
     CONFIG_SCHEMA = {
-        "dsn": {"type": "string", "secret": True, "discover_input": True,
-                "help": "postgresql://user:pass@host:port/dbname — the path after the slash picks "
-                        "the database (omitted, Postgres silently defaults to a db named after "
-                        "the user). Must be reachable from the NavFlow host; local installs can "
-                        "leave this empty and set PG_DSN on the daemon"},
-        "table": {"type": "string", "required": True, "discover_input": True,
+        "dsn": {"type": "string", "secret": True, "required": True, "discover_input": True,
+                "help": "postgresql://user:pass@host:port/dbname — this source's connection URL (the "
+                        "path after the slash picks the database; omitted, Postgres defaults to a db "
+                        "named after the user). Must be reachable from the NavFlow host. Stored as a "
+                        "secret: redacted in the API and omitted from catalog exports."},
+        # NOT discover_input: you don't fill the table in before discovering — Discover (which only
+        # needs the DSN) lists the tables and you pick one. So the form shows Discover right after
+        # the DSN, and the table field below it.
+        "table": {"type": "string", "required": True,
                   "help": "table to poll, e.g. orders or public.orders — leave empty and Discover "
                           "lists the tables it can see"},
         "cursor_column": {"type": "string", "required": True,
@@ -92,6 +131,11 @@ class PostgresConnector(Connector):
         "time_column": {"type": "string",
                         "help": "timestamp column for event_time (default: the cursor column if it "
                                 "is a timestamp, else ingest time)"},
+        "columns": {"type": "string",
+                    "help": "comma-separated columns to pull, e.g. id,status,amount — empty pulls "
+                            "every column (SELECT *). The cursor/key/time columns are always "
+                            "included so the source still works. `database` and `table` are also "
+                            "available as fields (from config) regardless of what you select."},
         "limit": {"type": "number", "default": 200, "help": "rows to fetch per poll"},
     }
 
@@ -101,10 +145,11 @@ class PostgresConnector(Connector):
         cursor_col = _ident(c["cursor_column"], "cursor_column")
         limit = int(c.get("limit", 200))
 
+        select = _select_clause(c, c["cursor_column"])
         cursor = self.store.get_cursor(self.cfg.name)
         # bind the cursor as its native type (asyncpg infers $1 from the column) — not as a string
         where = f"WHERE {cursor_col} > $1 " if cursor is not None else ""
-        sql = f"SELECT * FROM {table} {where}ORDER BY {cursor_col} ASC LIMIT {limit}"
+        sql = f"SELECT {select} FROM {table} {where}ORDER BY {cursor_col} ASC LIMIT {limit}"
         params = [_cursor_param(cursor, c.get("cursor_type"))] if cursor is not None else []
 
         conn = await _connect(_dsn(c))
@@ -118,10 +163,22 @@ class PostgresConnector(Connector):
         self.store.set_cursor(self.cfg.name, str(rows[-1][cursor_col]))
         return [self._row_envelope(dict(r), table) for r in rows]
 
+    def label_context(self, payload: dict | None) -> dict:
+        """Row columns PLUS the synthetic `database`/`table` fields (from config), so both can be
+        labeled/keyed and reproduce on relabel. A real column of the same name wins (setdefault)."""
+        ctx = dict(payload or {})
+        db, tname = _db_and_table(self.cfg.config)
+        ctx.setdefault("database", db)
+        ctx.setdefault("table", tname)
+        return ctx
+
     def _row_envelope(self, row: dict, table: str) -> Envelope:
         c = self.cfg.config
         jrow = _jsonable(row)  # Decimal->float, datetime->iso (lossless + JSON-safe)
         ctx = {k: ("" if v is None else str(v)) for k, v in jrow.items()}  # row IS the label context
+        db, tname = _db_and_table(c)
+        ctx.setdefault("database", db)   # synthetic fields — a real column of the same name wins
+        ctx.setdefault("table", tname)
         key_col = c.get("key_column")
         labels, key = self.keyed(ctx, fallback=ctx.get(key_col or "", "") or table.split(".")[-1])
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,8 @@ dependencies = [
     "pydantic>=2",
     "mcp>=1.2",
     "pytz>=2024.1",   # DuckDB needs it to bind tz-aware datetimes to TIMESTAMPTZ
+    "asyncpg>=0.29",  # Postgres connector driver — base so the connector works on `navflow up`
+    "anthropic>=0.40",  # console Ask/Organize agent — base so it works on `navflow up`
 ]
 
 [project.urls]
@@ -31,12 +33,10 @@ Documentation = "https://www.navflow.ai/docs"
 Repository = "https://github.com/glassflow/navflow"
 
 [project.optional-dependencies]
-# OTLP gRPC receiver (:4317). The OTLP/HTTP JSON receiver needs none of this.
+# OTLP gRPC receiver (:4317). The OTLP/HTTP JSON receiver needs none of this; grpcio is a heavy
+# compiled dep, so the gRPC path stays opt-in. (postgres/agent deps are now base — `navflow up`
+# ships a working Postgres connector and Ask agent with no extras.)
 otlp-grpc = ["grpcio>=1.60", "opentelemetry-proto>=1.20"]
-# Postgres table connector (the asyncpg driver).
-postgres = ["asyncpg>=0.29"]
-# In-app agent (the console's Ask view) — server-side chat loop over the read API.
-agent = ["anthropic>=0.40"]
 
 [project.scripts]
 navflow = "navflow.cli:main"

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -62,23 +62,21 @@ async def main():
     # discover orders -> updated_at cursor, tenant_id key, status label
     prop = await PostgresConnector.discover({"dsn": DSN, "table": "orders"})
     pc = prop["proposed_config"]
-    ck("discover orders -> cursor updated_at/timestamp",
-       (pc["cursor_column"], pc["cursor_type"]) == ("updated_at", "timestamp"), str(pc))
-    ck("discover orders -> keyed by tenant_id", pc.get("key_column") == "tenant_id", str(pc))
+    ck("discover orders -> cursor updated_at", pc["cursor_column"] == "updated_at", str(pc))
+    ck("discover proposes no separate key_column (key is a primary label)", "key_column" not in pc, str(pc))
     ck("discover orders -> primary label tenant_id + status facet",
        pc["labels"][0] == {"name": "tenant_id", "field": "tenant_id", "primary": True}
        and any(l["name"] == "status" for l in pc["labels"]), str(pc.get("labels")))
 
     # discover users -> int id cursor, no entity column
     up = (await PostgresConnector.discover({"dsn": DSN, "table": "users"}))["proposed_config"]
-    ck("discover users -> cursor id/int", (up["cursor_column"], up["cursor_type"]) == ("id", "int"), str(up))
+    ck("discover users -> cursor id", up["cursor_column"] == "id", str(up))
     ck("discover users -> no entity column", "key_column" not in up, str(up))
 
     # poll orders incrementally, keyed by tenant_id, status faceted
     store = FakeStore()
     conn = PostgresConnector(cfg({
-        "dsn": DSN, "table": "orders", "cursor_column": "id", "cursor_type": "int",
-        "key_column": "tenant_id",
+        "dsn": DSN, "table": "orders", "cursor_column": "id",
         "labels": [{"name": "tenant_id", "field": "tenant_id", "primary": True},
                    {"name": "status", "field": "status"}],
     }), store)
@@ -105,8 +103,7 @@ async def main():
     # timestamp cursor path: poll, advance (cursor stored as iso string), second poll empty
     tstore = FakeStore()
     tconn = PostgresConnector(cfg({
-        "dsn": DSN, "table": "orders", "cursor_column": "updated_at", "cursor_type": "timestamp",
-        "key_column": "tenant_id",
+        "dsn": DSN, "table": "orders", "cursor_column": "updated_at",
     }), tstore)
     t1 = await tconn.poll()
     ck("timestamp-cursor first poll returns rows", len(t1) >= 6, str(len(t1)))

--- a/ui/src/components/SourceForm.tsx
+++ b/ui/src/components/SourceForm.tsx
@@ -25,6 +25,18 @@ const DISCOVER_HINT: Record<string, string> = {
   postgres: "enter the DSN above, then Discover — it lists the tables it can see; pick one and it proposes the cursor, entity key and labels from the columns",
 };
 
+// Postgres form: plain-language field labels + grouping (main poll settings vs collapsed advanced),
+// so the internal schema names don't leak into the UI. Fields not in PG_GROUP go in the main group.
+const PG_LABEL: Record<string, string> = {
+  dsn: "Connection URL",
+  table: "Table",
+  cursor_column: "How we find new rows",
+  time_column: "Event time",
+  columns: "Columns to pull",
+  limit: "Rows per poll",
+};
+const PG_GROUP: Record<string, "advanced"> = { limit: "advanced" };
+
 interface Props {
   connector: string;
   spec: ConnectorSpec;
@@ -103,6 +115,7 @@ export default function SourceForm({ connector, spec, initial, lockName, submitL
   const [proposal, setProposal] = useState<DiscoverProposal>();
   const [colProposal, setColProposal] = useState<ColumnsProposal>();
   const [pgColumns, setPgColumns] = useState<string[]>();  // postgres: discovered column names, for the picker
+  const [editConn, setEditConn] = useState(false);         // postgres: connection collapsed after discover unless editing
   const [tables, setTables] = useState<string[]>();
   const [containers, setContainers] = useState<EnvScan["containers"]>();
   const [discovering, setDiscovering] = useState(false);
@@ -204,6 +217,7 @@ export default function SourceForm({ connector, spec, initial, lockName, submitL
       const cp = p as unknown as ColumnsProposal;
       setColProposal(cp);
       setPgColumns(cp.columns.map((c) => c.name));   // feed the column picker below
+      setEditConn(false);                            // collapse the connection now it's confirmed
     } else if (Array.isArray((p as { tables?: unknown[] }).tables)) {
       setTables((p as unknown as { tables: string[] }).tables);
     } else {
@@ -262,69 +276,97 @@ export default function SourceForm({ connector, spec, initial, lockName, submitL
     JSON.stringify(rs.filter((r) => r.name.trim()).map(rowToSpec));
   const labelsChanged = !!initial && canonRows(labelRows) !== canonRows(labelsToRows(initial?.config?.labels));
 
-  const renderField = (f: ConnectorField) => {
-    // Postgres column selection: once discover knows the table's columns, render a checklist instead
-    // of a comma-separated box (the stored value stays comma-separated for the API/agents).
+  // The right-column control for one field: postgres column checklist / single-column dropdown, a
+  // json textarea, or a plain input (with secret handling).
+  const fieldControl = (f: ConnectorField) => {
     if (connector === "postgres" && f.name === "columns" && pgColumns?.length) {
-      const mandatory = new Set(
-        [values.cursor_column, values.key_column, values.time_column].map((v) => v?.trim()).filter(Boolean) as string[]);
-      return (
-        <label className="field" key={f.name}>
-          <span className="lbl">{f.name}</span>
-          <ColumnPicker columns={pgColumns} value={values[f.name] ?? ""} mandatory={mandatory}
-                        onChange={(v) => setValues({ ...values, [f.name]: v })} />
-          <span className="help">{f.help}</span>
-        </label>
-      );
+      // always keep the cursor/time columns + any column a label reads (the key is a primary label)
+      const mandatory = new Set([
+        values.cursor_column, values.time_column,
+        ...labelRows.filter((r) => r.kind === "field").map((r) => r.value),
+      ].map((v) => v?.trim()).filter(Boolean) as string[]);
+      return <ColumnPicker columns={pgColumns} value={values[f.name] ?? ""} mandatory={mandatory}
+                           onChange={(v) => setValues({ ...values, [f.name]: v })} />;
     }
-    // Postgres single-column pickers: once the columns are known, pick one from a dropdown instead
-    // of typing it. cursor_column is required (empty = "— select —", enforced on save); key/time are
-    // optional (empty = "— none —"), matching their prior behaviour.
     if (connector === "postgres" && pgColumns?.length
-        && ["cursor_column", "key_column", "time_column"].includes(f.name)) {
+        && ["cursor_column", "time_column"].includes(f.name)) {
       const opts = pgColumns.includes(values[f.name] ?? "") || !values[f.name]
         ? pgColumns : [values[f.name], ...pgColumns];   // keep a stale value selectable
       return (
-        <label className={"field" + (jsonErrors[f.name] ? " invalid" : "")} key={f.name}>
-          <span className="lbl">{f.name} {f.required && <span className="req">*</span>}</span>
-          <select value={values[f.name] ?? ""}
-                  onChange={(e) => setValues({ ...values, [f.name]: e.target.value })}>
-            <option value="">{f.required ? "— select —" : "— none —"}</option>
-            {opts.map((c) => <option key={c} value={c}>{c}</option>)}
-          </select>
-          <span className="help">{f.help}</span>
-        </label>
+        <select value={values[f.name] ?? ""} onChange={(e) => setValues({ ...values, [f.name]: e.target.value })}>
+          <option value="">{f.required ? "— select —" : "— none —"}</option>
+          {opts.map((c) => <option key={c} value={c}>{c}</option>)}
+        </select>
       );
     }
-    return f.type === "list" ? (
-      <ListFieldEditor key={f.name} field={f} rows={rows[f.name] ?? []}
-                       onChange={(r) => setRows({ ...rows, [f.name]: r })} />
-    ) : (
-      <label className={"field" + (jsonErrors[f.name] ? " invalid" : "")} key={f.name}>
-        <span className="lbl">{f.name} {f.required && <span className="req">*</span>}</span>
-        {f.type === "json" ? (
-          <textarea className="code" value={values[f.name]}
-                    onChange={(e) => setValues({ ...values, [f.name]: e.target.value })} />
-        ) : (
-          <input type={f.secret ? "password" : f.type === "number" ? "number" : "text"}
-                 value={values[f.name]} autoComplete={f.secret ? "off" : undefined}
-                 disabled={secretSet(f) && cleared[f.name]}
-                 placeholder={secretSet(f) ? (cleared[f.name] ? "" : "leave blank to keep") : undefined}
-                 onChange={(e) => setValues({ ...values, [f.name]: e.target.value })} />
+    if (f.type === "json")
+      return <textarea className="code" value={values[f.name]}
+                       onChange={(e) => setValues({ ...values, [f.name]: e.target.value })} />;
+    return <input type={f.secret ? "password" : f.type === "number" ? "number" : "text"}
+                  value={values[f.name]} autoComplete={f.secret ? "off" : undefined}
+                  disabled={secretSet(f) && cleared[f.name]}
+                  placeholder={secretSet(f) ? (cleared[f.name] ? "" : "leave blank to keep") : undefined}
+                  onChange={(e) => setValues({ ...values, [f.name]: e.target.value })} />;
+  };
+
+  const fieldHelp = (f: ConnectorField) =>
+    secretSet(f) ? (
+      <span className="help">
+        {cleared[f.name]
+          ? <>will be removed on save — <button type="button" className="linklike"
+                onClick={() => setCleared({ ...cleared, [f.name]: false })}>undo</button></>
+          : <>a value is set — type to replace, or leave blank to keep ·{" "}
+              <button type="button" className="linklike"
+                onClick={() => { setCleared({ ...cleared, [f.name]: true }); setValues({ ...values, [f.name]: "" }); }}>remove</button></>}
+      </span>
+    ) : <span className="help">{jsonErrors[f.name] ?? f.help}</span>;
+
+  const fieldLabel = (f: ConnectorField) => (connector === "postgres" && PG_LABEL[f.name]) || f.name;
+  const fieldDetected = (f: ConnectorField) =>       // value came from Discover, not the user
+    connector === "postgres" && !!pgColumns?.length && !!values[f.name]?.trim()
+    && ["cursor_column", "time_column"].includes(f.name);
+
+  // Two-column row: label + description on the left, control on the right. (list fields keep their
+  // own full-width editor.)
+  const renderField = (f: ConnectorField) => {
+    if (f.type === "list")
+      return <ListFieldEditor key={f.name} field={f} rows={rows[f.name] ?? []}
+                              onChange={(r) => setRows({ ...rows, [f.name]: r })} />;
+    return (
+      <div className={"fld-row" + (jsonErrors[f.name] ? " invalid" : "")} key={f.name}>
+        <div className="fld-meta">
+          <span className="lbl">{fieldLabel(f)}{f.required && <span className="req"> *</span>}
+            {fieldDetected(f) && <span className="badge ok" style={{ marginLeft: 8 }}>detected</span>}</span>
+          {fieldHelp(f)}
+        </div>
+        <div className="fld-ctrl">{fieldControl(f)}</div>
+      </div>
+    );
+  };
+
+  // Postgres: group the poll settings into a main block + a collapsed "Advanced".
+  const renderPgFields = (fields: ConnectorField[]) => {
+    const main = fields.filter((f) => PG_GROUP[f.name] !== "advanced");
+    const advanced = fields.filter((f) => PG_GROUP[f.name] === "advanced");
+    const found = !!pgColumns?.length;
+    return (
+      <>
+        <div className="fld-group">
+          <div className="fld-group-head">
+            <h3>{found ? <>What we read from <code>{values.table || "the table"}</code></> : "How to poll the table"}</h3>
+            <p className="help">{found
+              ? "Discover picked these from the columns — adjust any that aren't right."
+              : "Run Discover above to fill these from the table, or set them by hand."}</p>
+          </div>
+          {main.map(renderField)}
+        </div>
+        {advanced.length > 0 && (
+          <details className="fld-group adv-group">
+            <summary>Advanced<span className="caret">›</span></summary>
+            <div>{advanced.map(renderField)}</div>
+          </details>
         )}
-        {secretSet(f) ? (
-          <span className="help">
-            {cleared[f.name]
-              ? <>will be removed on save — <button type="button" className="linklike"
-                    onClick={() => setCleared({ ...cleared, [f.name]: false })}>undo</button></>
-              : <>a value is set — type to replace, or leave blank to keep ·{" "}
-                  <button type="button" className="linklike"
-                    onClick={() => { setCleared({ ...cleared, [f.name]: true }); setValues({ ...values, [f.name]: "" }); }}>remove</button></>}
-          </span>
-        ) : (
-          <span className="help">{jsonErrors[f.name] ?? f.help}</span>
-        )}
-      </label>
+      </>
     );
   };
 
@@ -356,9 +398,22 @@ export default function SourceForm({ connector, spec, initial, lockName, submitL
         </label>
       )}
 
-      {(spec.discover ? spec.fields.filter((f) => f.discover_input) : spec.fields).map(renderField)}
+      {connector === "postgres" && spec.discover && pgColumns?.length && !editConn ? (
+        <div className="conn-summary">
+          <span className="tick">✓</span>
+          <span>Connected{(() => {
+            try { const u = new URL(values.dsn); const db = u.pathname.replace(/^\//, "");
+              return <> to <code>{db || u.hostname}</code>{db && u.hostname ? <> · {u.hostname}</> : null}</>; }
+            catch { return null; }
+          })()}</span>
+          <button type="button" className="linklike" style={{ marginLeft: "auto" }}
+                  onClick={() => setEditConn(true)}>edit connection</button>
+        </div>
+      ) : (
+        (spec.discover ? spec.fields.filter((f) => f.discover_input) : spec.fields).map(renderField)
+      )}
 
-      {spec.discover && (
+      {spec.discover && !(connector === "postgres" && pgColumns?.length && !editConn) && (
         <div className="panel" style={{ background: "var(--th-bg)", marginBottom: 14 }}>
           <div className="btnrow" style={{ alignItems: "center" }}>
             <button type="button" disabled={busy} onClick={() => discover()}>
@@ -417,7 +472,9 @@ export default function SourceForm({ connector, spec, initial, lockName, submitL
         </div>
       )}
 
-      {spec.discover && spec.fields.filter((f) => !f.discover_input).map(renderField)}
+      {spec.discover && (connector === "postgres"
+        ? renderPgFields(spec.fields.filter((f) => !f.discover_input))
+        : spec.fields.filter((f) => !f.discover_input).map(renderField))}
 
       <LabelsEditor rows={labelRows} onChange={setLabelRows} sourceName={initial?.name}
                     fields={labelFieldOpts} fieldHints={labelFieldHints} />

--- a/ui/src/components/SourceForm.tsx
+++ b/ui/src/components/SourceForm.tsx
@@ -102,6 +102,7 @@ export default function SourceForm({ connector, spec, initial, lockName, submitL
     : undefined;
   const [proposal, setProposal] = useState<DiscoverProposal>();
   const [colProposal, setColProposal] = useState<ColumnsProposal>();
+  const [pgColumns, setPgColumns] = useState<string[]>();  // postgres: discovered column names, for the picker
   const [tables, setTables] = useState<string[]>();
   const [containers, setContainers] = useState<EnvScan["containers"]>();
   const [discovering, setDiscovering] = useState(false);
@@ -200,7 +201,9 @@ export default function SourceForm({ connector, spec, initial, lockName, submitL
     if (Array.isArray((p as { metrics?: unknown[] }).metrics)) {
       setProposal(p);
     } else if (Array.isArray((p as { columns?: unknown[] }).columns)) {
-      setColProposal(p as unknown as ColumnsProposal);
+      const cp = p as unknown as ColumnsProposal;
+      setColProposal(cp);
+      setPgColumns(cp.columns.map((c) => c.name));   // feed the column picker below
     } else if (Array.isArray((p as { tables?: unknown[] }).tables)) {
       setTables((p as unknown as { tables: string[] }).tables);
     } else {
@@ -259,8 +262,41 @@ export default function SourceForm({ connector, spec, initial, lockName, submitL
     JSON.stringify(rs.filter((r) => r.name.trim()).map(rowToSpec));
   const labelsChanged = !!initial && canonRows(labelRows) !== canonRows(labelsToRows(initial?.config?.labels));
 
-  const renderField = (f: ConnectorField) =>
-    f.type === "list" ? (
+  const renderField = (f: ConnectorField) => {
+    // Postgres column selection: once discover knows the table's columns, render a checklist instead
+    // of a comma-separated box (the stored value stays comma-separated for the API/agents).
+    if (connector === "postgres" && f.name === "columns" && pgColumns?.length) {
+      const mandatory = new Set(
+        [values.cursor_column, values.key_column, values.time_column].map((v) => v?.trim()).filter(Boolean) as string[]);
+      return (
+        <label className="field" key={f.name}>
+          <span className="lbl">{f.name}</span>
+          <ColumnPicker columns={pgColumns} value={values[f.name] ?? ""} mandatory={mandatory}
+                        onChange={(v) => setValues({ ...values, [f.name]: v })} />
+          <span className="help">{f.help}</span>
+        </label>
+      );
+    }
+    // Postgres single-column pickers: once the columns are known, pick one from a dropdown instead
+    // of typing it. cursor_column is required (empty = "— select —", enforced on save); key/time are
+    // optional (empty = "— none —"), matching their prior behaviour.
+    if (connector === "postgres" && pgColumns?.length
+        && ["cursor_column", "key_column", "time_column"].includes(f.name)) {
+      const opts = pgColumns.includes(values[f.name] ?? "") || !values[f.name]
+        ? pgColumns : [values[f.name], ...pgColumns];   // keep a stale value selectable
+      return (
+        <label className={"field" + (jsonErrors[f.name] ? " invalid" : "")} key={f.name}>
+          <span className="lbl">{f.name} {f.required && <span className="req">*</span>}</span>
+          <select value={values[f.name] ?? ""}
+                  onChange={(e) => setValues({ ...values, [f.name]: e.target.value })}>
+            <option value="">{f.required ? "— select —" : "— none —"}</option>
+            {opts.map((c) => <option key={c} value={c}>{c}</option>)}
+          </select>
+          <span className="help">{f.help}</span>
+        </label>
+      );
+    }
+    return f.type === "list" ? (
       <ListFieldEditor key={f.name} field={f} rows={rows[f.name] ?? []}
                        onChange={(r) => setRows({ ...rows, [f.name]: r })} />
     ) : (
@@ -290,6 +326,7 @@ export default function SourceForm({ connector, spec, initial, lockName, submitL
         )}
       </label>
     );
+  };
 
   return (
     <form onSubmit={(e) => { e.preventDefault(); run(async () => onSubmit(build())); }}>
@@ -742,6 +779,56 @@ function ListFieldEditor({ field, rows, onChange }:
       <button type="button" onClick={() => onChange([...rows, blank()])}>
         + Add {field.name === "queries" ? "query" : "row"}
       </button>
+    </div>
+  );
+}
+
+// Postgres column selection as a checklist (once discover knows the table's columns). Emits the
+// same comma-separated string the API uses: all columns checked -> "" (SELECT *); a subset ->
+// "a,b,c". The cursor/key/time columns are always pulled, so they're shown checked + locked.
+function ColumnPicker({ columns, value, mandatory, onChange }: {
+  columns: string[]; value: string; mandatory: Set<string>; onChange: (v: string) => void;
+}) {
+  const [q, setQ] = useState("");
+  const listed = value.trim()
+    ? new Set(value.split(",").map((s) => s.trim()).filter(Boolean))
+    : null;   // null = "all"
+  const isChecked = (c: string) => mandatory.has(c) || listed === null || listed.has(c);
+  const emit = (checked: Set<string>) => {
+    mandatory.forEach((m) => checked.add(m));
+    onChange(checked.size >= columns.length ? "" : columns.filter((c) => checked.has(c)).join(","));
+  };
+  const toggle = (c: string) => {
+    const checked = new Set(columns.filter(isChecked));
+    checked.has(c) ? checked.delete(c) : checked.add(c);
+    emit(checked);
+  };
+  const nChecked = columns.filter(isChecked).length;
+  const shown = columns.filter((c) => !q || c.toLowerCase().includes(q.toLowerCase()));
+  return (
+    <div>
+      <div className="btnrow" style={{ marginBottom: 6, alignItems: "center" }}>
+        <button type="button" onClick={() => onChange("")}>All</button>
+        <button type="button" onClick={() => emit(new Set())}>None</button>
+        <span className="help">
+          {nChecked}/{columns.length} selected{nChecked >= columns.length ? " — pulls every column" : ""}
+        </span>
+      </div>
+      {columns.length > 8 && (
+        <input type="text" placeholder="filter columns…" value={q}
+               onChange={(e) => setQ(e.target.value)} style={{ marginBottom: 6 }} />
+      )}
+      <div style={{ maxHeight: 220, overflowY: "auto", border: "1px solid var(--line)", borderRadius: 6, padding: 4 }}>
+        {shown.map((c) => (
+          <label key={c} className="explore-item"
+                 style={{ cursor: mandatory.has(c) ? "default" : "pointer", opacity: mandatory.has(c) ? 0.7 : 1 }}>
+            <input type="checkbox" checked={isChecked(c)} disabled={mandatory.has(c)}
+                   onChange={() => toggle(c)} style={{ marginRight: 8 }} />
+            <span className="mono">{c}</span>
+            {mandatory.has(c) && <span className="badge push" style={{ marginLeft: 8 }} title="cursor/key/time — always pulled">always</span>}
+          </label>
+        ))}
+      </div>
     </div>
   );
 }

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -350,18 +350,52 @@ label.field.invalid input:focus, label.field.invalid textarea:focus { box-shadow
 label.field.invalid .help { color: var(--err); }
 label.field .help { display: block; font-size: 12px; color: var(--ink-soft); margin-top: 3px; }
 .help { color: var(--ink-soft); }
+
+/* two-column connector field rows: label + description on the left, control on the right */
+.fld-row { display: grid; grid-template-columns: minmax(0, 1fr) minmax(360px, 1.5fr); gap: 12px 40px;
+  align-items: start; padding: 15px 0; border-top: 1px solid var(--line); }
+@media (max-width: 720px) { .fld-row { grid-template-columns: 1fr; gap: 8px; } }
+
+/* collapsed connection summary (postgres, after Discover) */
+.conn-summary { display: flex; align-items: center; gap: 10px; margin: 4px 0 16px; padding: 12px 14px;
+  border: 1px solid var(--line); border-radius: 10px; background: var(--bg); font-size: 13.5px; color: var(--ink-soft); }
+.conn-summary .tick { width: 18px; height: 18px; border-radius: 50%; background: var(--ok); color: #fff;
+  display: grid; place-items: center; font-size: 11px; flex: none; }
+.conn-summary code { color: var(--ink); }
+.fld-meta { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
+.fld-meta .lbl { font-size: 13px; font-weight: 600; }
+.fld-meta .lbl .req { color: var(--accent); }
+.fld-meta .help { display: block; font-size: 12px; color: var(--ink-soft); margin: 0; line-height: 1.45; }
+.fld-ctrl { display: flex; flex-direction: column; }
+.fld-row.invalid input, .fld-row.invalid select, .fld-row.invalid textarea { border-color: var(--err); background: var(--err-soft); }
+.fld-row.invalid .help { color: var(--err); }
+/* field grouping (postgres) */
+.fld-group { margin: 4px 0; }
+.fld-group-head h3 { margin: 20px 0 2px; font-size: 15px; }
+.fld-group-head .help { margin: 0; }
+.fld-group-head + .fld-row, .fld-group > .fld-row:first-child { border-top: none; }
+details.adv-group { border-top: 1px solid var(--line); margin-top: 8px; }
+details.adv-group > summary { list-style: none; cursor: pointer; font-weight: 600; font-size: 13px;
+  padding: 14px 0 4px; display: flex; align-items: center; gap: 8px; }
+details.adv-group > summary::-webkit-details-marker { display: none; }
+details.adv-group > summary .caret { color: var(--ink-soft); transition: transform .18s ease; }
+details.adv-group[open] > summary .caret { transform: rotate(90deg); }
+details.adv-group .fld-row:first-child { border-top: none; }
+/* One consistent, clearly-visible data field: a filled box with a bold, defined border (derived
+   from the ink so it works in both themes — input-bg == panel in light mode made fields invisible). */
 input[type="text"], input[type="number"], input[type="password"], select, textarea {
   font: inherit;
   font-size: 13.5px;
   width: 100%;
-  padding: 7px 10px;
-  border: 1px solid var(--line);
-  border-radius: 6px;
-  background: var(--input-bg);
+  padding: 9px 11px;
+  border: 1.5px solid color-mix(in srgb, var(--ink) 34%, var(--panel));
+  border-radius: 7px;
+  background: color-mix(in srgb, var(--ink) 5%, var(--panel));
   color: var(--ink);
 }
+input:hover, select:hover, textarea:hover { border-color: color-mix(in srgb, var(--ink) 50%, var(--panel)); }
 textarea.code { font-family: var(--mono); font-size: 12.5px; min-height: 110px; }
-input:focus, select:focus, textarea:focus { outline: none; border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-soft); }
+input:focus, select:focus, textarea:focus { outline: none; background: var(--panel); border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-soft); }
 button:focus-visible, .btn:focus-visible, .navlink:focus-visible, .navbtn:focus-visible, .tabs button:focus-visible { outline: none; box-shadow: 0 0 0 3px var(--accent-soft); }
 
 /* ── panels / cards ── */


### PR DESCRIPTION
A pass over the Postgres connector driven by testing it locally end-to-end.

## Packaging
- **`asyncpg` + `anthropic` → base deps** — `navflow up` ships a working Postgres connector and Ask agent with no extras (`otlp-grpc` stays the one extra). Dockerfile installs `.[otlp-grpc]`.

## Config: only what a user can reason about
- **`dsn` required, config-only** — dropped the `PG_DSN`/`DATABASE_URL` env fallback (a DB URL is a per-source secret, redacted + omitted from exports).
- **Dropped `key_column`** — the entity key is a label marked *primary* (one place to set 'what each row is about', and it's a real named axis). Discover proposes it as a pre-ticked primary label.
- **Dropped `cursor_type`** — int-vs-timestamp is inferred from the cursor value at bind time (fixes a timestamp cursor bound as a string when the type was unset). No knob to get wrong.
- **Column selection** — new `columns` config (comma-sep for API/agents); `_select_clause` always keeps the cursor/time/label columns.
- **`database` + `table`** exposed as synthetic label fields.

## Form redesign
- Two-column rows (label + description left, control right), grouped into 'what we read from `table`' + a collapsed Advanced.
- Plain-language labels; Discover renders after the DSN; the connection collapses to a summary once discovered; columns as a checklist; cursor/time as dropdowns.
- One consistent, clearly-visible input style (filled box + bold border, both themes).

Tests updated; `test_postgres` green; UI typechecks + builds.