### PR TITLE
fix: window the agent roster's delivery counts (NF-86)

### DIFF
--- a/navflow/builtin_agents.py
+++ b/navflow/builtin_agents.py
@@ -151,6 +151,12 @@ class AgentRunner:
         # (agent, key) currently running. Dispatch is at-least-once, so a retried delivery would
         # otherwise run the same investigation twice and pay for it twice.
         self._inflight: set[tuple[str, str]] = set()
+        # Runs live in this process, so nothing can still be running from a previous one: any row
+        # left `running` is an orphan from a daemon that was killed mid-run. Left alone it stays
+        # running forever and keeps counting toward the daily cap.
+        reaped = store.reap_stale_agent_runs()
+        if reaped:
+            print(f"navflowd: reaped {reaped} interrupted agent run(s)")
 
     # ── entry point (called by the dispatcher, once per internal subscription) ─
     def deliver(self, agent_name: str, subscription_id: str, trigger_name: str, key: str,
@@ -201,8 +207,10 @@ class AgentRunner:
             msg = "no Anthropic key: set ANTHROPIC_API_KEY or add one in the console"
             self.store.finish_agent_run(run_id, "failed", error=msg)
             return "failed", msg
-        if self.store.agent_runs_today(agent["name"]) > DAILY_RUN_CAP:
-            msg = f"daily cap of {DAILY_RUN_CAP} runs reached for this agent"
+        # Count the runs BEFORE this one (its row is already inserted), so the cap fires at exactly
+        # DAILY_RUN_CAP runs rather than one over it.
+        if self.store.agent_runs_today(agent["name"], exclude_run_id=run_id) >= DAILY_RUN_CAP:
+            msg = f"cap of {DAILY_RUN_CAP} runs in the last 24h reached for this agent"
             self.store.finish_agent_run(run_id, "capped", error=msg)
             return "capped", msg
 

--- a/navflow/daemon.py
+++ b/navflow/daemon.py
@@ -1259,10 +1259,16 @@ def make_app() -> FastAPI:
                     "name": name, "endpoint": masked, "kind": kind,
                     "subscriptions": [], "triggers": [], "created_by": set(),
                     "first_seen": sub["created_at"],
-                    "delivered_ok": st.get("ok", 0), "delivered_fail": st.get("fail", 0),
+                    # windowed counts are what the roster shows (an all-time total next to a
+                    # "last woken" of weeks ago reads as busy); totals ride along for context.
+                    "delivered_ok_24h": st.get("ok", 0), "delivered_fail_24h": st.get("fail", 0),
+                    "delivered_ok_total": st.get("ok_total", 0),
+                    "delivered_fail_total": st.get("fail_total", 0),
                     "pending": st.get("pending", 0), "last_woken": st.get("last_at"),
-                    # currently failing: the most recent delivery to this endpoint did not succeed.
-                    "unhealthy": st.get("fail", 0) > 0 and not st.get("last_ok", True),
+                    # currently failing: the most recent delivery to this endpoint did not succeed —
+                    # deliberately over ALL deliveries, so a failing endpoint that has gone quiet
+                    # doesn't quietly go healthy when it falls out of the window.
+                    "unhealthy": st.get("fail_total", 0) > 0 and not st.get("last_ok", True),
                     "last_error": None if st.get("last_ok", True) else st.get("last_error"),
                     "recent": [{"at": d["at"], "ok": d["ok"], "trigger": d["trigger"],
                                 "key": d["key"], "error": d["error"], "dispatch_id": d["dispatch_id"]}

--- a/navflow/store.py
+++ b/navflow/store.py
@@ -15,6 +15,7 @@ from datetime import datetime
 import duckdb
 
 from .envelope import Envelope, now_utc
+from .views import parse_window
 
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS events (
@@ -809,13 +810,43 @@ class Store:
             for r in rows
         ]
 
-    def agent_runs_today(self, agent: str) -> int:
-        """Runs started in the last 24h — the cost ceiling's counter."""
+    def agent_runs_today(self, agent: str, exclude_run_id: str | None = None) -> int:
+        """Runs started in the last 24h — the cost ceiling's counter. `exclude_run_id` leaves out the
+        run being checked: the row is inserted before the cap is evaluated, so the cap must count the
+        runs that came BEFORE this one or it lets one extra through."""
+        sql = ("SELECT count(*) FROM agent_runs WHERE agent = ? "
+               "AND started_at > now() - INTERVAL 1 DAY")
+        params: list = [agent]
+        if exclude_run_id:
+            sql += " AND id <> ?"
+            params.append(exclude_run_id)
         with self._lock:
-            row = self.con.execute(
-                "SELECT count(*) FROM agent_runs WHERE agent = ? "
-                "AND started_at > now() - INTERVAL 1 DAY", [agent]).fetchone()
+            row = self.con.execute(sql, params).fetchone()
         return int(row[0]) if row else 0
+
+    def reap_stale_agent_runs(self, older_than: str | None = None) -> int:
+        """Close out orphaned `running` rows, returning how many were reaped.
+
+        A run lives in the daemon process (`AgentRunner._tasks`), so if the daemon is killed
+        mid-run its row stays `status='running'` forever — reading as in-flight on the runs list and
+        still counting toward the daily cap. Called at startup, where nothing can legitimately be in
+        flight yet, so the default reaps every `running` row; pass a window ("1h") to only reap rows
+        older than it."""
+        cutoff = None if older_than is None else now_utc() - parse_window(older_than)
+        where = "status = 'running'" + ("" if cutoff is None else " AND started_at < ?")
+        args: list = [] if cutoff is None else [cutoff]
+        with self._lock:
+            row = self.con.execute(f"SELECT count(*) FROM agent_runs WHERE {where}",
+                                   args).fetchone()
+            n = int(row[0]) if row else 0
+            if n:
+                ts = now_utc()
+                self.con.execute(
+                    "UPDATE agent_runs SET status = 'failed', error = ?, finished_at = ?, "
+                    "duration_ms = CAST(date_diff('millisecond', started_at, ?) AS INTEGER) "
+                    f"WHERE {where}",
+                    ["interrupted: navflowd stopped while this run was in flight", ts, ts] + args)
+        return n
 
     # ── settings (instance config set from the console) ───────────────────────
     def get_setting(self, key: str) -> str | None:
@@ -1170,24 +1201,35 @@ class Store:
         return [{"subscription_id": r[0], "trigger": r[1], "url": r[2],
                  "created_at": r[3], "created_by": r[4]} for r in rows]
 
-    def delivery_stats(self) -> dict:
-        """{url: {ok, fail, last_at, last_ok, last_error}} across all recorded deliveries. `last_ok`
-        / `last_error` describe the MOST RECENT delivery, so the UI can flag an endpoint that's
-        currently failing and say why (arg_max picks the value at the latest delivered_at)."""
+    def delivery_stats(self, window: str = "24h") -> dict:
+        """{url: {ok, fail, ok_total, fail_total, last_at, last_ok, last_error}} per endpoint.
+
+        `ok`/`fail` are counted over `window` only — an all-time total presented next to a "last
+        woken" of weeks ago reads as "this agent is busy" when it has been idle for a month. The
+        all-time totals come back alongside them (same single pass) so nothing is lost.
+
+        `last_at` / `last_ok` / `last_error` describe the MOST RECENT delivery *ever*, not the most
+        recent one in the window: an endpoint that is currently failing must keep saying so even
+        when it has been quiet for longer than the window (arg_max picks the value at the latest
+        delivered_at)."""
+        since = now_utc() - parse_window(window)
         with self._lock:
             # ok IS NULL is a pending NavFlow-agent run — count it as neither delivered nor failed,
             # and exclude it from the "most recent outcome" (arg_max over resolved deliveries only),
             # so a running agent never reads as a failure.
             rows = self.con.execute(
-                "SELECT url, SUM(CASE WHEN ok THEN 1 ELSE 0 END), "
+                "SELECT url, SUM(CASE WHEN ok AND delivered_at > ? THEN 1 ELSE 0 END), "
+                "SUM(CASE WHEN ok = FALSE AND delivered_at > ? THEN 1 ELSE 0 END), "
+                "SUM(CASE WHEN ok THEN 1 ELSE 0 END), "
                 "SUM(CASE WHEN ok = FALSE THEN 1 ELSE 0 END), MAX(delivered_at), "
                 "SUM(CASE WHEN ok IS NULL THEN 1 ELSE 0 END), "
                 "arg_max(ok, CASE WHEN ok IS NULL THEN NULL ELSE delivered_at END), "
                 "arg_max(error, CASE WHEN ok IS NULL THEN NULL ELSE delivered_at END) "
-                "FROM dispatch_deliveries GROUP BY url").fetchall()
-        return {r[0]: {"ok": int(r[1] or 0), "fail": int(r[2] or 0), "last_at": r[3],
-                       "pending": int(r[4] or 0),
-                       "last_ok": True if r[5] is None else bool(r[5]), "last_error": r[6]}
+                "FROM dispatch_deliveries GROUP BY url", [since, since]).fetchall()
+        return {r[0]: {"ok": int(r[1] or 0), "fail": int(r[2] or 0),
+                       "ok_total": int(r[3] or 0), "fail_total": int(r[4] or 0),
+                       "last_at": r[5], "pending": int(r[6] or 0),
+                       "last_ok": True if r[7] is None else bool(r[7]), "last_error": r[8]}
                 for r in rows}
 
     def recent_deliveries(self, url: str, limit: int = 20) -> list[dict]:

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -159,6 +159,14 @@ async def main():
             names = [dv["agent"] for dv in detail.get("deliveries", [])]
             ck("firing detail lists the NavFlow agent as a delivery", "first-look" in names, str(names))
 
+            # ── the roster counts are windowed, with the all-time total kept ──
+            me = next(a for a in (await cx.get(f"{B}/api/agents")).json()["agents"]
+                      if a["name"] == "first-look")
+            ck("roster counts deliveries in the last 24h", me.get("delivered_ok_24h", 0) >= 1, str(me))
+            ck("roster keeps the all-time total (every delivery here is fresh)",
+               me.get("delivered_ok_total") == me.get("delivered_ok_24h"), str(me))
+            ck("roster drops the unwindowed 'delivered_ok'", "delivered_ok" not in me, str(me))
+
             # ── the finding is an ordinary event on the entity's timeline ────
             rd = (await cx.post(f"{B}/read", json={"selector": {"service": "checkout"},
                                                    "window": "15m"})).json()
@@ -201,6 +209,42 @@ async def main():
         proc.send_signal(signal.SIGTERM)
         try: proc.wait(timeout=5)
         except Exception: proc.kill()
+
+    # ── a run orphaned by a killed daemon is reaped on the next boot ─────────
+    # Runs live in the daemon process, so a `running` row that outlives it is an orphan: it would
+    # otherwise stay running forever AND keep counting toward the daily cap.
+    try:
+        from navflow.store import Store
+        st = Store(DB)
+        st.upsert_catalog_agent("ghost", "incident", "Take a first look.")
+        st.start_agent_run("run_orphan", "ghost", "incident", "d_orphan", "checkout", "h")
+        ck("orphan counts toward the cap while it is running", st.agent_runs_today("ghost") == 1)
+        st.con.close()
+
+        proc = subprocess.Popen([sys.executable, "-c", "from navflow.cli import run_daemon; run_daemon()"],
+                                env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        try:
+            if not await _wait(f"{B}/health"):
+                ck("daemon back up", False)
+            else:
+                async with httpx.AsyncClient(timeout=20) as cx:
+                    rs = (await cx.get(f"{B}/api/agents/builtin/ghost/runs")).json()
+                    ck("no stuck 'running' run after a restart",
+                       all(r["status"] != "running" for r in rs), str(rs))
+                    ck("the orphan says it was interrupted",
+                       bool(rs) and "interrupted" in (rs[0].get("error") or ""), str(rs))
+        finally:
+            proc.send_signal(signal.SIGTERM)
+            try: proc.wait(timeout=5)
+            except Exception: proc.kill()
+
+        st = Store(DB)
+        # It still counts as an attempt (it ran, and spent tokens, before the daemon died) — what
+        # it no longer does is sit there as 'running' forever.
+        rs = st.list_agent_runs("ghost")
+        ck("the orphan is closed out as failed", [r["status"] for r in rs] == ["failed"], str(rs))
+        st.con.close()
+    finally:
         stub.shutdown()
     print(f"\n{P} passed, {F} failed")
 

--- a/ui/src/pages/Activity.tsx
+++ b/ui/src/pages/Activity.tsx
@@ -374,7 +374,7 @@ export function AgentsRoster({ only }: { only?: "connected" | "navflow" }) {
     <>
       {err && <div className="alert error">{err}</div>}
       <table>
-        <thead><tr><th>agent</th><th>endpoint</th><th>wakes on</th><th className="num">delivered</th><th className="num">failed</th><th>last woken</th><th></th></tr></thead>
+        <thead><tr><th>agent</th><th>endpoint</th><th>wakes on</th><th className="num">delivered (24h)</th><th className="num">failed (24h)</th><th>last woken</th><th></th></tr></thead>
         <tbody>
           {agents.map((a) => (
             <>
@@ -385,8 +385,15 @@ export function AgentsRoster({ only }: { only?: "connected" | "navflow" }) {
                 </td>
                 <td className="mono">{a.endpoint}</td>
                 <td>{a.triggers.map((t) => <span className="chip mono" key={t}>{t}</span>)}</td>
-                <td className="num">{a.delivered_ok}</td>
-                <td className="num" style={a.delivered_fail ? { color: "var(--err)" } : undefined}>{a.delivered_fail}</td>
+                <td className="num" title={`${a.delivered_ok_total} delivered all time`}>
+                  {a.delivered_ok_24h}
+                  {a.delivered_ok_total !== a.delivered_ok_24h && <span className="dim"> / {a.delivered_ok_total}</span>}
+                </td>
+                <td className="num" style={a.delivered_fail_24h ? { color: "var(--err)" } : undefined}
+                    title={`${a.delivered_fail_total} failed all time`}>
+                  {a.delivered_fail_24h}
+                  {a.delivered_fail_total !== a.delivered_fail_24h && <span className="dim"> / {a.delivered_fail_total}</span>}
+                </td>
                 <td style={{ whiteSpace: "nowrap" }}>{a.last_woken ? <TimeAgo ts={a.last_woken} /> : <span className="help">never</span>}</td>
                 <td className="dim">{open === a.name ? "▾" : "▸"}</td>
               </tr>

--- a/ui/src/pages/TriggerDetail.tsx
+++ b/ui/src/pages/TriggerDetail.tsx
@@ -89,7 +89,7 @@ export default function TriggerDetail() {
       </div>
       {wired.length > 0 ? (
         <table style={{ marginBottom: 10 }}>
-          <thead><tr><th>agent</th><th>kind</th><th>endpoint</th><th className="num">delivered</th><th className="num">failed</th><th>status</th></tr></thead>
+          <thead><tr><th>agent</th><th>kind</th><th>endpoint</th><th className="num">delivered (24h)</th><th className="num">failed (24h)</th><th>status</th></tr></thead>
           <tbody>
             {wired.map((a) => (
               <tr key={a.name}>
@@ -100,14 +100,21 @@ export default function TriggerDetail() {
                   ? <span className="badge">NavFlow</span>
                   : <span className="badge push">connected</span>}</td>
                 <td className="mono">{a.endpoint}</td>
-                <td className="num">{a.delivered_ok}</td>
-                <td className="num" style={a.delivered_fail ? { color: "var(--err)" } : undefined}>{a.delivered_fail}</td>
+                <td className="num" title={`${a.delivered_ok_total} delivered all time`}>
+                  {a.delivered_ok_24h}
+                  {a.delivered_ok_total !== a.delivered_ok_24h && <span className="dim"> / {a.delivered_ok_total}</span>}
+                </td>
+                <td className="num" style={a.delivered_fail_24h ? { color: "var(--err)" } : undefined}
+                    title={`${a.delivered_fail_total} failed all time`}>
+                  {a.delivered_fail_24h}
+                  {a.delivered_fail_total !== a.delivered_fail_24h && <span className="dim"> / {a.delivered_fail_total}</span>}
+                </td>
                 <td>
                   {a.pending
                     ? <span className="badge starting">running</span>
                     : a.unhealthy
                     ? <span className="badge error" title={a.last_error ?? "last delivery failed"}>failing{a.last_error ? `: ${a.last_error}` : ""}</span>
-                    : a.delivered_ok > 0 ? <span className="badge ok">ok</span> : <span className="dim">—</span>}
+                    : a.delivered_ok_total > 0 ? <span className="badge ok">ok</span> : <span className="dim">—</span>}
                 </td>
               </tr>
             ))}

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -141,8 +141,10 @@ export interface AgentInfo {
   triggers: string[];
   created_by: string[];
   first_seen: string | null;
-  delivered_ok: number;
-  delivered_fail: number;
+  delivered_ok_24h: number;     // deliveries in the last 24h — what the roster columns show
+  delivered_fail_24h: number;
+  delivered_ok_total: number;   // all-time, shown as secondary text so the number isn't lost
+  delivered_fail_total: number;
   pending?: number;             // in-flight NavFlow-agent runs
   last_woken: string | null;
   unhealthy?: boolean;          // the most recent delivery to this endpoint failed


### PR DESCRIPTION
Closes NF-86.

## What changed

**The roster's counts are windowed.** `Store.delivery_stats(window="24h")` now filters
`dispatch_deliveries` on `delivered_at` and returns the windowed counts *and* the all-time totals
from the same single pass (`ok`/`fail` + `ok_total`/`fail_total`). The window is parsed with the
existing `parse_window` (the one triggers use) — no second parser.

`last_at` / `last_ok` / `last_error` are deliberately still computed over **all** deliveries, so an
endpoint that is currently failing keeps its `failing` badge even when it has been quiet for longer
than the window. `unhealthy` in `agent_roster()` now keys off `fail_total`, for the same reason —
with the windowed count it would have gone silently healthy. The `arg_max` "most recent outcome"
logic and the `ok IS NULL` = pending handling are untouched.

`GET /api/agents` returns `delivered_ok_24h` / `delivered_fail_24h` and `delivered_ok_total` /
`delivered_fail_total`. The ambiguous `delivered_ok` / `delivered_fail` are gone rather than kept as
aliases — an unlabelled count next to a `last woken` of weeks ago is the bug.

**UI.** Both tables (`AgentsRoster` on Activity/Agents, and the wired-agents table on
TriggerDetail) head the columns `delivered (24h)` / `failed (24h)`, show the 24h number, and append
the all-time total as dimmed `/ N` secondary text when it differs, with a `title=` tooltip spelling
it out. TriggerDetail's `ok` badge now uses the all-time total so it doesn't disappear when an agent
goes quiet.

**Orphaned `running` rows.** New `Store.reap_stale_agent_runs()`, called from `AgentRunner.__init__`
(i.e. at daemon start). Runs live in the daemon process, so on a fresh boot nothing can legitimately
be in flight — the default reaps every `running` row, marking it `failed` with
`"interrupted: navflowd stopped while this run was in flight"` and filling in `finished_at` /
`duration_ms`. It takes an optional window (`"1h"`) if a caller ever wants the timeout form.

**Cap off-by-one.** `agent_runs_today(agent, exclude_run_id=...)` can now leave out the run being
checked, and `builtin_agents.py` uses `>= DAILY_RUN_CAP` against that pre-insert count, so the cap
is evaluated on the runs that came before this one. The message now says "in the last 24h" rather
than "daily", per the note in the ticket.

## Verified

`python tests/test_agents.py` — **39 passed, 0 failed** (32 before; 7 new assertions, incl. an
end-to-end orphan-reap phase that inserts a `running` row against a stopped daemon, restarts it, and
asserts the row comes back `failed` with an `interrupted` reason). `tests/test_auth.py` (14 passed)
and `tests/test_cli.py` (8 passed) also re-run clean.

`cd ui && npx tsc --noEmit` — clean, exit 0. `npm run build` — `✓ built in 903ms` (only the
pre-existing >500 kB chunk-size warning).

Direct check of the aggregate against a seeded DB (30 ok + 1 fail 40 days old, 3 ok 2 hours ago):

```
https://live.example/hook {'ok': 3, 'fail': 0, 'ok_total': 3,  'fail_total': 0, ... 'last_ok': True}
https://old.example/hook  {'ok': 0, 'fail': 0, 'ok_total': 30, 'fail_total': 1, ... 'last_ok': False, 'last_error': 'boom'}
```

— the idle endpoint reads `0` in the windowed column, keeps its total, and still reports as failing.
And the reaper: `runs_today incl current: 1 excl current: 0`, `reaped: 1`, `status now: failed`,
`reaped again: 0`.

## Notes / deferred

- **The off-by-one is arguably not one.** With the old `> DAILY_RUN_CAP` *after* the insert, the
  Nth run sees `count == N` and is capped at `N == 51`, so 50 runs actually executed — the effective
  ceiling was already 50, not 51. Implemented as written anyway (the ticket says to), because
  evaluating the cap on the count *before* the current row is the intent-revealing form and is
  robust to the run-status changes in this PR; net behaviour is unchanged at exactly
  `DAILY_RUN_CAP` executed runs.
- An interrupted run **still counts** toward the cap after being reaped (it ran, and spent tokens,
  before the daemon died). What it no longer does is sit there as `running`. Flagging in case
  "returns to the real number" in the acceptance criteria meant "stops counting entirely".
- `pending` is left as an all-time count, unchanged. A delivery left `ok IS NULL` by a killed daemon
  is the same class of orphan as the `running` rows and will show a permanent `running` badge —
  worth a follow-up alongside the retention ticket, but out of scope here.
- Retention/pruning of `dispatch_deliveries` and `agent_runs`, and the rolling-24h-vs-midnight
  semantics of `agent_runs_today`, are untouched per the ticket.
