### PR TITLE
prometheus: pick-don't-write discover + triggerable metric values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ deployment.md
 # Python build artifacts
 dist/
 *.egg-info/
+
+# local staging creds — never commit
+.prometheus

--- a/navflow/connectors/prometheus.py
+++ b/navflow/connectors/prometheus.py
@@ -2,13 +2,19 @@
 
 Stores every non-null sample (lossless); the view and triggers decide what's interesting.
 
-`discover()` introspects a Prometheus and proposes a source config (which metrics to ingest
-raw, a suggested entity key, labels, and type-aware derived suggestions) — deterministically,
-no LLM. "Raw ingest" is just a bare-metric-name PromQL, so the proposal is an ordinary config
-the poll loop above already understands.
+`discover()` is deterministic (no LLM) and drives a pick-don't-write flow: the user chooses *which
+metrics* to ingest (by name pattern or by label) and *which labels* become NavFlow labels — never
+writing PromQL. discover has three modes, keyed off its input:
+  - catalog (default): the metric-name list + the label-name list, for the pickers.
+  - for_label="<label>": the metric names that carry that label (the by-label picker).
+  - selected=[names]: finalize — sample the picked metrics and propose a ready config.
+The proposed config's poll query is a single `{__name__=~"(a|b|…)"}` selector with `by_name`, so one
+query ingests the whole basket, and the metric value rides along as a number-typed `value` label so
+triggers can aggregate it.
 """
 from __future__ import annotations
 
+import asyncio
 import re
 
 import httpx
@@ -18,12 +24,29 @@ from .base import Connector
 
 _BAD = ("NaN", "+Inf", "-Inf")
 
-# Prometheus/runtime internals hidden from discovery by default (still ingestable if asked).
+# Prometheus/runtime internals hidden from the catalog by default (still ingestable if typed).
 _INTERNAL = re.compile(r"^(go_|process_|prometheus_|scrape_|net_|promhttp_|python_)")
 # Labels that make a good entity key, best first. The first present with >1 value wins.
 _KEY_PRIORITY = ["service", "tenant", "tenant_id", "namespace", "pod", "app", "instance", "job"]
-# Standard/structural labels we don't propose as NavFlow labels.
-_LABEL_SKIP = {"le", "instance", "job"}
+# Structural labels we don't propose as NavFlow labels, and never as a key.
+_LABEL_SKIP = {"le", "instance", "job", "__name__"}
+
+# Finalize samples at most this many of the picked metrics (concurrently) to learn their label set —
+# the basket shares its label keys, so a few dozen reveal the union without sampling all of them.
+_SAMPLE_CAP = 40
+_SAMPLE_CONCURRENCY = 12
+_TOPK = 5   # topk(N) bounds each sample's response to N series (label keys are shared across series)
+
+
+def _client_kwargs(config: dict) -> dict:
+    """httpx.AsyncClient kwargs for the endpoint's auth: a bearer token (Authorization header) and/or
+    HTTP basic auth. Both are stored as secrets — redacted in the API and omitted from exports."""
+    kw: dict = {}
+    if config.get("bearer_token"):
+        kw["headers"] = {"Authorization": f"Bearer {config['bearer_token']}"}
+    if config.get("username"):
+        kw["auth"] = (config["username"], config.get("password") or "")
+    return kw
 
 
 class PrometheusConnector(Connector):
@@ -32,6 +55,13 @@ class PrometheusConnector(Connector):
     CONFIG_SCHEMA = {
         "url": {"type": "string", "required": True, "discover_input": True,
                 "help": "Prometheus base URL, e.g. http://localhost:9090"},
+        "bearer_token": {"type": "string", "secret": True, "discover_input": True,
+                         "help": "optional Authorization: Bearer token — for managed Prometheus "
+                                 "(Thanos/Cortex/Mimir) or one behind an auth proxy"},
+        "username": {"type": "string", "discover_input": True,
+                     "help": "optional HTTP basic-auth username (e.g. a Grafana Cloud instance id)"},
+        "password": {"type": "string", "secret": True, "discover_input": True,
+                     "help": "optional HTTP basic-auth password / API token, paired with username"},
         "default_key": {"type": "string", "default": "unknown",
                         "help": "entity key for series that carry no key label"},
         "queries": {
@@ -46,6 +76,11 @@ class PrometheusConnector(Connector):
                 "text": {"type": "string", "default": "{key} {field}={val}"},
                 "key_label": {"type": "string",
                               "help": "series label to read the entity key from, e.g. service"},
+                "by_name": {"type": "bool",
+                            "help": "whole-basket query ({__name__=~\"(a|b)\"}): derive event_type "
+                                    "& field from each series' own metric name"},
+                "exclude": {"type": "string",
+                            "help": "comma-separated substrings to drop by metric name (e.g. _bucket)"},
             },
         },
     }
@@ -54,136 +89,160 @@ class PrometheusConnector(Connector):
         url = self.cfg.config["url"].rstrip("/") + "/api/v1/query"
         default_key = self.cfg.config.get("default_key", "unknown")
         out = []
-        async with httpx.AsyncClient(timeout=10) as cx:
+        async with httpx.AsyncClient(timeout=15, **_client_kwargs(self.cfg.config)) as cx:
             for q in self.cfg.config.get("queries", []):
                 try:
-                    resp = await cx.get(url, params={"query": q["promql"]})
+                    # POST (not GET): a whole-basket selector can be a long regex — past URL limits.
+                    resp = await cx.post(url, data={"query": q["promql"]})
                     series = resp.json().get("data", {}).get("result", [])
                 except Exception:
                     continue
                 key_label = q.get("key_label")
-                field = q.get("field", "value")
+                by_name = q.get("by_name", False)
+                excludes = [e.strip() for e in str(q.get("exclude", "")).split(",") if e.strip()]
                 for s in series:
                     raw = s.get("value", [None, None])[1]
                     if raw in _BAD or raw is None:
                         continue
                     val = float(raw)
                     metric = s.get("metric", {})
+                    mname = metric.get("__name__", "")
+                    # whole-basket query: event_type & field come from each series' own metric name,
+                    # so one selector ingests the whole basket with per-metric names.
+                    if by_name:
+                        if any(x in mname for x in excludes):
+                            continue
+                        event_type = mname or q.get("event_type", "metric")
+                        field = mname or q.get("field", "value")
+                    else:
+                        event_type = q.get("event_type", "metric")
+                        field = q.get("field", "value")
                     fallback = metric.get(key_label, default_key) if key_label else default_key
-                    labels, key = self.keyed(metric, fallback=fallback)
+                    payload = {"metric": metric, "value": val, "promql": q["promql"]}
+                    # extract labels from the same context retroactive relabel uses (label_context),
+                    # so a `metric.<label>` field — as the field profile shows it — resolves both now
+                    # and on backfill. The numeric `value` label is read from payload.value here.
+                    labels, key = self.keyed(self.label_context(payload), fallback=fallback)
                     try:
                         text = q.get("text", "{key} {field}={val}").format(
-                            key=key, field=field, val=round(val, 3), **metric
+                            key=key, field=field, val=round(val, 3), event_type=event_type, **metric
                         )
                     except (KeyError, IndexError):
                         text = f"{key} {field}={round(val, 3)}"
                     out.append(Envelope(
                         source=self.cfg.name, source_type=self.cfg.type, key_value=key,
-                        event_type=q.get("event_type", "metric"), text=text, event_time=now_utc(),
-                        payload={"metric": metric, "value": val, "promql": q["promql"]},
-                        labels=labels,  # the series' labels; the primary one is the key
+                        event_type=event_type, text=text, event_time=now_utc(),
+                        payload=payload, labels=labels,  # the series' labels; the primary one is the key
                     ))
         return out
 
+    def label_context(self, payload: dict | None) -> dict:
+        """Prometheus labels are declared against the field profile, which shows series labels nested
+        as `metric.<label>` (e.g. metric.service, metric.table) plus a `value`. Expose the payload so
+        a dotted `metric.<label>` field and the bare `value` field both resolve, and merge the bare
+        series labels on top so an older source that declared `field: service` (bare) keeps working.
+        Used at ingest AND on relabel, so both reproduce identical labels."""
+        p = payload or {}
+        metric = p.get("metric") if isinstance(p.get("metric"), dict) else {}
+        return {**(metric or {}), **p}
+
+    # ── discover (deterministic; three modes off its input) ───────────────────
     @classmethod
     async def discover(cls, config: dict) -> dict:
         base = config["url"].rstrip("/")
-        async with httpx.AsyncClient(timeout=10) as cx:
-            async def get(path, **params):
+        for_label = str(config.get("for_label") or "").strip()
+        selected = [str(m) for m in (config.get("selected") or []) if str(m).strip()]
+        async with httpx.AsyncClient(timeout=20, **_client_kwargs(config)) as cx:
+            async def api(path, **params):
                 return (await cx.get(f"{base}{path}", params=params)).json().get("data", {})
 
+            async def query(promql):
+                r = await cx.post(f"{base}/api/v1/query", data={"query": promql})
+                return r.json().get("data", {}).get("result", [])
+
+            # MODE: metrics that carry one label — the by-label picker. One cheap query.
+            if for_label:
+                if not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", for_label):
+                    raise ValueError(f"bad label name {for_label!r}")
+                res = await query(f'group by (__name__) ({{{for_label}!=""}})')
+                names = sorted({s.get("metric", {}).get("__name__", "") for s in res} - {""})
+                return {"connector": "prometheus", "for_label": for_label, "metrics_for_label": names}
+
+            # MODE: finalize — sample the picked metrics and propose a ready config.
+            if selected:
+                return await cls._finalize(base, cx, api, query, config, selected)
+
+            # MODE: catalog (default) — the metric-name list + the label-name list for the pickers.
             try:
-                names = await get("/api/v1/label/__name__/values") or []
-                meta = await get("/api/v1/metadata") or {}
+                metrics = await api("/api/v1/label/__name__/values") or []
+                labels = await api("/api/v1/labels") or []
             except Exception as e:
                 raise ValueError(f"could not reach Prometheus at {base}: {e}")
+            # drop recording rules (`:`) — a {__name__=~"…"} query can't match them anyway.
+            metrics = sorted(m for m in metrics if ":" not in m)
+            labels = sorted(l for l in labels if ":" not in l and l != "__name__")
+            return {"connector": "prometheus", "catalog": {"metrics": metrics, "labels": labels}}
 
-            app = [n for n in names if not _INTERNAL.search(n)
-                   and not n.endswith(("_created", "_info")) and n != "up"]
+    @classmethod
+    async def _finalize(cls, base, cx, api, query, config, selected: list) -> dict:
+        """Sample the picked metrics for their label union + a suggested key, and build a ready
+        config: one whole-basket selector, the promoted labels, and the numeric `value` measurement."""
+        sem = asyncio.Semaphore(_SAMPLE_CONCURRENCY)
 
-            # histogram bases (a _bucket implies a histogram; its _count/_sum are components)
-            hist_bases = sorted({n[:-7] for n in app if n.endswith("_bucket")})
+        async def sample(n):
+            async with sem:
+                try:
+                    r = await cx.post(f"{base}/api/v1/query", data={"query": f"topk({_TOPK}, {n})"})
+                    res = r.json().get("data", {}).get("result", [])
+                except Exception:
+                    return [], None, "gauge"
+            labels = sorted({k for s in res for k in s.get("metric", {}) if k != "__name__"})
+            val = res[0]["value"][1] if res else None
+            mtype = "counter" if n.endswith("_total") else ("histogram" if n.endswith("_bucket") else "gauge")
+            return labels, val, mtype
 
-            def is_hist_part(n):
-                return any(n in (b + "_bucket", b + "_count", b + "_sum") for b in hist_bases)
+        sampled = selected[:_SAMPLE_CAP]
+        results = await asyncio.gather(*(sample(n) for n in sampled))
+        label_union = set()
+        preview = []
+        for n, (labels, val, mtype) in zip(sampled, results):
+            label_union |= set(labels)
+            preview.append({"name": n, "type": mtype, "sample": val, "labels": labels})
 
-            async def sample(n):
-                r = await cx.get(f"{base}/api/v1/query", params={"query": n})
-                res = r.json().get("data", {}).get("result", [])
-                labels = sorted({k for s in res for k in s.get("metric", {}) if k != "__name__"})
-                val = res[0]["value"][1] if res else None
-                return labels, len(res), val
+        # suggested key: first priority label present, preferring one with >1 distinct value
+        present = [l for l in _KEY_PRIORITY if l in label_union]
+        key, key_card, key_vals = None, 0, []
+        for l in present:
+            vals = await api(f"/api/v1/label/{l}/values") or []
+            if key is None or (len(vals) > 1 and key_card <= 1):
+                key, key_card, key_vals = l, len(vals), vals
+            if len(vals) > 1:
+                break
+        key = key or "instance"
+        default_key = key_vals[0] if key_vals else "unknown"
+        proposed_labels = sorted(label_union - _LABEL_SKIP - {key})
 
-            scalars = [n for n in app if not is_hist_part(n)]   # gauges + counters
-            label_union, metrics = set(), []
-            for n in scalars:
-                labels, card, val = await sample(n)
-                label_union |= set(labels)
-                m = (meta.get(n) or [{}])[0]
-                mtype = m.get("type") or ("counter" if n.endswith("_total") else "gauge")
-                metrics.append({"name": n, "type": mtype, "help": m.get("help", ""),
-                                "series": card, "sample": val, "labels": labels,
-                                "ingest": True,
-                                "reason": "raw ingest (lossless; rates derivable later)"})
-            for b in hist_bases:
-                labels, card, _ = await sample(b + "_bucket")
-                label_union |= set(labels)
-                metrics.append({"name": b, "type": "histogram", "help": (meta.get(b) or [{}])[0].get("help", ""),
-                                "series": card, "sample": None, "labels": labels, "ingest": False,
-                                "reason": "histogram — ingest a derived quantile (p99) instead of raw buckets"})
-
-            # suggested key: first priority label present, preferring one with >1 value
-            present = [l for l in _KEY_PRIORITY if l in label_union]
-            key, key_card, key_vals = None, 0, []
-            for l in present:
-                vals = await get(f"/api/v1/label/{l}/values") or []
-                if key is None or (len(vals) > 1 and key_card <= 1):
-                    key, key_card, key_vals = l, len(vals), vals
-                if len(vals) > 1:
-                    break
-            key = key or "instance"
-            default_key = "api-server" if "api-server" in key_vals else (key_vals[0] if key_vals else "default")
-
-            proposed_labels = sorted(label_union - _LABEL_SKIP - {key})
-
-            # type-aware derived suggestions
-            derived = []
-            for m in metrics:
-                if m["type"] == "counter" and "status" in m["labels"]:
-                    derived.append({
-                        "id": f"rate_5xx_{m['name']}", "label": "5xx rate",
-                        "promql": f'sum(rate({m["name"]}{{status=~"5.."}}[1m])) by ({key})',
-                        "event_type": "rate_5xx", "field": "rate_5xx",
-                        "reason": f"{m['name']} is a counter with a `status` label"})
-            for b in hist_bases:
-                derived.append({
-                    "id": f"p99_{b}", "label": "p99 latency",
-                    "promql": f"histogram_quantile(0.99, sum(rate({b}_bucket[5m])) by (le, {key}))",
-                    "event_type": "p99", "field": "p99_ms",
-                    "reason": f"{b} is a histogram"})
-
-            # a ready-to-use config: raw scalars + derived. The key is just the primary label
-            # (the suggested key, read from each series); default_key covers series without it.
-            queries = [{"promql": m["name"], "event_type": m["name"], "field": m["name"],
-                        "text": m["name"] + " {key}={val}"}
-                       for m in metrics if m["ingest"]]
-            queries += [{"promql": d["promql"], "event_type": d["event_type"], "field": d["field"],
-                         "text": d["label"] + " {key}={val}"} for d in derived]
-            proposed_config = {
-                "url": base, "default_key": default_key, "queries": queries,
-                "labels": [{"name": key, "field": key, "primary": True}]
-                          + [{"name": l, "field": l} for l in proposed_labels],
-            }
-
+        # one whole-basket query: an anchored alternation of the picked names, by_name so each
+        # series is named by its own metric. Metric names are [A-Za-z_:][A-Za-z0-9_:]* — no regex
+        # metachars — so a bare join is safe; still guard against anything unexpected.
+        safe = [n for n in selected if re.match(r"^[A-Za-z_:][A-Za-z0-9_:]*$", n)]
+        selector = '{__name__=~"(' + "|".join(safe) + ')"}'
+        proposed_config = {
+            "url": base, "default_key": default_key,
+            "queries": [{"promql": selector, "by_name": True}],
+            # labels reference the field profile's nested path (metric.<label>), matching what the
+            # field picker shows; `value` is a number-typed measurement (aggregatable, not faceted).
+            "labels": [{"name": key, "field": f"metric.{key}", "primary": True}]
+                      + [{"name": l, "field": f"metric.{l}"} for l in proposed_labels]
+                      + [{"name": "value", "field": "value", "type": "number"}],
+        }
         return {
             "connector": "prometheus",
-            "summary": {"total_metrics": len(names), "relevant": len(metrics),
-                        "hidden": len(names) - len(scalars) - len(hist_bases)},
+            "selected_count": len(selected),
             "suggested_key": {"name": key, "cardinality": key_card,
                               "values_preview": key_vals[:8],
                               "alternatives": [l for l in present if l != key]},
             "proposed_labels": proposed_labels,
-            "metrics": metrics,
-            "derived_suggestions": derived,
+            "preview": preview,
             "proposed_config": proposed_config,
         }

--- a/navflow/store.py
+++ b/navflow/store.py
@@ -166,9 +166,11 @@ _ENTITY_CARDINALITY_CAP = int(os.getenv("NAVFLOW_ENTITY_CARDINALITY_CAP", "10000
 
 def _accum_entity(ent: dict, source: str, label: str, value, ingest_time) -> None:
     """Fold one (source, label, value) observation into the batch's entity_counts deltas. Skips
-    empty/null and boolean values (not entity axes). The value is stringified to match how the read
+    empty/null, boolean, and numeric values — a number-typed label is a *measurement* you aggregate
+    (max/avg/sum), not an entity axis to facet by, and faceting it would materialize one bucket per
+    distinct number and blow the cardinality cap. The value is stringified to match how the read
     path reads it back (json_extract_string), so live deltas merge with seeded rows."""
-    if value is None or isinstance(value, bool):
+    if value is None or isinstance(value, bool) or isinstance(value, (int, float)):
         return
     v = str(value)
     if not v:

--- a/ui/src/components/SourceForm.tsx
+++ b/ui/src/components/SourceForm.tsx
@@ -23,6 +23,7 @@ const DISCOVER_HINT: Record<string, string> = {
   docker_logs: "list the containers navflowd can see, then pick one to fill this form",
   github: "enter the repo above, then Discover its default branch + author labels",
   postgres: "enter the DSN above, then Discover — it lists the tables it can see; pick one and it proposes the cursor, entity key and labels from the columns",
+  prometheus: "enter the URL (+ any auth) above, then Discover — it lists the metrics and labels so you can pick what to ingest (by name or by label). No PromQL to write.",
 };
 
 // Postgres form: plain-language field labels + grouping (main poll settings vs collapsed advanced),
@@ -36,6 +37,9 @@ const PG_LABEL: Record<string, string> = {
   limit: "Rows per poll",
 };
 const PG_GROUP: Record<string, "advanced"> = { limit: "advanced" };
+const PROM_LABEL: Record<string, string> = {
+  default_key: "Fallback entity key",
+};
 
 interface Props {
   connector: string;
@@ -117,6 +121,9 @@ export default function SourceForm({ connector, spec, initial, lockName, submitL
   const [pgColumns, setPgColumns] = useState<string[]>();  // postgres: discovered column names, for the picker
   const [editConn, setEditConn] = useState(false);         // postgres: connection collapsed after discover unless editing
   const [tables, setTables] = useState<string[]>();
+  const [catalog, setCatalog] = useState<{ metrics: string[]; labels: string[] }>();  // prometheus: pickers
+  const [basket, setBasket] = useState<Set<string>>(new Set());                       // prometheus: chosen metrics
+  const [metricsConfirmed, setMetricsConfirmed] = useState(false);                    // prometheus: basket collapsed
   const [containers, setContainers] = useState<EnvScan["containers"]>();
   const [discovering, setDiscovering] = useState(false);
   const [discoverErr, setDiscoverErr] = useState<string>();
@@ -211,8 +218,12 @@ export default function SourceForm({ connector, spec, initial, lockName, submitL
     // (prometheus: metrics), `colProposal` (postgres: table columns) or `tables` (postgres
     // without a table yet: pick one); simpler ones (github) just apply the proposed config
     // and report a one-line summary
-    if (Array.isArray((p as { metrics?: unknown[] }).metrics)) {
-      setProposal(p);
+    const cat = (p as { catalog?: { metrics: string[]; labels: string[] } }).catalog;
+    if (cat) {
+      // prometheus: the metric-name + label-name catalogs — feed the two-tab metric picker
+      setCatalog(cat);
+      setBasket(new Set());
+      setMetricsConfirmed(false);
     } else if (Array.isArray((p as { columns?: unknown[] }).columns)) {
       const cp = p as unknown as ColumnsProposal;
       setColProposal(cp);
@@ -233,6 +244,29 @@ export default function SourceForm({ connector, spec, initial, lockName, submitL
     setTables(undefined);
     void discover({ table: t });   // straight to the columns proposal for the picked table
   };
+
+  // prometheus: add/remove metrics in the basket (both tabs feed this one set)
+  const basketAdd = (names: string[]) =>
+    setBasket((s) => { const n = new Set(s); names.forEach((m) => n.add(m)); return n; });
+  const basketRemove = (name: string) =>
+    setBasket((s) => { const n = new Set(s); n.delete(name); return n; });
+  // fetch the metrics carrying a label (the by-label tab), via a discover call
+  const fetchLabelMetrics = async (label: string): Promise<string[]> => {
+    const cfg: Record<string, unknown> = { for_label: label };
+    for (const f of spec.fields) {
+      const raw = values[f.name]?.trim();
+      if (raw && f.type !== "json") cfg[f.name] = raw;
+    }
+    const p = await api.discoverSource("prometheus", cfg) as { metrics_for_label?: string[] };
+    return p.metrics_for_label ?? [];
+  };
+  // confirm the basket → finalize (sample + propose config) → fill the form, collapse the picker
+  const confirmMetrics = () => run(async () => {
+    if (!basket.size) return;
+    if (!name.trim()) setName("prometheus-metrics");
+    await doDiscover({ selected: [...basket] });   // finalize → else-branch applyConfig
+    setMetricsConfirmed(true);
+  });
 
   const pickContainer = (c: { name: string; service: string; project: string }) => {
     setValues((v) => ({ ...v, container: c.name }));
@@ -321,7 +355,9 @@ export default function SourceForm({ connector, spec, initial, lockName, submitL
       </span>
     ) : <span className="help">{jsonErrors[f.name] ?? f.help}</span>;
 
-  const fieldLabel = (f: ConnectorField) => (connector === "postgres" && PG_LABEL[f.name]) || f.name;
+  const fieldLabel = (f: ConnectorField) =>
+    (connector === "postgres" && PG_LABEL[f.name]) ||
+    (connector === "prometheus" && PROM_LABEL[f.name]) || f.name;
   const fieldDetected = (f: ConnectorField) =>       // value came from Discover, not the user
     connector === "postgres" && !!pgColumns?.length && !!values[f.name]?.trim()
     && ["cursor_column", "time_column"].includes(f.name);
@@ -341,6 +377,31 @@ export default function SourceForm({ connector, spec, initial, lockName, submitL
         </div>
         <div className="fld-ctrl">{fieldControl(f)}</div>
       </div>
+    );
+  };
+
+  // Prometheus: the discovered queries as a compact list, with the fallback-key field + a raw
+  // query editor tucked into a collapsed Advanced group (so the form isn't 80 fat panels tall).
+  const renderPromFields = (fields: ConnectorField[]) => {
+    const queriesField = fields.find((f) => f.name === "queries");
+    const rest = fields.filter((f) => f.name !== "queries");
+    return (
+      <>
+        {queriesField && (
+          <PromQueriesView rows={rows.queries ?? []}
+                           onChange={(r) => setRows({ ...rows, queries: r })} />
+        )}
+        <details className="fld-group adv-group">
+          <summary>Advanced<span className="caret">›</span></summary>
+          <div>
+            {rest.map(renderField)}
+            {queriesField && (
+              <ListFieldEditor field={queriesField} rows={rows.queries ?? []}
+                               onChange={(r) => setRows({ ...rows, queries: r })} />
+            )}
+          </div>
+        </details>
+      </>
     );
   };
 
@@ -398,13 +459,16 @@ export default function SourceForm({ connector, spec, initial, lockName, submitL
         </label>
       )}
 
-      {connector === "postgres" && spec.discover && pgColumns?.length && !editConn ? (
+      {spec.discover && !editConn
+        && ((connector === "postgres" && pgColumns?.length) || (connector === "prometheus" && catalog)) ? (
         <div className="conn-summary">
           <span className="tick">✓</span>
-          <span>Connected{(() => {
+          <span>Connected{connector === "postgres" ? (() => {
             try { const u = new URL(values.dsn); const db = u.pathname.replace(/^\//, "");
               return <> to <code>{db || u.hostname}</code>{db && u.hostname ? <> · {u.hostname}</> : null}</>; }
             catch { return null; }
+          })() : (() => {
+            try { return <> to <code>{new URL(values.url).host}</code></>; } catch { return null; }
           })()}</span>
           <button type="button" className="linklike" style={{ marginLeft: "auto" }}
                   onClick={() => setEditConn(true)}>edit connection</button>
@@ -413,20 +477,27 @@ export default function SourceForm({ connector, spec, initial, lockName, submitL
         (spec.discover ? spec.fields.filter((f) => f.discover_input) : spec.fields).map(renderField)
       )}
 
-      {spec.discover && !(connector === "postgres" && pgColumns?.length && !editConn) && (
+      {spec.discover && !(connector === "postgres" && pgColumns?.length && !editConn)
+        && !(connector === "prometheus" && metricsConfirmed) && (
         <div className="panel" style={{ background: "var(--th-bg)", marginBottom: 14 }}>
-          <div className="btnrow" style={{ alignItems: "center" }}>
-            <button type="button" disabled={busy} onClick={() => discover()}>
-              {discovering ? "⏳ discovering…"
-                : `✦ ${connector === "docker_logs" ? "Discover containers" : "Discover"}`}
-            </button>
-            <span className="help" style={{ margin: 0 }}>
-              {DISCOVER_HINT[connector]
-                ?? "fill the URL above, then let NavFlow introspect the source and propose what to ingest — no PromQL to write by hand"}
-            </span>
-          </div>
+          {!(connector === "prometheus" && catalog) && (
+            <div className="btnrow" style={{ alignItems: "center" }}>
+              <button type="button" disabled={busy} onClick={() => discover()}>
+                {discovering ? "⏳ discovering…"
+                  : `✦ ${connector === "docker_logs" ? "Discover containers" : "Discover"}`}
+              </button>
+              <span className="help" style={{ margin: 0 }}>
+                {DISCOVER_HINT[connector]
+                  ?? "fill the URL above, then let NavFlow introspect the source and propose what to ingest — no PromQL to write by hand"}
+              </span>
+            </div>
+          )}
           {discoverErr && <div className="alert error" style={{ marginTop: 10, marginBottom: 0 }}>{discoverErr}</div>}
           {proposal && <ProposalView proposal={proposal} onApply={applyProposal} />}
+          {connector === "prometheus" && catalog && !metricsConfirmed && (
+            <MetricBasket catalog={catalog} basket={basket} onAdd={basketAdd} onRemove={basketRemove}
+                          fetchLabelMetrics={fetchLabelMetrics} onConfirm={confirmMetrics} busy={busy} />
+          )}
           {tables && (
             <table style={{ marginTop: 10 }}>
               <thead><tr><th>table</th><th style={{ width: 100 }}></th></tr></thead>
@@ -472,12 +543,25 @@ export default function SourceForm({ connector, spec, initial, lockName, submitL
         </div>
       )}
 
+      {connector === "prometheus" && metricsConfirmed && (
+        <div className="conn-summary" style={{ marginBottom: 12 }}>
+          <span className="tick">✓</span>
+          <span>{basket.size} metric{basket.size === 1 ? "" : "s"} chosen</span>
+          <button type="button" className="linklike" style={{ marginLeft: "auto" }}
+                  onClick={() => setMetricsConfirmed(false)}>change metrics</button>
+        </div>
+      )}
+
       {spec.discover && (connector === "postgres"
         ? renderPgFields(spec.fields.filter((f) => !f.discover_input))
+        : connector === "prometheus"
+        ? (metricsConfirmed ? renderPromFields(spec.fields.filter((f) => !f.discover_input)) : null)
         : spec.fields.filter((f) => !f.discover_input).map(renderField))}
 
-      <LabelsEditor rows={labelRows} onChange={setLabelRows} sourceName={initial?.name}
-                    fields={labelFieldOpts} fieldHints={labelFieldHints} />
+      {!(connector === "prometheus" && !metricsConfirmed) && (
+        <LabelsEditor rows={labelRows} onChange={setLabelRows} sourceName={initial?.name}
+                      fields={labelFieldOpts} fieldHints={labelFieldHints} />
+      )}
 
       {labelsChanged && (
         <div className="alert info">
@@ -486,17 +570,19 @@ export default function SourceForm({ connector, spec, initial, lockName, submitL
         </div>
       )}
 
-      <div className="btnrow">
-        <button type="submit" className="primary" disabled={busy || Object.keys(jsonErrors).length > 0}>
-          {submitLabel}
-        </button>
-        {spec.mode === "poll" && (
-          <button type="button" disabled={busy}
-                  onClick={() => run(async () => setTest(await api.testSource(build())))}>
-            Test connection
+      {!(connector === "prometheus" && !metricsConfirmed) && (
+        <div className="btnrow">
+          <button type="submit" className="primary" disabled={busy || Object.keys(jsonErrors).length > 0}>
+            {submitLabel}
           </button>
-        )}
-      </div>
+          {spec.mode === "poll" && (
+            <button type="button" disabled={busy}
+                    onClick={() => run(async () => setTest(await api.testSource(build())))}>
+              Test connection
+            </button>
+          )}
+        </div>
+      )}
     </form>
   );
 }
@@ -840,6 +926,254 @@ function ListFieldEditor({ field, rows, onChange }:
   );
 }
 
+// Prometheus family picker: the metric families (name prefixes) as a scannable, sortable list —
+// count-descending, each with a proportional weight bar so the real systems (pg 373) stand out
+// from the long tail. Groups with only 1–2 metrics fold behind a toggle; select-all/none acts on
+// whatever the filter currently shows.
+function FamilyPicker({ groups, sel, q, setQ, onToggle, onSelect, onIntrospect, busy }: {
+  groups: { prefix: string; count: number }[];
+  sel: Set<string>; q: string; setQ: (v: string) => void;
+  onToggle: (p: string) => void; onSelect: (s: Set<string>) => void;
+  onIntrospect: () => void; busy: boolean;
+}) {
+  const max = groups[0]?.count ?? 1;
+  const bar = (n: number) => Math.max(3, Math.round(100 * Math.log(n + 1) / Math.log(max + 1)));
+  const match = (g: { prefix: string }) => !q || g.prefix.toLowerCase().includes(q.toLowerCase());
+  const shown = groups.filter(match);
+  const main = shown.filter((g) => g.count >= 3);
+  const tail = shown.filter((g) => g.count < 3);
+  const totalMetrics = groups.reduce((n, g) => n + g.count, 0);
+
+  const Row = (g: { prefix: string; count: number }) => (
+    <label key={g.prefix} className="fam-row">
+      <input type="checkbox" checked={sel.has(g.prefix)} onChange={() => onToggle(g.prefix)} />
+      <span className="mono fam-name">{g.prefix}<span className="fam-star">_*</span></span>
+      <span className="fam-bar"><span style={{ width: `${bar(g.count)}%` }} /></span>
+      <span className="fam-count">{g.count}</span>
+    </label>
+  );
+
+  return (
+    <div style={{ marginTop: 10 }}>
+      <p className="subtitle" style={{ marginTop: 0 }}>
+        {totalMetrics.toLocaleString()} metrics across {groups.length} systems — each is one exporter
+        or app. Tick the ones you want to ingest.
+      </p>
+      <div className="btnrow" style={{ marginBottom: 6, alignItems: "center", gap: 8 }}>
+        <input type="text" placeholder="filter systems…" value={q}
+               onChange={(e) => setQ(e.target.value)} style={{ flex: 1, margin: 0 }} />
+        <button type="button" onClick={() => onSelect(new Set([...sel, ...shown.map((g) => g.prefix)]))}>
+          select shown
+        </button>
+        <button type="button" onClick={() => onSelect(new Set())}>clear</button>
+      </div>
+      <div className="fam-list">
+        {main.map(Row)}
+        {tail.length > 0 && (
+          <details style={{ marginTop: 4 }}>
+            <summary className="help" style={{ cursor: "pointer", padding: "4px 6px" }}>
+              {tail.length} smaller {tail.length === 1 ? "group" : "groups"} (1–2 metrics each)
+            </summary>
+            <div style={{ marginTop: 4 }}>{tail.map(Row)}</div>
+          </details>
+        )}
+        {shown.length === 0 && <div className="help" style={{ padding: 8 }}>no systems match “{q}”</div>}
+      </div>
+      <div className="btnrow" style={{ marginTop: 8, alignItems: "center" }}>
+        <button type="button" className="primary" disabled={busy || sel.size === 0} onClick={onIntrospect}>
+          Introspect {sel.size || ""} selected
+        </button>
+        <span className="help" style={{ margin: 0 }}>
+          each becomes one compact query that ingests the whole family
+        </span>
+      </div>
+    </div>
+  );
+}
+
+// Prometheus metric picker: two tabs (by name pattern / by label) that both add to one shared
+// basket. No PromQL — the user picks metric names; the connector compiles the basket into a single
+// {__name__=~"(a|b|…)"} selector on confirm.
+function MetricBasket({ catalog, basket, onAdd, onRemove, fetchLabelMetrics, onConfirm, busy }: {
+  catalog: { metrics: string[]; labels: string[] };
+  basket: Set<string>;
+  onAdd: (names: string[]) => void;
+  onRemove: (name: string) => void;
+  fetchLabelMetrics: (label: string) => Promise<string[]>;
+  onConfirm: () => void;
+  busy: boolean;
+}) {
+  const [tab, setTab] = useState<"name" | "label">("name");
+  const [nameQ, setNameQ] = useState("");
+  const [labelQ, setLabelQ] = useState("");
+  const [pickedLabel, setPickedLabel] = useState<string>();
+  const [labelMetrics, setLabelMetrics] = useState<string[]>();
+  const [loadingLabel, setLoadingLabel] = useState(false);
+
+  const nameMatches = useMemo(() => {
+    const q = nameQ.trim().toLowerCase();
+    if (!q) return [];
+    const star = q.endsWith("*");
+    const pat = star ? q.slice(0, -1) : q;
+    return catalog.metrics
+      .filter((m) => { const lm = m.toLowerCase(); return star ? lm.startsWith(pat) : lm.includes(pat); })
+      .slice(0, 500);
+  }, [nameQ, catalog.metrics]);
+
+  const labelMatches = useMemo(() => {
+    const q = labelQ.trim().toLowerCase();
+    return catalog.labels.filter((l) => !q || l.toLowerCase().includes(q)).slice(0, 300);
+  }, [labelQ, catalog.labels]);
+
+  const pickLabel = async (l: string) => {
+    setPickedLabel(l); setLoadingLabel(true); setLabelMetrics(undefined);
+    try { setLabelMetrics(await fetchLabelMetrics(l)); } finally { setLoadingLabel(false); }
+  };
+
+  const ResultList = ({ items }: { items: string[] }) => (
+    <>
+      <div className="btnrow" style={{ margin: "6px 0", alignItems: "center" }}>
+        <button type="button" disabled={!items.length} onClick={() => onAdd(items)}>
+          add all {items.length}
+        </button>
+        <span className="help" style={{ margin: 0 }}>{items.length} match{items.length === 1 ? "" : "es"}
+          {items.length === 500 ? " (showing first 500 — narrow the pattern)" : ""}</span>
+      </div>
+      <div className="fam-list" style={{ maxHeight: 240 }}>
+        {items.map((m) => (
+          <label key={m} className="fam-row" style={{ gridTemplateColumns: "auto minmax(0,1fr) auto" }}>
+            <input type="checkbox" checked={basket.has(m)}
+                   onChange={() => (basket.has(m) ? onRemove(m) : onAdd([m]))} />
+            <span className="mono fam-name">{m}</span>
+            {basket.has(m) && <span className="badge ok">added</span>}
+          </label>
+        ))}
+      </div>
+    </>
+  );
+
+  return (
+    <div style={{ marginTop: 4 }}>
+      <p className="subtitle" style={{ marginTop: 0 }}>
+        Choose the metrics to ingest — by name, or by a label they carry. No PromQL to write.
+      </p>
+      <div className="btnrow" style={{ gap: 6, marginBottom: 8 }}>
+        <button type="button" className={tab === "name" ? "primary" : ""} onClick={() => setTab("name")}>
+          By metric name
+        </button>
+        <button type="button" className={tab === "label" ? "primary" : ""} onClick={() => setTab("label")}>
+          By label
+        </button>
+      </div>
+
+      {tab === "name" && (
+        <div>
+          <input type="text" placeholder="type a metric name or prefix — e.g. node_* or clickhouse"
+                 value={nameQ} onChange={(e) => setNameQ(e.target.value)} />
+          {nameQ.trim()
+            ? <ResultList items={nameMatches} />
+            : <p className="help">{catalog.metrics.length.toLocaleString()} metrics available — start typing to filter (append <span className="mono">*</span> for a prefix match)</p>}
+        </div>
+      )}
+
+      {tab === "label" && (
+        <div>
+          <input type="text" placeholder="filter labels — e.g. namespace, service, clickhouse_org"
+                 value={labelQ} onChange={(e) => setLabelQ(e.target.value)} />
+          <div className="fam-list" style={{ maxHeight: 150, marginTop: 6 }}>
+            {labelMatches.map((l) => (
+              <label key={l} className="fam-row" style={{ gridTemplateColumns: "minmax(0,1fr) auto", cursor: "pointer" }}
+                     onClick={(e) => { e.preventDefault(); void pickLabel(l); }}>
+                <span className="mono fam-name">{l}</span>
+                {pickedLabel === l && <span className="badge">selected</span>}
+              </label>
+            ))}
+          </div>
+          {loadingLabel && <p className="help">loading metrics for <span className="mono">{pickedLabel}</span>…</p>}
+          {labelMetrics && !loadingLabel && (
+            <div style={{ marginTop: 8 }}>
+              <p className="help" style={{ margin: 0 }}>
+                metrics carrying <span className="mono">{pickedLabel}</span>:
+              </p>
+              <ResultList items={labelMetrics} />
+            </div>
+          )}
+        </div>
+      )}
+
+      <div style={{ marginTop: 12, borderTop: "1px solid var(--line)", paddingTop: 10 }}>
+        <div className="btnrow" style={{ alignItems: "center" }}>
+          <strong>{basket.size} metric{basket.size === 1 ? "" : "s"} selected</strong>
+          {basket.size > 0 && (
+            <button type="button" className="linklike" onClick={() => [...basket].forEach(onRemove)}>clear</button>
+          )}
+          <button type="button" className="primary" style={{ marginLeft: "auto" }}
+                  disabled={busy || basket.size === 0} onClick={onConfirm}>
+            Use these {basket.size || ""} metrics →
+          </button>
+        </div>
+        {basket.size > 0 && (
+          <div style={{ maxHeight: 120, overflowY: "auto", marginTop: 6 }}>
+            {[...basket].map((m) => (
+              <span key={m} className="chip mono" style={{ margin: "2px 4px 2px 0", display: "inline-flex", alignItems: "center", gap: 4 }}>
+                {m}
+                <button type="button" onClick={() => onRemove(m)}
+                        style={{ border: "none", background: "none", cursor: "pointer", padding: 0, color: "inherit", fontWeight: 700 }}>×</button>
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// Prometheus queries rendered compactly: one line per query (a whole-family {__name__=~"fam_.*"}
+// query or a derived series), with a remove button — instead of a fat multi-input panel per row.
+// Full hand-editing stays available via the raw ListFieldEditor in the Advanced group below.
+function PromQueriesView({ rows, onChange }:
+  { rows: Array<Record<string, string>>; onChange: (r: Array<Record<string, string>>) => void }) {
+  const summarize = (q: Record<string, string>) => {
+    if (q.by_name) {
+      // inner of __name__=~"..." → either a single family (prefix_.*) or an (a|b|c) basket
+      const inner = (q.promql?.match(/=~"(.*)"/)?.[1] ?? "").replace(/^\(|\)$/g, "");
+      if (/^[A-Za-z0-9_]+_\.\*$/.test(inner)) {
+        return { icon: "▦", title: inner.replace(/_\.\*$/, "_*"),
+                 note: `whole family${q.exclude ? ` · excludes ${q.exclude}` : ""}` };
+      }
+      const names = inner.split("|").filter(Boolean);
+      return { icon: "▦", title: `${names.length} metric${names.length === 1 ? "" : "s"}`,
+               note: names.slice(0, 4).join(", ") + (names.length > 4 ? ", …" : "") };
+    }
+    return { icon: "ƒ", title: (q.text ?? "").replace(" {key}={val}", "") || q.event_type || "derived",
+             note: q.promql ?? "" };
+  };
+  return (
+    <div className="field">
+      <span className="lbl">metrics to ingest</span>
+      <span className="help" style={{ marginTop: 0, marginBottom: 6 }}>
+        the metrics this source will ingest. Remove anything you don't want, or “change metrics” above.
+      </span>
+      {rows.length === 0 && (
+        <div className="empty" style={{ padding: 10 }}>none yet — run Discover above and pick metrics</div>
+      )}
+      {rows.map((q, i) => {
+        const s = summarize(q);
+        return (
+          <div key={i} className="conn-summary" style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 6 }}>
+            <span aria-hidden style={{ opacity: 0.6, flex: "none" }}>{s.icon}</span>
+            <span className="mono" style={{ flex: "none" }}>{s.title}</span>
+            <span className="help" style={{ margin: 0, flex: 1, minWidth: 0, overflow: "hidden",
+                                            textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{s.note}</span>
+            <button type="button" className="danger" style={{ marginLeft: "auto", flex: "none" }}
+                    onClick={() => onChange(rows.filter((_, j) => j !== i))}>remove</button>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
 // Postgres column selection as a checklist (once discover knows the table's columns). Emits the
 // same comma-separated string the API uses: all columns checked -> "" (SELECT *); a subset ->
 // "a,b,c". The cursor/key/time columns are always pulled, so they're shown checked + locked.
@@ -926,71 +1260,99 @@ function ColumnsProposalView({ proposal, onApply }: { proposal: ColumnsProposal;
 
 function ProposalView({ proposal, onApply }: { proposal: DiscoverProposal; onApply: () => void }) {
   const k = proposal.suggested_key;
+  const families = proposal.families ?? [];
+  // group the sampled preview metrics under the family each belongs to, so the preview is one
+  // collapsible block per family rather than one flat dump across all of them
+  const famOf = (name: string) => families.find((f) => name.startsWith(f + "_")) ?? name.split("_")[0];
+  const byFamily = new Map<string, typeof proposal.metrics>();
+  for (const m of proposal.metrics) {
+    const f = famOf(m.name);
+    (byFamily.get(f) ?? byFamily.set(f, []).get(f)!).push(m);
+  }
   return (
     <div style={{ marginTop: 12 }}>
-      <p className="subtitle" style={{ marginTop: 0 }}>
-        found {proposal.summary.total_metrics} metrics · {proposal.summary.relevant} relevant ·{" "}
-        {proposal.summary.hidden} internals hidden
-      </p>
-
-      <div className="field" style={{ marginBottom: 10 }}>
-        <span className="lbl">suggested key</span>
+      <div className="field" style={{ marginBottom: 12 }}>
+        <span className="lbl">will ingest</span>
         <div>
-          <span className="chip mono">{k.name}</span>
+          {families.map((f) => <span className="chip mono" key={f}>{f}_*</span>)}
           <span className="help" style={{ marginLeft: 8 }}>
-            {k.cardinality} {k.cardinality === 1 ? "entity" : "entities"}
-            {k.values_preview.length ? ` — ${k.values_preview.join(", ")}` : ""}
-            {k.alternatives.length ? ` · alternatives: ${k.alternatives.join(", ")}` : ""}
+            {proposal.summary.total_metrics} metrics
+            {families.length > 1 ? ` · ${families.length} families` : ""}
+            {" "}— each family is one query (histogram buckets excluded)
           </span>
         </div>
       </div>
 
-      <div className="field" style={{ marginBottom: 10 }}>
-        <span className="lbl">will ingest ({proposal.metrics.filter((m) => m.ingest).length})</span>
-        <table>
-          <thead>
-            <tr>
-              <th style={{ width: 36, textAlign: "center" }} title="ingested">in</th>
-              <th>metric</th>
-              <th style={{ width: 84 }}>type</th>
-              <th>detail</th>
-            </tr>
-          </thead>
-          <tbody>
-            {proposal.metrics.map((m) => (
-              <tr key={m.name} style={{ opacity: m.ingest ? 1 : 0.5 }}>
-                <td style={{ textAlign: "center" }}>{m.ingest ? "✓" : "—"}</td>
-                <td className="mono">{m.name}</td>
-                <td><span className="chip">{m.type}</span></td>
-                <td className="help">{m.help || m.reason}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+      <div className="field" style={{ marginBottom: 12 }}>
+        <span className="lbl">entity key</span>
+        <div style={{ display: "flex", flexDirection: "column", gap: 3 }}>
+          <div>
+            <span className="chip mono">{k.name}</span>
+            <span className="help" style={{ marginLeft: 8 }}>
+              {k.cardinality} distinct {k.cardinality === 1 ? "entity" : "entities"}
+            </span>
+          </div>
+          {k.values_preview.length > 0 && (
+            <span className="help" style={{ margin: 0 }}>
+              e.g. {k.values_preview.slice(0, 5).join(", ")}{k.cardinality > 5 ? ", …" : ""}
+            </span>
+          )}
+          {k.alternatives.length > 0 && (
+            <span className="help" style={{ margin: 0 }}>or key on: {k.alternatives.join(", ")}</span>
+          )}
+        </div>
+      </div>
+
+      <div className="field" style={{ marginBottom: 12 }}>
+        <span className="lbl">preview</span>
+        <div>
+          {[...byFamily].map(([f, ms]) => (
+            <details key={f} style={{ marginBottom: 4 }}>
+              <summary className="help" style={{ cursor: "pointer", padding: "2px 0" }}>
+                <span className="mono">{f}_*</span> — {ms.length} sampled
+              </summary>
+              <div style={{ maxHeight: 220, overflowY: "auto", margin: "6px 0 6px 16px" }}>
+                <table>
+                  <thead><tr><th>metric</th><th style={{ width: 84 }}>type</th><th>detail</th></tr></thead>
+                  <tbody>
+                    {ms.map((m) => (
+                      <tr key={m.name}>
+                        <td className="mono">{m.name}</td>
+                        <td><span className="chip">{m.type}</span></td>
+                        <td className="help">{m.help || m.reason}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </details>
+          ))}
+        </div>
       </div>
 
       {proposal.derived_suggestions.length > 0 && (
-        <div className="field" style={{ marginBottom: 10 }}>
-          <span className="lbl">derived suggestions</span>
+        <div className="field" style={{ marginBottom: 12 }}>
+          <span className="lbl">derived series</span>
+          <span className="help" style={{ marginTop: 0, marginBottom: 6 }}>
+            extra computed series added alongside the raw metrics
+          </span>
           {proposal.derived_suggestions.map((d) => (
             <div key={d.id} style={{ marginBottom: 4 }}>
               <span className="chip">{d.label}</span>
-              <span className="help mono" style={{ marginLeft: 8 }}>{d.promql}</span>
+              <span className="help" style={{ marginLeft: 8 }}>{d.reason}</span>
             </div>
           ))}
         </div>
       )}
 
       {proposal.proposed_labels.length > 0 && (
-        <div className="field" style={{ marginBottom: 10 }}>
+        <div className="field" style={{ marginBottom: 12 }}>
           <span className="lbl">labels</span>
           <div>{proposal.proposed_labels.map((l) => <span className="chip mono" key={l}>{l}</span>)}</div>
         </div>
       )}
 
-      <button type="button" className="primary" onClick={onApply}>
-        Apply to form
-      </button>
+      <button type="button" className="primary" onClick={onApply}>Apply to form</button>
       <span className="help" style={{ marginLeft: 10 }}>
         fills the fields below — review, Test connection, then Create
       </span>

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -362,6 +362,20 @@ label.field .help { display: block; font-size: 12px; color: var(--ink-soft); mar
 .conn-summary .tick { width: 18px; height: 18px; border-radius: 50%; background: var(--ok); color: #fff;
   display: grid; place-items: center; font-size: 11px; flex: none; }
 .conn-summary code { color: var(--ink); }
+
+/* Prometheus family picker — scannable rows with a proportional weight bar */
+.fam-list { max-height: 320px; overflow-y: auto; border: 1px solid var(--line);
+  border-radius: 8px; padding: 4px; }
+.fam-row { display: grid; grid-template-columns: auto minmax(0, 1fr) 120px 48px;
+  align-items: center; gap: 10px; padding: 4px 8px; border-radius: 6px; cursor: pointer; }
+.fam-row:hover { background: var(--accent-soft); }
+.fam-row input { margin: 0; }
+.fam-name { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.fam-star { color: var(--ink-soft); opacity: 0.55; }
+.fam-bar { height: 6px; border-radius: 3px; background: color-mix(in srgb, var(--ink) 8%, transparent); overflow: hidden; }
+.fam-bar > span { display: block; height: 100%; border-radius: 3px;
+  background: color-mix(in srgb, var(--accent) 55%, var(--panel)); }
+.fam-count { font-variant-numeric: tabular-nums; text-align: right; color: var(--ink-soft); font-size: 13px; }
 .fld-meta { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
 .fld-meta .lbl { font-size: 13px; font-weight: 600; }
 .fld-meta .lbl .req { color: var(--accent); }

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -122,7 +122,8 @@ export interface EnvScan {
 
 export interface DiscoverProposal {
   connector: string;
-  summary: { total_metrics: number; relevant: number; hidden: number };
+  families?: string[];   // prometheus: the metric families (name prefixes) this proposal ingests
+  summary: { total_metrics: number; relevant: number; hidden: number; capped?: boolean; families?: number };
   suggested_key: { name: string; cardinality: number; values_preview: string[]; alternatives: string[] };
   proposed_labels: string[];
   metrics: DiscoverMetric[];


### PR DESCRIPTION
Reworks the Prometheus connector so users **pick metrics** instead of writing PromQL, and makes metric values actually usable by triggers.

## Discover — deterministic, three modes
- **catalog** (default): metric-name list + label-name list for the pickers (cheap, 2 calls).
- **for_label**: the metrics carrying a chosen label (one `group by (__name__)` query).
- **finalize**: sample the picked metrics → propose key + labels + a ready config.

## UI
- Two-tab metric picker (**by name pattern** / **by label**) feeding one shared basket; connection collapses after discover like Postgres.
- The old family-by-prefix picker is replaced.
- Compact "metrics to ingest" row (count + preview, no regex overflow).

## Ingest model
- One whole-basket `{__name__=~"(a|b|…)"}` selector; `by_name` derives event_type/field per series. Poll switched to **POST** (long selectors exceed URL limits).
- Metric **value stored as a number-typed `value` label** → triggers can `max/avg/sum` it.
- `entity_counts` **skips numeric labels** → the value measurement never blows the cardinality cap.
- Labels reference the field-profile path (`metric.<label>`); `label_context` makes ingest and retroactive relabel reproduce identical labels.

Verified end-to-end against a live Prometheus (2,582 metrics / 347 labels): all three discover modes, config normalization round-trip, and a poll storing `value` as a float.