### PR TITLE
Re-imagine the demo around Prometheus alerting

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,16 +64,18 @@ Then ask your agent:
 
 > Use navflow: what happened to api-server in the last 15 minutes?
 
-The agent calls `read` and gets the incident correlated: the 5xx request logs, the error-rate
-spike, and the alert in one time-ordered response — nothing to stitch together across systems.
-(The `error_spike` trigger fires too — **Agents → Trigger dispatches**; `./demo/inject.sh clear`
-rolls the fault back.) Other clients, stdio transport, and auth are covered in [connecting AI agents over MCP](https://www.navflow.ai/docs/agents).
+The agent calls `read` and gets the incident correlated: the `HighErrorRate` alert Prometheus fired,
+the 5xx request logs, and the error-rate spike in one time-ordered response — nothing to stitch
+together across systems. (The `incident` trigger fires too — **Agents → Trigger dispatches**;
+`./demo/inject.sh clear` rolls the fault back.) Other clients, stdio transport, and auth are covered
+in [connecting AI agents over MCP](https://www.navflow.ai/docs/agents).
 
 ## What you get: connectors, reads, triggers, MCP tools
 
-- **Connectors** — Prometheus, Docker logs, GitHub, Postgres, Vercel, OpenTelemetry (OTLP), a generic
-  webhook, agent memory, and Claude Code sessions. Add and configure sources at runtime; a **Discover**
-  step proposes config for connectors that can introspect. → [Connector setup docs](https://www.navflow.ai/docs/connectors)
+- **Connectors** — Prometheus (metrics and alerts), Alertmanager, Docker logs, GitHub, Postgres,
+  Vercel, OpenTelemetry (OTLP), a generic webhook, reference documents, agent memory, and Claude Code
+  sessions. Add and configure sources at runtime; a **Discover** step proposes config for connectors
+  that can introspect. → [Connector setup docs](https://www.navflow.ai/docs/connectors)
 - **Reads** — `read(selector, window)` returns any entity's correlated timeline across *all* sources
   with no view required; `query(view, …)` reads through a saved, narrowed view; agents `subscribe` to
   be pushed the timeline when a trigger fires. → [reads, views, and triggers explained](https://www.navflow.ai/docs/concepts)

--- a/demo/README.md
+++ b/demo/README.md
@@ -51,10 +51,15 @@ still empty; been running NavFlow already? Restart on a fresh `--data-dir`.)
 
 ## 3. Look around
 
-- **Explore** — pick the `api-server` entity and watch metrics, logs, and alerts merge into one
-  time-ordered timeline. Flip **Agent view** to see the exact read an agent gets over MCP.
-- **Views / Triggers** — `service_timeline` is the saved read; `error_spike` and `slow_responses`
-  are watching it.
+- **Explore** — pick the `api-server` entity and watch metrics, logs, and the alerts Prometheus
+  fires merge into one time-ordered timeline. Flip **Agent view** to see the exact read an agent
+  gets over MCP.
+- **Views / Triggers** — `service_timeline` is the saved read; the `incident` trigger watches it and
+  fires when Prometheus fires an alert, pushing the whole correlated timeline to a subscribed agent.
+
+Prometheus owns alerting here (the demo ships three rules — `HighErrorRate`, `HighLatency`,
+`DependencyDown`); NavFlow ingests the fired alerts (`prometheus_alerts`), correlates them, and wakes
+the agent to **diagnose** — it doesn't re-implement the thresholds.
 
 ## 4. Cause an incident
 
@@ -65,13 +70,16 @@ curl -s -XPOST localhost:8080/demo/inject -H 'content-type: application/json' \
   -d '{"scenario": "error_spike"}'
 ```
 
-- `error_spike` — 5xx storm → the `error_spike` trigger fires
-- `latency` — p99 > 1s → the `slow_responses` trigger fires
-- `dependency_outage` — DB down → 503s + a `dependency_up=0` metric
-- `clear` — roll back, faults cleared
+- `error_spike` — 5xx storm → Prometheus fires `HighErrorRate`
+- `latency` — p99 > 1s → Prometheus fires `HighLatency`
+- `dependency_outage` — a dependency goes down → Prometheus fires `DependencyDown`
+- `clear` — roll back; the alerts resolve (a `resolved` event lands in the timeline)
 
-Watch it land in **Explore** (the timeline turns red) and, once an agent is subscribed, in
-**Agents → Trigger dispatches**.
+Give it ~30s (the rules have a 15s `for:`, then NavFlow polls the alert). The alert lands in
+**Explore** (the timeline turns red) next to the metric that tripped it and the error logs, the
+`incident` trigger fires, and — once an agent is subscribed — it shows in
+**Agents → Trigger dispatches**. Ask the agent *"what's wrong with api-server?"* and it diagnoses
+from the one correlated read.
 
 ## 5. Stop
 

--- a/demo/catalog.demo.yaml
+++ b/demo/catalog.demo.yaml
@@ -1,90 +1,81 @@
 # NavFlow catalog for the demo stack (demo/docker-compose.yml).
-# Prometheus on :9090, logs via docker. All sources share key=api-server so logs, metrics,
-# and alerts correlate in one timeline.
+# Prometheus on :9090 (metrics + alerting rules), logs via docker. Everything is keyed `api-server`,
+# so logs, metrics, and the alerts Prometheus fires correlate in one timeline.
+#
+# The division of labour is the real one: Prometheus evaluates the alerting rules and fires; NavFlow
+# ingests those alerts, correlates them with the metrics and logs, and a trigger wakes a subscribed
+# agent with the whole timeline — NavFlow diagnoses, it doesn't re-implement alerting.
 #
 # Works from any directory (the logs source tails the container by its fixed name):
 #   curl -O https://raw.githubusercontent.com/glassflow/navflow/main/demo/catalog.demo.yaml
 #   NAVFLOW_CATALOG=catalog.demo.yaml navflow up
 
 sources:
-  - name: metrics
+  # Prometheus metrics — context in the timeline (the signals behind the alert). Values ride on the
+  # `value` number label so they show in Fields (and could drive their own triggers if you wanted).
+  - name: demo_metrics
     connector: prometheus
     poll: 5s
     config:
       url: http://localhost:9090
-      default_key: api-server
-      labels:
-        - name: service
-          field: service        # tag each series with its Prometheus `service` label
       queries:
         - promql: 'sum(rate(http_requests_total{status=~"5.."}[1m])) by (service)'
           event_type: 5xx_rate
-          field: rate_5xx
           text: "5xx rate {service}={val}/s"
         - promql: 'histogram_quantile(0.99, sum(rate(http_request_duration_milliseconds_bucket[2m])) by (le, service))'
           event_type: p99
-          field: p99_ms
           text: "p99 {service}={val}ms"
-        - promql: 'db_pool_size'
-          event_type: db_pool
-          field: db_pool_size
-          text: "db_pool_size={val}"
         - promql: 'db_connections_active'
           event_type: db_active
-          field: db_connections_active
-          text: "db_connections_active={val}"
+          text: "db connections active={val}"
         - promql: 'dependency_up'
           event_type: dependency
-          field: dependency_up
           text: "dependency {dependency} up={val}"
+      labels:
+        - { name: service, const: api-server, primary: true }   # one service in the demo — key everything to it
+        - { name: value, field: value, type: number }           # the metric value, aggregatable
 
-  - name: logs
+  # Container logs — one line per request.
+  - name: demo_logs
     connector: docker_logs
     poll: 5s
     config:
-      container: navflow-demo-api-server  # fixed container_name in docker-compose.yml
-      key: api-server
+      container: navflow-demo-api-server   # fixed container_name in docker-compose.yml
+      labels:
+        - { name: service, const: api-server, primary: true }   # same key as metrics/alerts, and a real label
 
-  - name: alerts
-    connector: alerts
-    poll: 5s
+  # The alerts Prometheus's own rules have fired (polls /api/v1/alerts — no Alertmanager needed).
+  - name: demo_alerts
+    connector: prometheus_alerts
+    poll: 10s
     config:
       url: http://localhost:9090
-      key: api-server
-      threshold: 5
-      ratio_promql: '100*sum(rate(http_requests_total{status=~"5.."}[1m]))/sum(rate(http_requests_total[1m]))'
+      labels:
+        - { name: service, field: labels.service, primary: true }   # the rule sets service=api-server
+        - { name: alertname, field: labels.alertname }
+        - { name: severity, field: labels.severity }
+        - { name: state, field: state }
+        - { name: alert_active, const: 1, type: number }            # 1 per alert event — lets the trigger react to alerts
 
 views:
   - name: service_timeline
     key_field: service
-    sources: [logs, metrics, alerts]
+    sources: [demo_logs, demo_metrics, demo_alerts]
 
 triggers:
-  # 5xx storm — fires on an actual error spike.
-  - name: error_spike
+  # Wake the agent when Prometheus fires an alert — reacting to the alert, not re-thresholding the
+  # metric. `alert_active` is 1 on every alert event, so its sum over the window is the alert count;
+  # grouping by key_value keeps the dispatched payload the full correlated timeline for api-server.
+  - name: incident
     view: service_timeline
     condition:
-      aggregate: max
-      field: rate_5xx
-      predicate: "> 1.0"
+      aggregate: sum
+      field: alert_active
+      predicate: "> 0"
       window: 1m
       group_by: [key_value]
     emit:
-      kind: error_spike
-      attach_view: true
-    cooldown: 5m
-
-  # Latency regression — the right signal for the slow/timeout-shaped incident.
-  - name: slow_responses
-    view: service_timeline
-    condition:
-      aggregate: max
-      field: p99_ms
-      predicate: "> 1000"
-      window: 1m
-      group_by: [key_value]
-    emit:
-      kind: slow_responses
+      kind: incident
       attach_view: true
       context_window: 15m
-    cooldown: 30s
+    cooldown: 5m

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -31,6 +31,9 @@ services:
       - source: prometheus_config
         target: /etc/prometheus/prometheus.yml
         mode: 0444    # prometheus runs as nobody; the default config mode isn't world-readable
+      - source: prometheus_rules
+        target: /etc/prometheus/rules.yml
+        mode: 0444
     depends_on:
       - api-server
 
@@ -61,8 +64,36 @@ configs:
     content: |
       global:
         scrape_interval: 5s
+        evaluation_interval: 5s   # evaluate the alerting rules as fast as we scrape (snappy demo)
+
+      rule_files:
+        - /etc/prometheus/rules.yml
 
       scrape_configs:
         - job_name: api-server
           static_configs:
             - targets: ["api-server:8080"]
+
+  # Alerting rules — Prometheus evaluates these itself and exposes firing alerts on /api/v1/alerts,
+  # which NavFlow's `prometheus_alerts` source polls. No Alertmanager needed. Short `for:` so an
+  # injected fault fires within ~15s. Each maps 1:1 to a `./inject.sh` scenario.
+  prometheus_rules:
+    content: |
+      groups:
+        - name: api-server
+          rules:
+            - alert: HighErrorRate
+              expr: 100 * sum(rate(http_requests_total{status=~"5.."}[1m])) / sum(rate(http_requests_total[1m])) > 5
+              for: 15s
+              labels: { severity: critical, service: api-server }
+              annotations: { summary: "5xx error rate high on api-server" }
+            - alert: HighLatency
+              expr: histogram_quantile(0.99, sum(rate(http_request_duration_milliseconds_bucket[2m])) by (le)) > 1000
+              for: 15s
+              labels: { severity: warning, service: api-server }
+              annotations: { summary: "p99 latency over 1s on api-server" }
+            - alert: DependencyDown
+              expr: dependency_up == 0
+              for: 15s
+              labels: { severity: critical, service: api-server }
+              annotations: { summary: "a dependency is down for api-server" }


### PR DESCRIPTION
Rebuilds the demo on the new connectors and the real division of labour: **Prometheus owns alerting; NavFlow ingests + correlates + wakes an agent to diagnose** (the old demo used the removed `alerts` connector, and its triggers relied on the dropped auto-`fields` column).

- **`docker-compose.yml`** — Prometheus now evaluates three alerting rules (`HighErrorRate`, `HighLatency`, `DependencyDown`, `for: 15s`) and exposes them on `/api/v1/alerts`. No Alertmanager needed.
- **`catalog.demo.yaml`** — `demo_metrics` (`prometheus`, value on a number label), `demo_logs` (`docker_logs`, `service` as a primary label), `demo_alerts` (`prometheus_alerts`). One `incident` trigger reacts to a fired alert (`sum(alert_active) > 0`, grouped by `key_value`) and dispatches the full correlated timeline — it does **not** re-threshold the metric.
- **`README.md` / `demo/README.md`** — updated flow + connector list.

Verified live end to end: inject `error_spike` → Prometheus fires `HighErrorRate` → `demo_alerts` ingests it → `incident` trigger dispatches the correlated timeline (alert + 5xx metric + logs) → a sub-agent diagnosed from that read alone (0 extra queries, correctly ruled out DB/latency) → `clear` → `resolved` event lands.

Demo files ship from `main`, so no release/version bump.