### PR TITLE
metering: GET /api/usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Backend — install + tests
         run: |
           pip install -e .
-          for t in test_labels test_normalize test_auth test_api_keys test_agents test_catalog_sync test_cli; do
+          for t in test_labels test_normalize test_auth test_api_keys test_agents test_catalog_sync test_cli test_usage; do
             echo "== $t =="
             python "tests/$t.py"
           done

--- a/navflow/daemon.py
+++ b/navflow/daemon.py
@@ -1338,6 +1338,8 @@ def make_app() -> FastAPI:
         """What this instance is using: db + WAL bytes, the volume they sit on, and event counts.
         `max_bytes` is what the operator says this instance may grow to (NAVFLOW_MAX_DB_SIZE — a
         hosted cell gets its PVC size); unset -> null, and nothing is enforced here either way.
+        `pct_used` is (db + wal) over max_bytes on a 0-100 scale, NOT a 0-1 fraction — so a
+        "warn at 80%" consumer compares against 80, not 0.8. Null whenever max_bytes is null.
         Cheap by construction: file stats plus the maintained per-source counters, no table scan,
         so the cost does not grow with the event count."""
         u = store.usage()

--- a/navflow/daemon.py
+++ b/navflow/daemon.py
@@ -11,7 +11,9 @@ import asyncio
 import hashlib
 import json
 import os
+import re
 import secrets
+import shutil
 import uuid
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -71,6 +73,26 @@ def _public(method: str, path: str) -> bool:
         return True
     return method in ("GET", "HEAD") and not (
         path.startswith("/api/") or path.startswith("/catalog") or path == "/query")
+
+
+_SIZE_UNITS = {"": 1, "k": 10**3, "m": 10**6, "g": 10**9, "t": 10**12,
+               "ki": 1 << 10, "mi": 1 << 20, "gi": 1 << 30, "ti": 1 << 40}
+
+
+def _parse_size(v: str | None) -> int | None:
+    """NAVFLOW_MAX_DB_SIZE -> bytes. Accepts a plain integer or a Kubernetes-style quantity
+    ('10Gi', '500Mi', '2G') so a Helm chart can pass the PVC size through verbatim. Unset,
+    empty or unparseable -> None, i.e. no denominator and exactly today's behaviour."""
+    if not v or not (v := v.strip()):
+        return None
+    m = re.fullmatch(r"(\d+(?:\.\d+)?)\s*([KMGTkmgt]i?|)[Bb]?", v)
+    if not m:
+        return None
+    n = int(float(m.group(1)) * _SIZE_UNITS[m.group(2).lower()])
+    return n if n > 0 else None
+
+
+MAX_DB_SIZE = _parse_size(os.getenv("NAVFLOW_MAX_DB_SIZE"))
 
 
 def _ui_dist() -> Path:
@@ -1309,6 +1331,25 @@ def make_app() -> FastAPI:
             _err(ValueError(f"invalid YAML: {e}"))
         runtime.reload_catalog()
         return {"ok": True, **counts}
+
+    # ── metering ──────────────────────────────────────────────────────────────
+    @app.get("/api/usage")
+    async def usage():
+        """What this instance is using: db + WAL bytes, the volume they sit on, and event counts.
+        `max_bytes` is what the operator says this instance may grow to (NAVFLOW_MAX_DB_SIZE — a
+        hosted cell gets its PVC size); unset -> null, and nothing is enforced here either way.
+        Cheap by construction: file stats plus the maintained per-source counters, no table scan,
+        so the cost does not grow with the event count."""
+        u = store.usage()
+        try:
+            du = shutil.disk_usage(os.path.dirname(os.path.abspath(DB_PATH)) or ".")
+            disk_total, disk_free = du.total, du.free
+        except OSError:
+            disk_total = disk_free = None
+        used = u["db_bytes"] + u["wal_bytes"]
+        return {**u, "disk_total": disk_total, "disk_free": disk_free,
+                "max_bytes": MAX_DB_SIZE,
+                "pct_used": round(100 * used / MAX_DB_SIZE, 2) if MAX_DB_SIZE else None}
 
     # ── console UI (built SPA; catch-all registered last so API routes win) ──
     @app.get("/{path:path}", include_in_schema=False)

--- a/navflow/store.py
+++ b/navflow/store.py
@@ -282,6 +282,14 @@ def _cgroup_mem_bytes() -> int | None:
     return None
 
 
+def _file_size(path: str) -> int:
+    """Bytes on disk, 0 if the file isn't there (an in-memory db, or a WAL that's checkpointed)."""
+    try:
+        return os.path.getsize(path)
+    except OSError:
+        return 0
+
+
 def _bound_duckdb_memory(con, path: str) -> None:
     """Bound DuckDB to the CONTAINER, not the host. Without a memory_limit DuckDB sizes itself to
     the node's RAM, so one heavy scan over a grown dataset blows past the cgroup limit and the
@@ -310,6 +318,7 @@ class Store:
         # All access is from navflowd's event loop thread; the lock is belt-and-suspenders since
         # FastAPI may run sync work in a threadpool.
         self._lock = threading.Lock()
+        self.path = path          # kept so usage() can size the db file and its WAL
         self.con = duckdb.connect(path)
         _bound_duckdb_memory(self.con, path)
         for stmt in _SCHEMA.strip().split(";"):
@@ -928,6 +937,28 @@ class Store:
                 "SELECT source, events, last_ingest FROM source_stats ORDER BY source"
             ).fetchall()
         return [{"source": r[0], "events": r[1], "last_ingest": r[2]} for r in rows]
+
+    def usage(self) -> dict:
+        """What this instance is costing on disk, for the metering endpoint. Every number here is
+        O(1)-ish: file sizes come from stat(), per-source event counts from the maintained
+        `source_stats` counter (never a scan of events), and the two row counts are unfiltered
+        COUNT(*)s, which DuckDB answers from table metadata. Per-source bytes are None — DuckDB
+        stores every source in one events table and does not attribute storage per value."""
+        db_bytes = _file_size(self.path)
+        wal_bytes = _file_size(self.path + ".wal")
+        with self._lock:
+            sources = self.con.execute(
+                "SELECT source, events FROM source_stats ORDER BY source").fetchall()
+            runs = self.con.execute("SELECT COUNT(*) FROM agent_runs").fetchone()[0]
+            deliveries = self.con.execute("SELECT COUNT(*) FROM dispatch_deliveries").fetchone()[0]
+        return {
+            "db_bytes": db_bytes,
+            "wal_bytes": wal_bytes,
+            "events": sum(int(r[1] or 0) for r in sources),
+            "sources": [{"name": r[0], "events": int(r[1] or 0), "bytes": None} for r in sources],
+            "agent_runs": int(runs),
+            "dispatch_deliveries": int(deliveries),
+        }
 
     def recent_events(self, source: str | None = None, limit: int = 50) -> list[dict]:
         where = "WHERE source = ?" if source else ""

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -1,0 +1,145 @@
+"""Instance metering — GET /api/usage. Real daemon: file sizes match the db on disk, per-source
+counts agree with /api/sources, the NAVFLOW_MAX_DB_SIZE denominator drives max_bytes/pct_used
+(null when unset), the endpoint is a read scope (ingest-only keys are refused), and the response
+stays fast as the event count grows (no table scan).
+"""
+import asyncio, os, subprocess, sys, time
+import httpx
+
+from navflow.daemon import _parse_size
+
+P = F = 0
+def ck(l, c, d=""):
+    global P, F; P += 1 if c else 0; F += 0 if c else 1
+    print(("  ok   " if c else "  FAIL ") + l + ("" if c else f"  {d}"))
+
+SEED = "/tmp/usage_catalog.yaml"
+with open(SEED, "w") as fh:
+    fh.write("""sources:
+  - name: evt
+    connector: webhook
+    poll: 5s
+    config: {}
+  - name: evt2
+    connector: webhook
+    poll: 5s
+    config: {}
+""")
+DB, PORT = "/tmp/usage.duckdb", "8809"
+AUTH = "root-token"
+BLOCK = 1 << 18   # DuckDB writes in 256KiB blocks; sizes are compared to that tolerance
+
+
+async def _wait(url):
+    for _ in range(80):
+        try:
+            async with httpx.AsyncClient() as cx:
+                if (await cx.get(url, timeout=1)).status_code == 200:
+                    return True
+        except Exception:
+            pass
+        await asyncio.sleep(0.25)
+    return False
+
+
+def H(tok):
+    return {"Authorization": f"Bearer {tok}"}
+
+
+def _boot(**extra):
+    env = {k: v for k, v in os.environ.items()
+           if k not in ("NAVFLOW_AUTH_TOKEN", "NAVFLOW_MAX_DB_SIZE")}
+    env |= {"NAVFLOW_DB": DB, "NAVFLOW_CATALOG": SEED, "NAVFLOW_PORT": PORT,
+            "NAVFLOW_OTLP_GRPC_PORT": "off", **extra}
+    return subprocess.Popen([sys.executable, "-c", "from navflow.cli import run_daemon; run_daemon()"],
+                            env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+
+def _units():
+    # NAVFLOW_MAX_DB_SIZE parsing: plain bytes and Kubernetes-style quantities (so Helm can pass
+    # the PVC size through verbatim); anything unparseable degrades to "no limit".
+    ck("size: plain bytes", _parse_size("1073741824") == 1 << 30)
+    ck("size: 10Gi", _parse_size("10Gi") == 10 * (1 << 30))
+    ck("size: 500Mi", _parse_size("500Mi") == 500 * (1 << 20))
+    ck("size: 2G is decimal", _parse_size("2G") == 2 * 10**9)
+    ck("size: unset -> None", _parse_size(None) is None and _parse_size("") is None)
+    ck("size: garbage -> None", _parse_size("lots") is None and _parse_size("0") is None)
+
+
+async def main():
+    _units()
+    for p in (DB, DB + ".wal"):
+        if os.path.exists(p):
+            os.remove(p)
+    B = f"http://127.0.0.1:{PORT}"
+
+    # ── no limit configured, auth off ──
+    proc = _boot()
+    try:
+        if not await _wait(f"{B}/health"):
+            ck("daemon up", False); return
+        async with httpx.AsyncClient() as cx:
+            await cx.post(f"{B}/ingest/evt", json=[{"m": i} for i in range(20)])
+            await cx.post(f"{B}/ingest/evt2", json=[{"m": i} for i in range(5)])
+            u = (await cx.get(f"{B}/api/usage")).json()
+
+            db, wal = os.path.getsize(DB), (os.path.getsize(DB + ".wal") if os.path.exists(DB + ".wal") else 0)
+            ck("db_bytes matches the file on disk", abs(u["db_bytes"] - db) <= BLOCK, f"{u['db_bytes']} vs {db}")
+            ck("wal_bytes matches the wal on disk", abs(u["wal_bytes"] - wal) <= BLOCK, f"{u['wal_bytes']} vs {wal}")
+            ck("db_bytes > 0", u["db_bytes"] > 0, str(u["db_bytes"]))
+            ck("disk_total/disk_free are real",
+               u["disk_total"] > 0 and 0 < u["disk_free"] <= u["disk_total"], str(u))
+            ck("no NAVFLOW_MAX_DB_SIZE -> max_bytes null", u["max_bytes"] is None, str(u["max_bytes"]))
+            ck("no NAVFLOW_MAX_DB_SIZE -> pct_used null", u["pct_used"] is None, str(u["pct_used"]))
+            ck("events total", u["events"] == 25, str(u["events"]))
+            ck("per-source counts", {s["name"]: s["events"] for s in u["sources"]} == {"evt": 20, "evt2": 5},
+               str(u["sources"]))
+            ck("sources sum to events", sum(s["events"] for s in u["sources"]) == u["events"])
+            ck("agent_runs / dispatch_deliveries present",
+               u["agent_runs"] == 0 and u["dispatch_deliveries"] == 0, str(u))
+
+            srcs = (await cx.get(f"{B}/api/sources")).json()
+            from_sources = {s["name"]: (s["health"] or {}).get("events_total") for s in srcs}
+            ck("per-source counts agree with /api/sources",
+               all(from_sources.get(s["name"]) == s["events"] for s in u["sources"]), str(from_sources))
+
+            # ── cost must not grow with the event count (counter read, not a scan) ──
+            t0 = time.perf_counter(); await cx.get(f"{B}/api/usage"); small = time.perf_counter() - t0
+            for _ in range(5):
+                await cx.post(f"{B}/ingest/evt", json=[{"m": i, "text": "x" * 200} for i in range(2000)])
+            t0 = time.perf_counter(); u2 = (await cx.get(f"{B}/api/usage")).json()
+            big = time.perf_counter() - t0
+            ck("counted the new events", u2["events"] == 10025, str(u2["events"]))
+            ck("response time flat at 10k events (no scan)", big < max(0.25, small * 5),
+               f"{small*1000:.1f}ms at 25 events -> {big*1000:.1f}ms at 10k")
+    finally:
+        proc.terminate(); proc.wait(timeout=10)
+
+    # ── limit configured + auth on ──
+    proc = _boot(NAVFLOW_AUTH_TOKEN=AUTH, NAVFLOW_MAX_DB_SIZE="1Gi")
+    try:
+        if not await _wait(f"{B}/health"):
+            ck("daemon up (auth)", False); return
+        async with httpx.AsyncClient() as cx:
+            ck("no credential -> 401", (await cx.get(f"{B}/api/usage")).status_code == 401)
+            r = await cx.post(f"{B}/api/keys", json={"name": "meter", "scopes": ["read"]}, headers=H(AUTH))
+            read_key = r.json()["secret"]
+            ing_key = (await cx.post(f"{B}/api/keys", json={"name": "prod", "scopes": ["ingest"]},
+                                     headers=H(AUTH))).json()["secret"]
+            ck("ingest-only key -> 403", (await cx.get(f"{B}/api/usage", headers=H(ing_key))).status_code == 403)
+            r = await cx.get(f"{B}/api/usage", headers=H(read_key))
+            ck("read key -> 200", r.status_code == 200, r.text)
+            u = r.json()
+            ck("max_bytes from NAVFLOW_MAX_DB_SIZE", u["max_bytes"] == 1 << 30, str(u["max_bytes"]))
+            expect = round(100 * (u["db_bytes"] + u["wal_bytes"]) / (1 << 30), 2)
+            ck("pct_used = (db+wal)/max as a percentage", u["pct_used"] == expect and u["pct_used"] > 0,
+               f"{u['pct_used']} vs {expect}")
+            ck("counts survived the restart", u["events"] == 10025, str(u["events"]))
+    finally:
+        proc.terminate(); proc.wait(timeout=10)
+
+    print(f"\n{P} passed, {F} failed")
+    raise SystemExit(1 if F else 0)
+
+
+asyncio.run(main())


### PR DESCRIPTION
Implements NF-88 — instance metering. Nothing in NavFlow knew how much storage it was using; this adds a read-only endpoint that answers it, without enforcing anything.

## What changed

**`navflow/store.py`**
- `Store.__init__` now keeps `self.path` (the db path was not retained anywhere before).
- `_file_size(path)` helper — `os.path.getsize`, 0 when the file is absent (in-memory db, checkpointed WAL).
- `Store.usage()` — db/wal bytes, total + per-source event counts read from the maintained `source_stats` counter (no scan of `events`), plus `agent_runs` and `dispatch_deliveries` row counts. Takes `self._lock` like every other store method.

**`navflow/daemon.py`**
- `GET /api/usage`, registered before the SPA catch-all. Returns `db_bytes`, `wal_bytes`, `disk_total`, `disk_free` (`shutil.disk_usage` on the db's directory), `max_bytes`, `pct_used`, `events`, `sources[]`, `agent_runs`, `dispatch_deliveries`.
- `NAVFLOW_MAX_DB_SIZE` (`_parse_size`) accepts a plain byte count *or* a Kubernetes-style quantity (`10Gi`, `500Mi`, `2G`) so a chart can pass a PVC size through verbatim. Unset/unparseable -> `null`, `pct_used` -> `null`: today's behaviour exactly. Nothing is enforced — that is the quota ticket.
- No `_required_scope` change needed: a `GET /api/*` already falls through to `read`, so an ingest-only key gets 403 (asserted in the test).

**`tests/test_usage.py`** (new, added to the CI list in `.github/workflows/ci.yml`) — same plain-script + `ck()` shape as `test_api_keys.py`: boots a real daemon twice (open/no-limit, then auth + `1Gi`).

## Notes / decisions

- `pct_used` is a percentage `0..100` rounded to 2dp, not a 0..1 fraction — the ticket's "db+wal over max_bytes" was ambiguous and the field is named `pct`.
- `sources[].bytes` is always `null`. The schema allows `int | null`, and DuckDB keeps every source in one `events` table with no cheap way to attribute storage per source value; a proportional guess would be a made-up number in a metering API. Total bytes are exact.
- `agent_runs` / `dispatch_deliveries` are extra top-level fields beyond the response shape in the ticket (the ticket asks for the counts in `Store.usage()` but doesn't show them in the JSON) — they are exposed since they're the growth story for NF-86.

## Deferred

- **Helm wiring** (`navflow-cloud/charts/navflow-cell/`, pass the PVC size in as `NAVFLOW_MAX_DB_SIZE`) is a follow-up in the private repo — not touched here. `_parse_size` already accepts the `10Gi` PVC quantity format so the chart can pass `.Values` straight through.
- Enforcement, retention/pruning/`CHECKPOINT`, and the control-plane/admin-console surface stay out of scope (NF-87, NF-82, integration spec §5/§6).

## Verification (actual output)

`python tests/test_usage.py` — 25 passed, 0 failed, including:

```
  ok   db_bytes matches the file on disk
  ok   wal_bytes matches the wal on disk
  ok   no NAVFLOW_MAX_DB_SIZE -> max_bytes null
  ok   no NAVFLOW_MAX_DB_SIZE -> pct_used null
  ok   per-source counts agree with /api/sources
  ok   response time flat at 10k events (no scan)
  ok   no credential -> 401
  ok   ingest-only key -> 403
  ok   max_bytes from NAVFLOW_MAX_DB_SIZE
  ok   pct_used = (db+wal)/max as a percentage
```

Existing suites unaffected: `tests/test_api_keys.py` 25 passed, 0 failed; `tests/test_auth.py` 14 passed, 0 failed.

Live daemon, as in the ticket's Verify block:

```
$ NAVFLOW_DB=/tmp/manual.duckdb python -m navflow.cli up &
$ curl -s localhost:8811/api/usage
{"db_bytes":12288,"wal_bytes":5881,"events":0,"sources":[],"agent_runs":0,
 "dispatch_deliveries":0,"disk_total":994662584320,"disk_free":470800351232,
 "max_bytes":null,"pct_used":null}
$ ls -l /tmp/manual.duckdb*
-rw-r--r--  1 ashishbagri  wheel  12288 Aug  3 15:58 /tmp/manual.duckdb
-rw-r--r--  1 ashishbagri  wheel   5881 Aug  3 15:58 /tmp/manual.duckdb.wal

$ NAVFLOW_MAX_DB_SIZE=1073741824 ... curl -s localhost:8812/api/usage
{... "max_bytes":1073741824,"pct_used":0.0}
```

Console is untouched but confirmed green: `cd ui && npx tsc --noEmit && npm run build` -> `✓ built in 913ms`.
