### PR TITLE
slack: slack://channel/<id> as a first-class dispatch sink

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Backend — install + tests
         run: |
           pip install -e .
-          for t in test_labels test_normalize test_auth test_api_keys test_agents test_catalog_sync test_cli test_usage; do
+          for t in test_labels test_normalize test_auth test_api_keys test_agents test_catalog_sync test_cli test_usage test_slack; do
             echo "== $t =="
             python "tests/$t.py"
           done

--- a/README.md
+++ b/README.md
@@ -85,6 +85,11 @@ Other clients, stdio transport, and auth are covered in
   fires: it reads the correlated timeline and writes a **finding** back onto the entity's timeline
   (so the next agent to read that entity starts ahead). Read-only — it concludes, it doesn't act.
   → [NavFlow agents](https://www.navflow.ai/docs/navflow-agents)
+- **Slack**: subscribe a channel to any trigger with `slack://channel/C0123456789` and every firing
+  is posted there as Block Kit — retried, logged in the delivery ledger, and visible in the console
+  like any other subscriber. One bot token per instance (`NAVFLOW_SLACK_BOT_TOKEN`, or set it under
+  **Security**); the token is never returned by the API. This is the way forward for Slack: an
+  agent's older per-agent `slack_webhook` still works, but it is not retried or logged.
 - **Console**: Sources (health + setup), **Explore** (pick an entity, read its timeline, human or
   agent view), Views & Triggers, **Agents** (create NavFlow agents + connect external ones), and
   **Ask** (an in-console assistant over your data, summonable with ⌘K).

--- a/navflow/builtin_agents.py
+++ b/navflow/builtin_agents.py
@@ -28,6 +28,7 @@ import uuid
 import httpx
 
 from .config import FINDINGS_SOURCE, agent_url
+from .slack import deep_link as _slack_deep_link
 from .views import resolve_query_full, resolve_read
 
 MODEL = os.getenv("NAVFLOW_AGENT_MODEL", "claude-sonnet-4-6")
@@ -338,10 +339,14 @@ class AgentRunner:
         a link to 127.0.0.1 is worse than no link — so the message must stand alone. The text is the
         stored finding verbatim; a summary here would become a second, divergent record.
 
-        A deep link is appended only when the instance knows it is reachable (NAVFLOW_PUBLIC_URL).
+        A deep link is appended only when the instance knows it is reachable (NAVFLOW_PUBLIC_URL) —
+        the same rule the slack:// dispatch sink applies, hence the shared helper.
+
+        This is the ORIGINAL per-agent incoming-webhook path and stays as it is. The way forward is
+        a `slack://channel/<id>` subscription (`navflow/slack.py`), which is per-trigger, retried
+        and logged in the delivery ledger; existing agents are not migrated.
         """
-        base = os.getenv("NAVFLOW_PUBLIC_URL", "").strip().rstrip("/")
-        link = f"\n\n<{base}/explore?key={key}|Open {key} in NavFlow>" if base else ""
+        link = _slack_deep_link(key)
         text = f"*{agent_name}* · `{trigger_name}` fired for *{key}*\n\n{finding}{link}"
         try:
             async with httpx.AsyncClient(timeout=15) as cx:

--- a/navflow/config.py
+++ b/navflow/config.py
@@ -91,6 +91,44 @@ def agent_name_from_url(url: str) -> str | None:
     return url[len(AGENT_URL_PREFIX):] if url.startswith(AGENT_URL_PREFIX) else None
 
 
+# Slack is the third sink, wired the same way: a subscription whose URL names a channel instead of
+# an endpoint. The dispatcher posts it via chat.postMessage with the instance's bot token, so the
+# channel is addressable without the operator holding a per-channel incoming-webhook URL.
+SLACK_URL_PREFIX = "slack://channel/"
+
+# Channel IDs are C/G/D + uppercase alphanumerics. A human-typed `#general` is accepted too —
+# chat.postMessage still resolves names — but is normalized to the bare name.
+_SLACK_ID = re.compile(r"^[CGD][A-Z0-9]{6,}$")
+_SLACK_NAME = re.compile(r"^[a-z0-9][a-z0-9._-]{0,79}$")
+
+
+def slack_url(channel: str) -> str:
+    return SLACK_URL_PREFIX + channel.lstrip("#")
+
+
+def slack_channel_from_url(url: str) -> str | None:
+    """The channel a `slack://channel/<id>` subscription addresses, else None. Returns None for a
+    malformed channel as well: `fire` must fall through to the webhook path only for URLs that are
+    genuinely not Slack, so validation happens at subscribe time (see `validate_slack_channel`)."""
+    if not url.startswith(SLACK_URL_PREFIX):
+        return None
+    chan = url[len(SLACK_URL_PREFIX):].strip().lstrip("#")
+    return chan or None
+
+
+def validate_slack_channel(channel: str) -> str:
+    """Normalize and check a channel, raising ValueError with a usable message. Called on the
+    subscribe path — a subscription that can never deliver is worse than a 400."""
+    chan = (channel or "").strip().lstrip("#")
+    if not chan:
+        raise ValueError("slack:// subscription needs a channel, e.g. slack://channel/C0123456789")
+    if _SLACK_ID.match(chan) or _SLACK_NAME.match(chan):
+        return chan
+    raise ValueError(
+        f"{channel!r} is not a Slack channel — use the channel ID (C0123456789, from the channel's "
+        "'Copy link') or its lowercase name")
+
+
 @dataclass
 class Catalog:
     sources: dict   # name -> SourceCfg

--- a/navflow/daemon.py
+++ b/navflow/daemon.py
@@ -23,9 +23,10 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse, PlainTextResponse, StreamingResponse
 from pydantic import BaseModel
 
-from .config import (CatalogError, agent_url, export_db_to_yaml, import_yaml_to_db,
-                     validate_agent_dict, validate_source_dict, validate_trigger_dict,
-                     validate_view_dict, _source_from_dict)
+from .config import (SLACK_URL_PREFIX, CatalogError, agent_url, export_db_to_yaml,
+                     import_yaml_to_db, slack_channel_from_url, slack_url,
+                     validate_agent_dict, validate_slack_channel, validate_source_dict,
+                     validate_trigger_dict, validate_view_dict, _source_from_dict)
 from .connectors import (SPECS, normalize_config, redact_config, restore_secrets,
                          source_type_for)
 from .dispatch import Dispatcher
@@ -33,6 +34,7 @@ from .envelope import now_utc
 from .builtin_agents import (PRESETS as AGENT_PRESETS, AgentRunner,
                              resolve_key as resolve_anthropic_key)
 from .runtime import Runtime
+from .slack import SETTING_KEY as SLACK_TOKEN_SETTING, resolve_token as resolve_slack_token
 from .store import Store
 from .views import resolve_query_full, resolve_read
 
@@ -54,6 +56,8 @@ LOGIN_URL = os.getenv("NAVFLOW_LOGIN_URL", "").strip()
 # The Anthropic key for the in-app Ask agent (and NavFlow agents) is resolved at request time via
 # resolve_anthropic_key(store): env ANTHROPIC_API_KEY, else the console-stored key.
 # Never returned by any API — capabilities exposes only a boolean.
+# The Slack bot token behind the slack:// dispatch sink follows exactly the same rule via
+# resolve_slack_token(store): env NAVFLOW_SLACK_BOT_TOKEN, else the console-stored value.
 
 
 def _is_ingest(path: str) -> bool:
@@ -189,6 +193,10 @@ class ImportReq(BaseModel):
 
 class AnthropicKeyIn(BaseModel):
     key: str    # blank-to-keep is not offered here: the only edits are "set a new one" or DELETE
+
+
+class SlackTokenIn(BaseModel):
+    token: str  # same contract as AnthropicKeyIn: set a new one, or DELETE to clear
 
 
 def make_app() -> FastAPI:
@@ -363,11 +371,23 @@ def make_app() -> FastAPI:
     async def subscribe(req: SubReq, request: Request):
         if req.trigger not in {t.name for t in runtime.catalog.triggers}:
             _err(KeyError(f"unknown trigger {req.trigger!r}"), 404)
+        url = req.url.strip()
+        if url.startswith(SLACK_URL_PREFIX):
+            # A Slack subscription is checked at creation, not at the first firing: an unroutable
+            # channel or a missing token would otherwise surface hours later as a failed delivery
+            # nobody is watching.
+            try:
+                url = slack_url(validate_slack_channel(url[len(SLACK_URL_PREFIX):]))
+            except ValueError as e:
+                _err(e)
+            if not resolve_slack_token(store)[0]:
+                _err(ValueError("no Slack bot token configured — set NAVFLOW_SLACK_BOT_TOKEN or "
+                                "add one under Security before subscribing a channel"))
         sid = "sub_" + uuid.uuid4().hex[:8]
         # record the creating credential: revoking a key removes its subscriptions (a revoked
         # agent must stop receiving trigger dispatches)
         ident = getattr(request.state, "credential", None)
-        store.add_subscription(sid, req.trigger, req.url, created_by=ident["id"] if ident else None)
+        store.add_subscription(sid, req.trigger, url, created_by=ident["id"] if ident else None)
         return {"subscription_id": sid}
 
     @app.post("/unsubscribe")
@@ -694,6 +714,9 @@ def make_app() -> FastAPI:
             # or the console-stored key) — so once a key is set anywhere, the Ask chat stops
             # prompting for a browser-pasted one.
             "agent_key_configured": bool(resolve_anthropic_key(store)[0]),
+            # gates the "subscribe a Slack channel" affordance on a trigger — offering it with no
+            # bot token configured only leads to a 400.
+            "slack_configured": bool(resolve_slack_token(store)[0]),
         }
 
     @app.post("/api/labels/preview")
@@ -1209,6 +1232,39 @@ def make_app() -> FastAPI:
         key, origin = resolve_anthropic_key(store)
         return {"ok": True, "configured": bool(key), "source": origin}
 
+    # ── the Slack bot token: same contract as the Anthropic key ──────────────
+    # One token per instance, behind every slack:// subscription. It is a credential, so it is
+    # write-only over the API exactly like the model key: the console can learn THAT one resolves
+    # and where from, never what it is.
+    @app.get("/api/settings/slack-bot-token")
+    async def get_slack_token():
+        token, origin = resolve_slack_token(store)
+        return {"configured": bool(token), "source": origin,
+                "stored": bool(store.get_setting(SLACK_TOKEN_SETTING)),
+                "env_overrides": origin.startswith("env:")}
+
+    @app.put("/api/settings/slack-bot-token")
+    async def set_slack_token(body: SlackTokenIn):
+        token = body.token.strip()
+        if not token:
+            _err(ValueError("token is required (use DELETE to remove the stored token)"))
+        if not token.startswith("xox"):
+            # Caught here rather than on the first failed delivery: a pasted webhook URL or signing
+            # secret would otherwise sit in the settings table looking configured.
+            _err(ValueError("that does not look like a Slack bot token — it should start with "
+                            "'xoxb-' (OAuth & Permissions → Bot User OAuth Token)"))
+        store.set_setting(SLACK_TOKEN_SETTING, token)
+        _, origin = resolve_slack_token(store)
+        return {"ok": True, "source": origin,
+                **({"note": "an environment token takes precedence and is still in use"}
+                   if origin.startswith("env:") else {})}
+
+    @app.delete("/api/settings/slack-bot-token")
+    async def clear_slack_token():
+        store.set_setting(SLACK_TOKEN_SETTING, None)
+        token, origin = resolve_slack_token(store)
+        return {"ok": True, "configured": bool(token), "source": origin}
+
     # ── management API: activity (what agents saw / what woke them) ──────────
     @app.get("/api/activity/queries")
     async def activity_queries(limit: int = 100):
@@ -1241,13 +1297,18 @@ def make_app() -> FastAPI:
 
     def _agent_identity(url: str) -> tuple[str, str]:
         """(name, masked display URL) for a subscriber endpoint. A NavFlow agent's URL carries its
-        real name and no secret, so it's shown verbatim. An external hook URL is the identity but
-        carries a secret in the path, so it's anonymized (deterministic name) and the last path
-        segment masked."""
+        real name and no secret, so it's shown verbatim; a Slack channel likewise. An external hook
+        URL is the identity but carries a secret in the path, so it's anonymized (deterministic
+        name) and the last path segment masked."""
         from .config import agent_name_from_url
         internal = agent_name_from_url(url.rstrip("/"))
         if internal is not None:
             return internal, "in-process (NavFlow agent)"
+        channel = slack_channel_from_url(url.rstrip("/"))
+        if channel is not None:
+            # The channel IS the identity and holds no secret (the token does), so it's shown as
+            # written — a raw slack://channel/C0123456 URL in the roster reads like a bug.
+            return f"#{channel}", "Slack channel"
         norm = url.rstrip("/")
         h = int(hashlib.sha256(norm.encode()).hexdigest(), 16)
         name = f"{_AGENT_ADJ[h % len(_AGENT_ADJ)]}-{_AGENT_NOUN[(h // 16) % len(_AGENT_NOUN)]}"
@@ -1275,7 +1336,9 @@ def make_app() -> FastAPI:
             if a is None:
                 from .config import agent_name_from_url
                 name, masked = _agent_identity(norm)
-                kind = "navflow" if agent_name_from_url(norm) is not None else "connected"
+                kind = ("navflow" if agent_name_from_url(norm) is not None
+                        else "slack" if slack_channel_from_url(norm) is not None
+                        else "connected")
                 st = stats.get(sub["url"], stats.get(norm, {}))
                 a = agents[norm] = {
                     "name": name, "endpoint": masked, "kind": kind,

--- a/navflow/dispatch.py
+++ b/navflow/dispatch.py
@@ -3,11 +3,12 @@
 The dispatch body carries the rendered view payload, so the agent boots already holding the
 correlated timeline (zero reads to begin). At-least-once; subscribers dedupe on `dispatch_id`.
 
-Two kinds of subscriber, ONE mechanism: an external agent's webhook (POST) and a NavFlow agent
-(run in-process). Both are ordinary subscription rows — a NavFlow agent's URL uses the
-navflow://agent/ scheme — so both are logged as deliveries and appear identically in the roster,
-a trigger's woken-agents list, and recent firings. The in-process runs are dispatched without
-awaiting: an investigation takes minutes and must not delay a webhook delivery on the same trigger.
+Three kinds of subscriber, ONE mechanism: an external agent's webhook (POST), a NavFlow agent
+(run in-process), and a Slack channel. All three are ordinary subscription rows — a NavFlow
+agent's URL uses the navflow://agent/ scheme, a channel's uses slack://channel/ — so all three are
+logged as deliveries and appear identically in the roster, a trigger's woken-agents list, and
+recent firings. The in-process runs are dispatched without awaiting: an investigation takes
+minutes and must not delay a webhook delivery on the same trigger.
 """
 from __future__ import annotations
 
@@ -16,7 +17,8 @@ import uuid
 
 import httpx
 
-from .config import agent_name_from_url
+from . import slack
+from .config import agent_name_from_url, slack_channel_from_url
 from .envelope import now_utc
 
 
@@ -49,7 +51,12 @@ class Dispatcher:
                 if self.agents is not None:
                     self.agents.deliver(agent_name, sid, trigger.name, key, payload, dispatch_id)
                 continue
-            ok, error = await self._post(url, body)
+            channel = slack_channel_from_url(url)
+            if channel is not None:
+                ok, error = await self._slack_post(channel, trigger.name, key, payload,
+                                                   body["fired_at"])
+            else:
+                ok, error = await self._post(url, body)
             self.store.log_delivery(dispatch_id, sid, url, ok, error)   # per-agent delivery history
             if ok:
                 delivered += 1
@@ -76,6 +83,55 @@ class Dispatcher:
                 except Exception as e:            # transport failure — unreachable / timeout / DNS
                     error = (type(e).__name__ + (f": {e}" if str(e).strip() else ""))[:200]
                 if attempt < attempts - 1:        # no point sleeping after the final attempt
+                    await asyncio.sleep(delay)
+                    delay = min(delay * 2, 30)
+        return False, error
+
+    async def _slack_post(self, channel: str, trigger: str, key: str, payload: str,
+                          fired_at: str | None = None,
+                          attempts: int = 5) -> tuple[bool, str | None]:
+        """Deliver one firing to a Slack channel. Same contract as `_post` — (ok, error), same
+        five attempts and the same capped exponential backoff — so a Slack subscription's delivery
+        row reads identically to a webhook's.
+
+        The difference is where the verdict comes from: `chat.postMessage` answers HTTP 200 with
+        `{"ok": false, "error": ...}`, so the retry decision is made by `slack.classify` on the
+        body rather than by the status code. A revoked token or a channel the bot isn't in fails on
+        the FIRST attempt with that reason in the ledger, instead of five timeouts and no reason.
+        """
+        token, _origin = slack.resolve_token(self.store)
+        if not token:
+            # Not retryable and not transient: nothing about waiting 30s makes a token appear.
+            return False, "slack: no bot token configured (set NAVFLOW_SLACK_BOT_TOKEN or add one under Security)"
+        msg = {"channel": channel, **slack.build_message(trigger, key, payload, fired_at)}
+        headers = {"authorization": f"Bearer {token}", "content-type": "application/json"}
+        delay = 1.0
+        error = None
+        async with httpx.AsyncClient(timeout=10) as cx:
+            for attempt in range(attempts):
+                try:
+                    r = await cx.post(f"{slack.API_BASE}/chat.postMessage",
+                                      json=msg, headers=headers)
+                    try:
+                        data = r.json()
+                    except Exception:
+                        data = None
+                    ok, error, retry = slack.classify(r.status_code, data)
+                    if ok:
+                        return True, None
+                    if not retry:
+                        return False, error
+                    # Slack tells us how long to wait when it rate-limits; obeying it is the
+                    # difference between backing off once and being throttled for the whole window.
+                    if after := r.headers.get("retry-after"):
+                        try:
+                            delay = max(delay, min(float(after), 60.0))
+                        except ValueError:
+                            pass
+                except Exception as e:            # transport failure — unreachable / timeout / DNS
+                    error = ("slack: " + type(e).__name__
+                             + (f": {e}" if str(e).strip() else ""))[:200]
+                if attempt < attempts - 1:
                     await asyncio.sleep(delay)
                     delay = min(delay * 2, 30)
         return False, error

--- a/navflow/slack.py
+++ b/navflow/slack.py
@@ -1,0 +1,124 @@
+"""Slack as a dispatch sink — resolve the bot token, format the message, post it.
+
+This is the *generic* half of NavFlow's Slack support: a bot token that an operator configures
+(env or console) and one `chat.postMessage` call. Nothing here knows about OAuth or hosted
+installs; a self-hosted user gets the full feature by pasting a token.
+
+Deliberately plain `httpx`, no `slack_sdk`: this is one HTTP call, and `Dispatcher` already owns
+its client, its timeout and its retry policy. Adding an SDK for it would buy a dependency and a
+second, divergent retry loop.
+
+The one thing that needs care is Slack's error taxonomy. `chat.postMessage` answers **HTTP 200
+with `{"ok": false, "error": "..."}`** for most failures, so the status code alone cannot decide
+whether to retry — a revoked token would otherwise burn all five attempts and land in the ledger
+as a timeout rather than as "invalid_auth".
+"""
+from __future__ import annotations
+
+import os
+
+API_BASE = os.getenv("NAVFLOW_SLACK_API_BASE", "https://slack.com/api").rstrip("/")
+SETTING_KEY = "slack_bot_token"
+ENV_VAR = "NAVFLOW_SLACK_BOT_TOKEN"
+
+# Failures that will still be failures on the fifth attempt. Retrying these wastes ~30s of backoff
+# and, worse, buries the real reason: the ledger must say "channel_not_found", not "timeout".
+DEFINITIVE_ERRORS = {
+    "invalid_auth", "not_authed", "account_inactive", "token_revoked", "token_expired",
+    "no_permission", "missing_scope", "ekm_access_denied", "org_login_required",
+    "channel_not_found", "not_in_channel", "is_archived", "restricted_action",
+    "restricted_action_read_only_channel", "restricted_action_thread_only_channel",
+    "msg_too_long", "no_text", "invalid_blocks", "invalid_blocks_format", "invalid_arguments",
+    "team_access_not_granted", "as_user_not_supported",
+}
+
+# Section text caps at 3000 chars; leave room for the code fence we wrap the timeline in.
+_MAX_SECTION = 2800
+
+
+def resolve_token(store) -> tuple[str, str]:
+    """(token, where-it-came-from). Mirrors `resolve_key` for the Anthropic key: the environment
+    wins over the console-stored value, so an operator's deployment config is never silently
+    overridden by something typed into a UI months earlier."""
+    val = os.getenv(ENV_VAR, "").strip()
+    if val:
+        return val, f"env:{ENV_VAR}"
+    stored = ((store.get_setting(SETTING_KEY) or "") if store is not None else "").strip()
+    return (stored, "console") if stored else ("", "")
+
+
+def deep_link(key: str) -> str:
+    """The `<url|label>` suffix appended to a Slack message, or "" when this instance has no
+    reachable address. A link to 127.0.0.1 is worse than no link, so it is only emitted when the
+    operator has told us the instance is reachable (NAVFLOW_PUBLIC_URL)."""
+    base = os.getenv("NAVFLOW_PUBLIC_URL", "").strip().rstrip("/")
+    return f"\n\n<{base}/explore?key={key}|Open {key} in NavFlow>" if base else ""
+
+
+def _truncate(text: str, limit: int = _MAX_SECTION) -> str:
+    return text if len(text) <= limit else text[:limit - 1].rstrip() + "…"
+
+
+def build_message(trigger: str, key: str, payload: str, fired_at: str | None = None) -> dict:
+    """Block Kit body for a fired trigger. `text` is always set as well — Slack uses it for the
+    notification and for clients that can't render blocks, so a blocks-only message shows up as an
+    empty push notification."""
+    headline = f"*{trigger}* fired for *{key}*"
+    link = deep_link(key)
+    blocks: list[dict] = [{"type": "section", "text": {"type": "mrkdwn", "text": headline}}]
+    body = (payload or "").strip()
+    if body:
+        blocks.append({"type": "section", "text": {
+            "type": "mrkdwn", "text": "```" + _truncate(body) + "```"}})
+    context = f"NavFlow · {fired_at}" if fired_at else "NavFlow"
+    if link:
+        context += " ·" + link.strip()
+    blocks.append({"type": "context", "elements": [{"type": "mrkdwn", "text": context}]})
+    return {"text": f"{trigger} fired for {key}", "blocks": blocks}
+
+
+def classify(status: int, data: dict | None) -> tuple[bool, str | None, bool]:
+    """(ok, error, retry) for one `chat.postMessage` response.
+
+    Slack's answers come in three shapes and all three have to be told apart:
+      · HTTP 200 + `{"ok": true}`                → delivered
+      · HTTP 200 + `{"ok": false, "error": ...}` → the real failure mode. Definitive per
+        DEFINITIVE_ERRORS; anything else there (internal_error, service_unavailable) is a
+        transient Slack fault and retries, as does `ratelimited`.
+      · HTTP 429 / 5xx                           → rate limit or outage, retry. Other 4xx are
+        definitive, the same rule `Dispatcher._post` applies to a webhook.
+    """
+    if status == 429:
+        return False, "slack: ratelimited", True
+    if status >= 500:
+        return False, f"slack: HTTP {status}", True
+    if not isinstance(data, dict):
+        # A 2xx that isn't JSON means we are not talking to Slack (a proxy, a captive portal).
+        return False, f"slack: HTTP {status} (non-JSON response)", False
+    if data.get("ok"):
+        return True, None, False
+    err = str(data.get("error") or "unknown_error")
+    if err == "ratelimited":
+        return False, "slack: ratelimited", True
+    if err in DEFINITIVE_ERRORS or 400 <= status < 500:
+        return False, f"slack: {err}{_error_detail(err, data)}", False
+    return False, f"slack: {err}", True    # transient Slack-side fault — worth another attempt
+
+
+_HINTS = {
+    "invalid_auth": "the bot token is invalid or revoked",
+    "token_revoked": "the bot token has been revoked",
+    "account_inactive": "the bot token belongs to a deactivated workspace or app",
+    "channel_not_found": "no such channel, or the bot cannot see it",
+    "not_in_channel": "invite the bot to the channel first (/invite @NavFlow)",
+    "is_archived": "the channel is archived",
+    "missing_scope": "the bot token is missing the chat:write scope",
+    "msg_too_long": "the message exceeded Slack's size limit",
+}
+
+
+def _error_detail(err: str, data: dict) -> str:
+    hint = _HINTS.get(err)
+    if not hint and err == "missing_scope" and data.get("needed"):
+        hint = f"needs scope {data['needed']}"
+    return f" ({hint})" if hint else ""

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -1,0 +1,266 @@
+"""Slack as a first-class dispatch sink — `slack://channel/<id>` alongside webhooks and agents.
+
+End-to-end against a stub Slack API (NAVFLOW_SLACK_API_BASE): configure a bot token, subscribe a
+channel to a trigger, ingest until the trigger fires, and assert the channel behaves like any other
+subscriber — it appears in the roster, its delivery lands in the ledger and is counted by
+`GET /api/agents`, and the message itself is Block Kit with a text fallback and a deep link.
+
+The failure modes are the point of the ticket, so they are asserted directly: `invalid_auth` and
+`channel_not_found` come back as HTTP 200 with `{"ok": false}`, and must fail on the FIRST attempt
+with that reason in the ledger — not five timeouts. A transient Slack fault must still retry.
+
+The token is a credential: it is write-only over the API, and the environment beats the stored one.
+"""
+import asyncio, json, os, signal, subprocess, sys, threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import httpx
+
+P = F = 0
+def ck(l, c, d=""):
+    global P, F; P += 1 if c else 0; F += 0 if c else 1
+    print(("  ok   " if c else "  FAIL ") + l + ("" if c else f"  {d}"))
+
+SEED = "/tmp/slack_catalog.yaml"
+with open(SEED, "w") as fh:
+    fh.write(
+        "sources:\n  - name: evt\n    connector: webhook\n    poll: 5s\n"
+        "    config:\n      labels:\n        - name: service\n          field: service\n"
+        "          primary: true\n"
+        "views:\n  - name: svc\n    key_field: service\n    sources: [evt]\n"
+        # short cooldown: the same entity has to be able to fire again for each failure mode below
+        "triggers:\n  - name: incident\n    view: svc\n    cooldown: 1s\n"
+        "    condition:\n      aggregate: count\n      predicate: '>= 2'\n      window: 1m\n")
+
+DB, PORT, STUB_PORT = "/tmp/slack.duckdb", "8810", "8811"
+CHANNEL = "C0123456789"
+TOKEN = "xoxb-stored-test-token"
+ENV_TOKEN = "xoxb-env-test-token"
+PUBLIC_URL = "https://navflow.example.com"
+
+# ── stub Slack: chat.postMessage, with the reply switchable per phase ────────
+# Slack answers HTTP 200 with {"ok": false, "error": ...} for nearly everything that goes wrong,
+# which is exactly why the sink can't read the status code alone.
+CALLS: list = []
+MODE = "ok"
+
+
+class Stub(BaseHTTPRequestHandler):
+    def do_POST(self):
+        body = json.loads(self.rfile.read(int(self.headers["content-length"])))
+        CALLS.append({"path": self.path, "body": body,
+                      "auth": self.headers.get("authorization", "")})
+        out = ({"ok": True, "channel": body.get("channel"), "ts": "1700000000.000100"}
+               if MODE == "ok" else {"ok": False, "error": MODE})
+        raw = json.dumps(out).encode()
+        self.send_response(200)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
+
+    def log_message(self, *a):
+        pass
+
+
+async def _wait(url, tries=80):
+    for _ in range(tries):
+        try:
+            async with httpx.AsyncClient() as cx:
+                if (await cx.get(url, timeout=1)).status_code == 200:
+                    return True
+        except Exception:
+            pass
+        await asyncio.sleep(0.25)
+    return False
+
+
+async def _until(fn, tries=60):
+    for _ in range(tries):
+        if await fn():
+            return True
+        await asyncio.sleep(0.5)
+    return False
+
+
+def _spawn(env):
+    return subprocess.Popen([sys.executable, "-c", "from navflow.cli import run_daemon; run_daemon()"],
+                            env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+
+def _stop(proc):
+    proc.send_signal(signal.SIGTERM)
+    try: proc.wait(timeout=5)
+    except Exception: proc.kill()
+
+
+B = f"http://127.0.0.1:{PORT}"
+
+
+async def _slack_row(cx):
+    for a in (await cx.get(f"{B}/api/agents")).json()["agents"]:
+        if a["kind"] == "slack":
+            return a
+    return None
+
+
+async def _fire(cx, n=3, tag=""):
+    """Push enough events to satisfy `count >= 2 over 1m` for one entity."""
+    for i in range(n):
+        await cx.post(f"{B}/ingest/evt", json={"service": "checkout", "msg": f"500 {tag}#{i}"})
+
+
+async def main():
+    global MODE
+    for p in (DB, DB + ".wal"):
+        if os.path.exists(p):
+            os.remove(p)
+
+    stub = HTTPServer(("127.0.0.1", int(STUB_PORT)), Stub)
+    threading.Thread(target=stub.serve_forever, daemon=True).start()
+
+    base_env = {**os.environ, "NAVFLOW_DB": DB, "NAVFLOW_CATALOG": SEED, "NAVFLOW_PORT": PORT,
+                "NAVFLOW_OTLP_GRPC_PORT": "off",
+                "NAVFLOW_SLACK_API_BASE": f"http://127.0.0.1:{STUB_PORT}",
+                "NAVFLOW_PUBLIC_URL": PUBLIC_URL,
+                "NAVFLOW_TRIGGER_DEBOUNCE_SECONDS": "0"}
+    base_env.pop("NAVFLOW_SLACK_BOT_TOKEN", None)     # phase 1 stores one through the API instead
+    proc = _spawn(base_env)
+    try:
+        if not await _wait(f"{B}/health"):
+            ck("daemon up", False); return
+        async with httpx.AsyncClient(timeout=20) as cx:
+            # ── the bot token: write-only, and required before a channel can subscribe ──
+            st = (await cx.get(f"{B}/api/settings/slack-bot-token")).json()
+            ck("no token configured to start with", st["configured"] is False and st["stored"] is False, str(st))
+
+            r = await cx.post(f"{B}/subscribe", json={"trigger": "incident",
+                                                      "url": f"slack://channel/{CHANNEL}"})
+            ck("subscribing a channel with no token is rejected (400)", r.status_code == 400, r.text)
+            ck("...and says why", "token" in r.text.lower(), r.text)
+
+            r = await cx.put(f"{B}/api/settings/slack-bot-token", json={"token": "https://hooks.slack.com/x"})
+            ck("a pasted webhook URL is not accepted as a bot token", r.status_code == 400, r.text)
+
+            r = await cx.put(f"{B}/api/settings/slack-bot-token", json={"token": TOKEN})
+            ck("PUT token -> 200", r.status_code == 200, r.text)
+            ck("PUT never echoes the token", TOKEN not in r.text, r.text)
+            st = (await cx.get(f"{B}/api/settings/slack-bot-token")).json()
+            ck("token reported configured from the console", st["configured"] and st["source"] == "console", str(st))
+            ck("token value is never returned", TOKEN not in json.dumps(st), str(st))
+            caps = (await cx.get(f"{B}/api/capabilities")).json()
+            ck("capabilities advertises Slack as configured", caps.get("slack_configured") is True, str(caps))
+
+            # ── subscribing a channel ────────────────────────────────────────
+            r = await cx.post(f"{B}/subscribe", json={"trigger": "incident", "url": "slack://channel/not a channel!"})
+            ck("a malformed channel is rejected (400)", r.status_code == 400, r.text)
+            r = await cx.post(f"{B}/subscribe", json={"trigger": "nope", "url": f"slack://channel/{CHANNEL}"})
+            ck("an unknown trigger is still a 404", r.status_code == 404, str(r.status_code))
+
+            r = await cx.post(f"{B}/subscribe", json={"trigger": "incident",
+                                                      "url": f"slack://channel/{CHANNEL}"})
+            ck("subscribe a channel -> 200", r.status_code == 200, r.text)
+
+            row = await _slack_row(cx)
+            ck("the channel is in the roster", row is not None, str(row))
+            ck("roster tags it kind=slack", row and row["kind"] == "slack", str(row))
+            ck("roster names it by channel, not by raw URL",
+               row and row["name"] == f"#{CHANNEL}" and "slack://" not in row["endpoint"], str(row))
+            ck("roster shows it woken by the trigger", row and "incident" in row["triggers"], str(row))
+
+            # ── it delivers ──────────────────────────────────────────────────
+            CALLS.clear()
+            await _fire(cx, tag="ok ")
+            ck("a firing posts to Slack", await _until(lambda: asyncio.sleep(0, result=bool(CALLS))),
+               "no chat.postMessage received")
+            call = CALLS[0] if CALLS else {"body": {}, "auth": "", "path": ""}
+            ck("posted to chat.postMessage", call["path"].endswith("/chat.postMessage"), call["path"])
+            ck("authenticated with the bot token", call["auth"] == f"Bearer {TOKEN}", call["auth"])
+            ck("addressed the subscribed channel", call["body"].get("channel") == CHANNEL, str(call["body"])[:200])
+            blocks = json.dumps(call["body"].get("blocks") or [])
+            ck("message is Block Kit", bool(call["body"].get("blocks")), str(call["body"])[:200])
+            ck("message has a plain-text fallback for notifications",
+               "incident" in str(call["body"].get("text", "")), str(call["body"].get("text")))
+            ck("blocks name the trigger and the entity",
+               "incident" in blocks and "checkout" in blocks, blocks[:300])
+            ck("blocks carry a deep link when NAVFLOW_PUBLIC_URL is set",
+               f"{PUBLIC_URL}/explore?key=checkout" in blocks, blocks[:400])
+
+            async def _counted():
+                a = await _slack_row(cx)
+                return bool(a) and a.get("delivered_ok_24h", 0) >= 1
+            ck("GET /api/agents counts the delivery", await _until(_counted), str(await _slack_row(cx)))
+
+            disp = (await cx.get(f"{B}/api/activity/dispatches")).json()[0]
+            detail = (await cx.get(f"{B}/api/activity/dispatches/{disp['dispatch_id']}")).json()
+            dv = next((d for d in detail.get("deliveries", []) if d["agent"] == f"#{CHANNEL}"), None)
+            ck("the firing's ledger lists the channel as delivered", dv is not None and dv["ok"], str(detail)[:300])
+
+            # ── a revoked token is DEFINITIVE: one attempt, readable reason ──
+            for mode, needle in (("invalid_auth", "invalid_auth"), ("channel_not_found", "channel_not_found")):
+                before = (await _slack_row(cx)).get("delivered_fail_total", 0)
+                MODE = mode
+                CALLS.clear()
+                await asyncio.sleep(1.2)          # clear the trigger's per-entity cooldown
+                await _fire(cx, tag=mode + " ")
+
+                async def _failed():
+                    a = await _slack_row(cx)
+                    return bool(a) and a.get("delivered_fail_total", 0) > before
+                ck(f"{mode}: the delivery is recorded as failed", await _until(_failed), str(await _slack_row(cx)))
+                a = await _slack_row(cx)
+                ck(f"{mode}: the ledger carries the reason", needle in str(a.get("last_error") or ""),
+                   str(a.get("last_error")))
+                ck(f"{mode}: the endpoint reads as failing", a.get("unhealthy") is True, str(a))
+                # the whole point: 5 attempts of backoff would take ~15s and bury the reason
+                ck(f"{mode}: tried exactly once, not five times", len(CALLS) == 1, f"{len(CALLS)} attempts")
+
+            # ── a transient Slack fault DOES retry ───────────────────────────
+            MODE = "internal_error"
+            CALLS.clear()
+            await asyncio.sleep(1.2)
+            await _fire(cx, tag="transient ")
+            ck("a transient Slack error is retried", await _until(lambda: asyncio.sleep(0, result=len(CALLS) >= 2), tries=20),
+               f"{len(CALLS)} attempts")
+            MODE = "ok"
+    finally:
+        _stop(proc)
+
+    # ── the environment beats the stored token ──────────────────────────────
+    # An operator's deployment config must never be silently overridden by something typed into the
+    # console months earlier — the same rule the Anthropic key follows.
+    env2 = {**base_env, "NAVFLOW_SLACK_BOT_TOKEN": ENV_TOKEN}
+    proc = _spawn(env2)
+    try:
+        if not await _wait(f"{B}/health"):
+            ck("daemon back up", False)
+        else:
+            async with httpx.AsyncClient(timeout=20) as cx:
+                st = (await cx.get(f"{B}/api/settings/slack-bot-token")).json()
+                ck("env token wins over the stored one",
+                   st["source"] == "env:NAVFLOW_SLACK_BOT_TOKEN" and st["env_overrides"] is True, str(st))
+                ck("the console is told a stored token exists but is unused", st["stored"] is True, str(st))
+                ck("neither token is ever returned",
+                   TOKEN not in json.dumps(st) and ENV_TOKEN not in json.dumps(st), str(st))
+
+                CALLS.clear()
+                await _fire(cx, tag="env ")
+                ck("deliveries use the env token",
+                   await _until(lambda: asyncio.sleep(0, result=bool(CALLS)), tries=30)
+                   and CALLS[0]["auth"] == f"Bearer {ENV_TOKEN}",
+                   str(CALLS[:1])[:200])
+
+                r = await cx.delete(f"{B}/api/settings/slack-bot-token")
+                ck("DELETE clears the stored token", r.status_code == 200, r.text)
+                st = (await cx.get(f"{B}/api/settings/slack-bot-token")).json()
+                ck("still configured afterwards — the env token remains",
+                   st["configured"] is True and st["stored"] is False, str(st))
+    finally:
+        _stop(proc)
+        stub.shutdown()
+
+    print(f"\n{P} passed, {F} failed")
+    raise SystemExit(1 if F else 0)
+
+
+asyncio.run(main())

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -77,7 +77,8 @@ export const api = {
   },
   connectors: () => request<Record<string, ConnectorSpec>>("/api/connectors"),
   capabilities: () =>
-    request<{ version?: string | null; discover_docker: boolean; agent_key_configured?: boolean }>("/api/capabilities"),
+    request<{ version?: string | null; discover_docker: boolean; agent_key_configured?: boolean;
+              slack_configured?: boolean }>("/api/capabilities"),
   keys: () => request<{ keys: ApiKey[]; enforced: boolean; scopes: string[] }>("/api/keys"),
   createKey: (name: string, scopes: string[]) =>
     request<{ id: string; name: string; scopes: string[]; secret: string }>(
@@ -151,6 +152,18 @@ export const api = {
       { method: "PUT", body: JSON.stringify({ key }) }),
   clearAnthropicKey: () =>
     request<{ ok: boolean; configured: boolean }>("/api/settings/anthropic-key",
+      { method: "DELETE" }),
+
+  // The Slack bot token behind slack:// subscriptions. Same contract as the Anthropic key: the
+  // value never leaves the server, only whether one resolves and where from.
+  slackTokenStatus: () =>
+    request<{ configured: boolean; source: string; stored: boolean; env_overrides: boolean }>(
+      "/api/settings/slack-bot-token"),
+  setSlackToken: (token: string) =>
+    request<{ ok: boolean; source: string; note?: string }>("/api/settings/slack-bot-token",
+      { method: "PUT", body: JSON.stringify({ token }) }),
+  clearSlackToken: () =>
+    request<{ ok: boolean; configured: boolean }>("/api/settings/slack-bot-token",
       { method: "DELETE" }),
 
   agents: () => request<{ agents: AgentInfo[] }>("/api/agents"),

--- a/ui/src/pages/Activity.tsx
+++ b/ui/src/pages/Activity.tsx
@@ -362,11 +362,17 @@ export function AgentsRoster({ only }: { only?: "connected" | "navflow" }) {
 
   if (error) return <div className="alert error">{error}</div>;
   if (!data) return <div className="dim">loading…</div>;
-  const agents = only ? data.agents.filter((a) => a.kind === only) : data.agents;
+  // "connected" means everything that isn't a NavFlow agent — an external webhook or a Slack
+  // channel. Both are things the operator wired to a trigger from outside; splitting them into a
+  // third table would say less than the badge on the row does.
+  const agents = only
+    ? data.agents.filter((a) => (only === "connected" ? a.kind !== "navflow" : a.kind === only))
+    : data.agents;
   if (!agents.length) {
     return (
       <div className="empty">
-        no external agents connected — connect one from a <Link to="/triggers">trigger's</Link> page
+        no external agents connected — connect one, or a Slack channel, from a{" "}
+        <Link to="/triggers">trigger's</Link> page
       </div>
     );
   }
@@ -381,6 +387,7 @@ export function AgentsRoster({ only }: { only?: "connected" | "navflow" }) {
               <tr key={a.name} className="clickable" onClick={() => setOpen(open === a.name ? undefined : a.name)}>
                 <td>
                   <strong>{a.name}</strong>
+                  {a.kind === "slack" && <span className="badge" style={{ marginLeft: 8 }} title="a Slack channel subscribed to this trigger">Slack</span>}
                   {a.unhealthy && <span className="badge error" style={{ marginLeft: 8 }} title={a.last_error ?? "last delivery failed"}>failing</span>}
                 </td>
                 <td className="mono">{a.endpoint}</td>

--- a/ui/src/pages/Security.tsx
+++ b/ui/src/pages/Security.tsx
@@ -6,10 +6,11 @@ import { Close } from "../components/icons";
 import { TimeAgo } from "../components/bits";
 import type { ApiKey } from "../types";
 
-// Three distinct credential concepts, one box each:
+// Four distinct credential concepts, one box each:
 //   · Access     — is this instance open, or does it require a login? (navflow up --auth)
 //   · API keys   — scoped, revocable, show-once credentials the operator mints for machines
 //   · Anthropic  — the model key NavFlow agents (and Ask) run on
+//   · Slack      — the bot token behind slack:// trigger subscriptions
 // The per-source ingest URL is an address, not a secret — it lives on the source page, not here.
 export default function Security() {
   return (
@@ -19,6 +20,7 @@ export default function Security() {
       <AccessPanel />
       <ApiKeysPanel />
       <AnthropicKeyPanel />
+      <SlackTokenPanel />
     </>
   );
 }
@@ -116,6 +118,80 @@ function AnthropicKeyPanel() {
               <button className="danger" disabled={busy} onClick={async () => {
                 setBusy(true);
                 try { await api.clearAnthropicKey(); await load(); }
+                catch (e) { setErr(String((e as Error).message ?? e)); }
+                setBusy(false);
+              }}>Clear stored</button>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+// One bot token per instance, behind every `slack://channel/<id>` trigger subscription. Same
+// contract as the Anthropic key — env wins, the value is never returned — so this panel is a
+// deliberate near-copy rather than a variation the reader has to diff in their head.
+function SlackTokenPanel() {
+  const [st, setSt] = useState<{ configured: boolean; source: string; stored: boolean; env_overrides: boolean }>();
+  const [token, setToken] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string>();
+  const [msg, setMsg] = useState<string>();
+
+  const load = () =>
+    api.slackTokenStatus().then(setSt).catch((e) => setErr(String((e as Error).message ?? e)));
+  useEffect(() => { load(); }, []);
+
+  const save = async () => {
+    setBusy(true); setErr(undefined); setMsg(undefined);
+    try {
+      const r = await api.setSlackToken(token.trim());
+      setToken("");
+      setMsg(r.note ?? "✓ saved");
+      await load();
+    } catch (e) { setErr(String((e as Error).message ?? e)); }
+    setBusy(false);
+  };
+
+  return (
+    <div className="panel">
+      <h2 style={{ marginTop: 0 }}>Slack bot token</h2>
+      <p className="help" style={{ marginTop: 0 }}>
+        Lets a trigger post to a channel: subscribe{" "}
+        <code>slack://channel/C0123456789</code> on any trigger and every firing is delivered,
+        retried and logged like a webhook. Create a Slack app with the <code>chat:write</code>{" "}
+        scope, invite it to the channel, and paste its <strong>Bot User OAuth Token</strong> here —
+        or set <code>NAVFLOW_SLACK_BOT_TOKEN</code> in the daemon's environment. It is never
+        returned by the API and never included in a catalog export.
+      </p>
+
+      {err && <div className="alert error">{err}</div>}
+      {msg && <p className="help">{msg}</p>}
+
+      {!st ? <div className="muted">loading…</div> : (
+        <>
+          <p style={{ margin: "0 0 10px" }}>
+            {st.configured
+              ? <><span className="badge ok">configured</span>{" "}
+                  <span className="help">from <span className="mono">{st.source}</span></span></>
+              : <><span className="badge">not configured</span>{" "}
+                  <span className="help">channels cannot be subscribed until one is set</span></>}
+          </p>
+          {st.env_overrides && st.stored && (
+            <div className="alert">
+              A token is set in the environment and takes precedence — the one stored here is not in
+              use. Remove the environment variable, or clear the stored token to avoid confusion.
+            </div>
+          )}
+          <div className="btnrow" style={{ alignItems: "center", maxWidth: 720 }}>
+            <input type="password" className="mono" style={{ flex: 1 }} placeholder="xoxb-…"
+                   value={token} onChange={(e) => setToken(e.target.value)} />
+            <button className="primary" disabled={busy || !token.trim()} onClick={save}>Save</button>
+            {st.stored && (
+              <button className="danger" disabled={busy} onClick={async () => {
+                setBusy(true);
+                try { await api.clearSlackToken(); await load(); }
                 catch (e) { setErr(String((e as Error).message ?? e)); }
                 setBusy(false);
               }}>Clear stored</button>

--- a/ui/src/pages/TriggerDetail.tsx
+++ b/ui/src/pages/TriggerDetail.tsx
@@ -19,8 +19,10 @@ export default function TriggerDetail() {
   const { data: agents } = usePolling(() => api.agents(), 10000);
   const { data: dispatches } = usePolling(() => api.dispatches(100), 10000);
   const [url, setUrl] = useState("");
+  const [channel, setChannel] = useState("");
   const [busy, setBusy] = useState(false);
   const [msg, setMsg] = useState<string>();
+  const { data: caps } = usePolling(() => api.capabilities(), 60000);
 
   if (error) return <div className="alert error">{error}</div>;
   if (!triggers) return <div className="dim">loading…</div>;
@@ -98,6 +100,8 @@ export default function TriggerDetail() {
                   : <Link to={`/activity?agent=${encodeURIComponent(a.name)}`}><strong>{a.name}</strong></Link>}</td>
                 <td>{a.kind === "navflow"
                   ? <span className="badge">NavFlow</span>
+                  : a.kind === "slack"
+                  ? <span className="badge">Slack</span>
                   : <span className="badge push">connected</span>}</td>
                 <td className="mono">{a.endpoint}</td>
                 <td className="num" title={`${a.delivered_ok_total} delivered all time`}>
@@ -142,6 +146,33 @@ export default function TriggerDetail() {
           setBusy(false);
         }}>Subscribe</button>
       </div>
+
+      {/* A Slack channel is the same thing as the webhook above — one more subscription row —
+          so it lives here rather than in a Slack-shaped corner of the app. */}
+      <p className="help" style={{ margin: "10px 0 4px" }}>
+        or post every firing to a <strong>Slack channel</strong> — retried and logged like any
+        other delivery:
+      </p>
+      <div className="btnrow" style={{ alignItems: "center", maxWidth: 720 }}>
+        <input type="text" className="mono" style={{ flex: 1 }}
+               placeholder="C0123456789 — the channel ID, from Slack's “Copy link”"
+               value={channel} onChange={(e) => setChannel(e.target.value)} />
+        <button className="primary" disabled={!channel.trim() || busy} onClick={async () => {
+          setBusy(true); setMsg(undefined);
+          try {
+            const r = await api.subscribe(name, `slack://channel/${channel.trim().replace(/^#/, "")}`);
+            setMsg(`✓ subscribed (${r.subscription_id})`);
+            setChannel("");
+          } catch (e) { setMsg(`⚠️ ${String((e as Error).message ?? e)}`); }
+          setBusy(false);
+        }}>Subscribe channel</button>
+      </div>
+      {caps && caps.slack_configured === false && (
+        <p className="help" style={{ margin: "4px 0", whiteSpace: "normal" }}>
+          no Slack bot token is configured yet — add one under{" "}
+          <Link to="/security">Security</Link>, and invite the bot to the channel.
+        </p>
+      )}
       {msg && <p className="help">{msg}</p>}
 
       <h2>Recent firings</h2>

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -136,7 +136,8 @@ export interface DiscoverProposal {
 export interface AgentInfo {
   name: string;
   endpoint: string;   // masked — the last path segment may carry a secret
-  kind: "navflow" | "connected";   // a NavFlow agent (in-process) or an external webhook
+  // a NavFlow agent (in-process), an external webhook, or a Slack channel (slack://channel/<id>)
+  kind: "navflow" | "connected" | "slack";
   subscriptions: { subscription_id: string; trigger: string; created_at: string | null }[];
   triggers: string[];
   created_by: string[];


### PR DESCRIPTION
Closes NF-89 (child 1 of NF-85).

## What

Slack stops being a side effect of one code path and becomes the third dispatch sink, equal to the two that already exist. Subscribe `slack://channel/C0123456789` to any trigger and every firing is posted to that channel — retried, logged in `dispatch_deliveries`, counted by `GET /api/agents`, and visible in Activity and on the trigger's page like a webhook.

Before this, only *agent findings* could reach Slack, via a per-agent incoming webhook on `catalog_agents.slack_webhook`: a plain trigger firing could not, and there was no ledger, no retry and no visibility.

Per NF-85, the cell stays generic — a manually configured bot token, no OAuth. The control plane will broker tokens for hosted installs in child 3; nothing here knows whether it is hosted.

## How

* **`navflow/slack.py`** (new) — token resolution, Block Kit formatting, and Slack's error taxonomy. Plain `httpx`, no `slack_sdk`: it is one API call and `Dispatcher` already owns its client, timeout and retry policy.
* **`navflow/config.py`** — `SLACK_URL_PREFIX` / `slack_channel_from_url()` / `validate_slack_channel()`, alongside `AGENT_URL_PREFIX` and `agent_name_from_url()`.
* **`navflow/dispatch.py`** — `Dispatcher.fire` routes `slack://` to `_slack_post`, which has the same `(ok, error)` contract, the same 5 attempts and the same capped exponential backoff as `_post`. One `log_delivery` row per delivery with the final outcome, exactly like the webhook path.
* **`navflow/daemon.py`** — `GET/PUT/DELETE /api/settings/slack-bot-token` mirroring the Anthropic-key endpoints; `/subscribe` validates the channel and refuses a Slack subscription when no token is configured; `_agent_identity` renders a channel as `#C0123456789` / "Slack channel" instead of a raw URL, and the roster tags it `kind: "slack"`; `/api/capabilities` gains `slack_configured`.
* **Console** — a "Slack bot token" panel on Security (a deliberate near-copy of the Anthropic-key panel), a "Subscribe channel" input on a trigger's page next to the webhook one, and a Slack badge in the roster. The roster's `only="connected"` filter now means "not a NavFlow agent", so a channel shows up on the Agents page too.

### Retry semantics

`chat.postMessage` answers **HTTP 200 with `{"ok": false, "error": ...}`** for most failures, so the status code alone cannot decide whether to retry. `slack.classify` reads the body:

* `invalid_auth` / `token_revoked` / `channel_not_found` / `not_in_channel` / `is_archived` / `missing_scope` / … → **definitive**, one attempt, the reason recorded in the ledger (e.g. `slack: not_in_channel (invite the bot to the channel first)`). Five attempts of backoff would take ~15s and bury the reason behind a timeout.
* `ratelimited` (or HTTP 429) → retry, honouring `Retry-After`.
* `internal_error` / `service_unavailable` / HTTP 5xx → retry with the standard backoff.
* Other 4xx → definitive, the same rule `_post` applies to a webhook.

### Credential handling

`slack_bot_token` in the `settings` k/v table. `NAVFLOW_SLACK_BOT_TOKEN` wins over the stored value; the endpoints only ever return `{configured, source, stored, env_overrides}`; the token is not in a catalog export. `PUT` rejects anything that isn't `xox…` so a pasted webhook URL or signing secret doesn't sit there looking configured.

### Back-compat

`catalog_agents.slack_webhook` and `AgentRunner._slack()` are untouched and no agent is migrated. The one change there is that `_slack()` now calls the shared `slack.deep_link()` helper instead of its own inline copy — same output, one rule for when a `NAVFLOW_PUBLIC_URL` link is emitted.

## Verified first-hand

`tests/test_slack.py` (new, added to CI) drives a real daemon against a stubbed Slack API on a second port, the `http.server` pattern from `test_agents.py`. **41 passed, 0 failed**, including:

* a firing posts to `chat.postMessage` with `Bearer <token>`, the subscribed channel, Block Kit blocks, a plain `text` fallback, and the `NAVFLOW_PUBLIC_URL` deep link;
* the delivery is counted by `GET /api/agents` and listed in the dispatch's ledger as the channel;
* `invalid_auth` and `channel_not_found` each fail with the reason in `last_error`, mark the endpoint failing, and hit Slack **exactly once** (asserted on the stub's call count), while `internal_error` retries;
* subscribing with no token is a 400, a malformed channel is a 400, and an unknown trigger is still a 404;
* neither the stored nor the env token appears in any response; env beats stored across a restart, and `DELETE` clears the stored one while the env one keeps the sink working.

Regressions, all green locally:

* `python tests/test_agents.py` → 39 passed, 0 failed (covers the untouched `slack_webhook` path)
* `test_auth` 14/0 · `test_api_keys` 25/0 · `test_catalog_sync` 3/0 · `test_usage` 25/0 · `test_labels` 29/0 · `test_normalize` 22/0 · `test_cli` 8/0
* `cd ui && npx tsc --noEmit` clean; `npm run build` succeeds.

## Note for the concurrent NF-82 branch

I stayed out of `Store.__init__`, `make_app()`/`/health`, `bits.tsx`, `ViewsTriggers.tsx`, `Ask.tsx` and `AuthGate.tsx`. I did not add any `<ErrorState>` / `<EmptyState>` — the new Security panel and trigger affordance reuse the existing `.panel` / `.alert` / `.help` patterns, so there is nothing to reconcile with the shared components NF-82 is adding.

## Out of scope (children 2 and 3)

Inbound Slack, the `/navflow` slash command, signature verification, OAuth / hosted install, interactive Block Kit buttons, and deprecating the per-agent `slack_webhook`.
