### PR TITLE
NF-82: start degraded instead of dying when DuckDB won't open

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Backend — install + tests
         run: |
           pip install -e .
-          for t in test_labels test_normalize test_auth test_api_keys test_agents test_catalog_sync test_cli test_usage; do
+          for t in test_labels test_normalize test_auth test_api_keys test_agents test_catalog_sync test_cli test_usage test_degraded; do
             echo "== $t =="
             python "tests/$t.py"
           done

--- a/navflow/daemon.py
+++ b/navflow/daemon.py
@@ -14,6 +14,7 @@ import os
 import re
 import secrets
 import shutil
+import traceback
 import uuid
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -33,7 +34,7 @@ from .envelope import now_utc
 from .builtin_agents import (PRESETS as AGENT_PRESETS, AgentRunner,
                              resolve_key as resolve_anthropic_key)
 from .runtime import Runtime
-from .store import Store
+from .store import Store, StoreUnavailable
 from .views import resolve_query_full, resolve_read
 
 CATALOG_PATH = os.getenv("NAVFLOW_CATALOG", "catalog.yaml")
@@ -109,6 +110,58 @@ def _ui_dist() -> Path:
 
 
 UI_DIST = _ui_dist()
+
+# /health reports `degraded` at or above this share of NAVFLOW_MAX_DB_SIZE. On the 0-100 scale of
+# /api/usage's pct_used, so 90 means 90% — not 0.9. Unknown (no limit configured) is never degraded.
+DEGRADED_PCT = float(os.getenv("NAVFLOW_DEGRADED_PCT", "90"))
+
+
+def _serve_ui(path: str):
+    """The built console SPA: a real file if it exists, else index.html (client-side routing)."""
+    if not UI_DIST.exists():
+        return JSONResponse(
+            {"detail": "console not built — run `npm install && npm run build` in ui/"},
+            status_code=404)
+    f = (UI_DIST / path).resolve()
+    if path and f.is_file() and f.is_relative_to(UI_DIST.resolve()):
+        return FileResponse(f)
+    return FileResponse(UI_DIST / "index.html")
+
+
+def _degraded_app(reason: str) -> FastAPI:
+    """The app we serve when the store could not be opened. It exists so the failure reaches a
+    human instead of ERR_CONNECTION_REFUSED: the console still loads and every data route answers
+    503 with the reason, so the UI can name the problem. No runtime, no connectors, no ingest —
+    nothing that would need the store. Restart once the DB is reachable again."""
+    app = FastAPI(title="navflowd (degraded)")
+    app.add_middleware(CORSMiddleware, allow_origins=["*"], allow_methods=["*"],
+                       allow_headers=["*"])
+
+    @app.get("/health", include_in_schema=False)
+    async def health():
+        # HTTP 200 with status "down": a probe that can read the body learns WHAT is wrong, and the
+        # console (which only ever reaches this daemon) can render it. Keys AuthGate depends on stay.
+        body = {"status": "down", "detail": reason, "auth_required": bool(AUTH_TOKEN),
+                "sources": [], "pct_used": None}
+        if LOGIN_URL:
+            body["login_url"] = LOGIN_URL
+        return body
+
+    async def unavailable():
+        return JSONResponse({"detail": f"database unavailable — {reason}", "status": "down"},
+                            status_code=503)
+
+    # Everything that needs the store answers 503 (not a bare 500, and not the SPA's index.html).
+    for _p in ("/api/{rest:path}", "/query", "/read", "/remember", "/catalog", "/catalog/{rest:path}",
+               "/ingest/{rest:path}", "/v1/logs", "/v1/traces", "/v1/metrics"):
+        app.add_api_route(_p, unavailable, include_in_schema=False,
+                          methods=["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"])
+
+    @app.get("/{path:path}", include_in_schema=False)
+    async def ui(path: str):
+        return _serve_ui(path)
+
+    return app
 
 
 class QueryReq(BaseModel):
@@ -192,7 +245,16 @@ class AnthropicKeyIn(BaseModel):
 
 
 def make_app() -> FastAPI:
-    store = Store(DB_PATH)
+    try:
+        store = Store(DB_PATH)
+    except StoreUnavailable as e:
+        # Losing the DB must not cost us the ability to SAY that we lost the DB. Log the full
+        # traceback (degraded mode explains the failure to the user, it does not hide it from the
+        # operator) and serve the console + 503s instead of exiting before uvicorn ever binds.
+        traceback.print_exc()
+        print(f"navflowd: DEGRADED — {e.reason}. Serving the console and 503s; fix the database "
+              f"and restart.", flush=True)
+        return _degraded_app(e.reason)
 
     # seed the DB catalog from YAML on first boot — or on every boot when CATALOG_SYNC is set, so
     # the file stays the source of truth (the admin interface for a read-only demo: edit + restart).
@@ -324,8 +386,27 @@ def make_app() -> FastAPI:
     # ── agent surface (unchanged contract; queries now logged) ───────────────
     @app.get("/health")
     async def health():
-        body = {"status": "ok", "auth_required": bool(AUTH_TOKEN),
-                "sources": [] if AUTH_TOKEN else list(runtime.catalog.sources)}
+        """Liveness that actually touches the store, so a wedged DuckDB can't read as healthy to a
+        k8s probe or the control plane's uptime check. `ok` / `degraded` (running, but nearly out of
+        the configured storage) / `down` (the store stopped answering — restart needed). Always
+        HTTP 200: the status and `detail` say what is wrong, which a bare 503 could not.
+        `pct_used` is on /api/usage's 0-100 scale and is null when no limit is configured — unknown,
+        never 0. The probe is a SELECT 1 plus a stat() of the db file; no table is scanned."""
+        status, detail, pct = "ok", None, None
+        try:
+            store.ping()
+        except Exception as e:
+            status, detail = "down", f"database unavailable: {e}"
+        if status == "ok" and MAX_DB_SIZE:
+            pct = round(100 * store.disk_bytes() / MAX_DB_SIZE, 2)
+            if pct >= DEGRADED_PCT:
+                status = "degraded"
+                detail = f"storage {pct}% full ({MAX_DB_SIZE} byte limit)"
+        body = {"status": status, "auth_required": bool(AUTH_TOKEN),
+                "sources": [] if AUTH_TOKEN else list(runtime.catalog.sources),
+                "pct_used": pct}
+        if detail:
+            body["detail"] = detail
         if LOGIN_URL:
             # public, non-secret: where the logged-out console sends the browser to authenticate.
             body["login_url"] = LOGIN_URL
@@ -1362,13 +1443,6 @@ def make_app() -> FastAPI:
     # ── console UI (built SPA; catch-all registered last so API routes win) ──
     @app.get("/{path:path}", include_in_schema=False)
     async def ui(path: str):
-        if not UI_DIST.exists():
-            return JSONResponse(
-                {"detail": "console not built — run `npm install && npm run build` in ui/"},
-                status_code=404)
-        f = (UI_DIST / path).resolve()
-        if path and f.is_file() and f.is_relative_to(UI_DIST.resolve()):
-            return FileResponse(f)
-        return FileResponse(UI_DIST / "index.html")
+        return _serve_ui(path)
 
     return app

--- a/navflow/store.py
+++ b/navflow/store.py
@@ -314,21 +314,52 @@ def _bound_duckdb_memory(con, path: str) -> None:
         print(f"navflowd: could not bound DuckDB memory ({e})")
 
 
+class StoreUnavailable(RuntimeError):
+    """The database could not be opened or initialized — locked by another daemon, permissions,
+    a full disk, a corrupt file. Raised instead of the raw DuckDB error so navflowd can start in
+    degraded mode (serve the console and explain itself) rather than exit with a traceback."""
+
+    def __init__(self, reason: str, path: str = ""):
+        super().__init__(reason)
+        self.reason = reason
+        self.path = path
+
+
 class Store:
     def __init__(self, path: str = "navflow.duckdb"):
         # All access is from navflowd's event loop thread; the lock is belt-and-suspenders since
         # FastAPI may run sync work in a threadpool.
         self._lock = threading.Lock()
         self.path = path          # kept so usage() can size the db file and its WAL
-        self.con = duckdb.connect(path)
-        _bound_duckdb_memory(self.con, path)
-        for stmt in _SCHEMA.strip().split(";"):
-            if stmt.strip():
+        # Opening the DB is the one startup step that routinely fails for reasons outside the
+        # process (another daemon holds the lock, the file is unreadable, the volume is full).
+        # Fail as StoreUnavailable so the caller can degrade; the original error is kept as the
+        # cause so the traceback still reaches the process log.
+        try:
+            self.con = duckdb.connect(path)
+        except Exception as e:
+            raise StoreUnavailable(f"cannot open the database at {path}: {e}", path) from e
+        try:
+            _bound_duckdb_memory(self.con, path)
+            for stmt in _SCHEMA.strip().split(";"):
+                if stmt.strip():
+                    self.con.execute(stmt)
+            for stmt in _MIGRATIONS:
                 self.con.execute(stmt)
-        for stmt in _MIGRATIONS:
-            self.con.execute(stmt)
-        self._init_source_stats()
-        self._init_entity_counts()
+            self._init_source_stats()
+            self._init_entity_counts()
+        except Exception as e:
+            raise StoreUnavailable(f"cannot initialize the database at {path}: {e}", path) from e
+
+    def ping(self) -> None:
+        """Cheapest possible liveness probe for /health — proves the connection still answers.
+        Raises whatever DuckDB raises when the store has gone away underneath us."""
+        with self._lock:
+            self.con.execute("SELECT 1").fetchone()
+
+    def disk_bytes(self) -> int:
+        """db + WAL bytes, from stat() only — no query, so /health can call it on every probe."""
+        return _file_size(self.path) + _file_size(self.path + ".wal")
 
     def _init_source_stats(self) -> None:
         """`source_stats` is a maintained per-source counter (event count + last ingest) so the

--- a/tests/test_degraded.py
+++ b/tests/test_degraded.py
@@ -1,0 +1,138 @@
+"""Degraded mode — a DuckDB that won't open must not cost the user the console.
+
+Two real failures (an unreadable db file, and a second daemon on a db another daemon holds open):
+the daemon must still bind, still serve the SPA, answer /health with a non-ok status that says why,
+and 503 every data route instead of exiting before uvicorn binds (which the browser sees as
+ERR_CONNECTION_REFUSED — a blank page with nothing to explain it). Plus the other half of the same
+bug: /health must actually touch the store, so a wedged db can't read as healthy to a k8s probe.
+"""
+import asyncio, os, subprocess, sys
+import httpx
+
+P = F = 0
+def ck(l, c, d=""):
+    global P, F; P += 1 if c else 0; F += 0 if c else 1
+    print(("  ok   " if c else "  FAIL ") + l + ("" if c else f"  {d}"))
+
+SEED = "/tmp/degraded_catalog.yaml"
+with open(SEED, "w") as fh:
+    fh.write("sources:\n  - name: evt\n    connector: webhook\n    poll: 5s\n    config: {}\n")
+OK_DB, BAD_DB, LOCK_DB = "/tmp/degraded_ok.duckdb", "/tmp/degraded_bad.duckdb", "/tmp/degraded_lock.duckdb"
+PORT, PORT2 = "8811", "8812"
+
+
+def _boot(db, port, **extra):
+    env = {k: v for k, v in os.environ.items()
+           if k not in ("NAVFLOW_AUTH_TOKEN", "NAVFLOW_MAX_DB_SIZE")}
+    env |= {"NAVFLOW_DB": db, "NAVFLOW_CATALOG": SEED, "NAVFLOW_PORT": port,
+            "NAVFLOW_OTLP_GRPC_PORT": "off", **extra}
+    return subprocess.Popen([sys.executable, "-c", "from navflow.cli import run_daemon; run_daemon()"],
+                            env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+
+async def _health(port, tries=80):
+    """Wait for /health to answer at all (any status) and return the body — the point of degraded
+    mode is that it answers even when the store is gone."""
+    for _ in range(tries):
+        try:
+            async with httpx.AsyncClient() as cx:
+                r = await cx.get(f"http://127.0.0.1:{port}/health", timeout=1)
+                if r.status_code == 200:
+                    return r.json()
+        except Exception:
+            pass
+        await asyncio.sleep(0.25)
+    return None
+
+
+def _rm(*paths):
+    for p in paths:
+        for f in (p, p + ".wal"):
+            if os.path.exists(f):
+                os.chmod(f, 0o644)
+                os.remove(f)
+
+
+async def main():
+    _rm(OK_DB, BAD_DB, LOCK_DB)
+
+    # ── 1. healthy: /health proves the store answers, and reports usage on the 0-100 scale ──
+    proc = _boot(OK_DB, PORT)
+    try:
+        h = await _health(PORT)
+        ck("healthy daemon answers /health", h is not None)
+        ck("status is ok", h and h["status"] == "ok", h)
+        # the keys AuthGate + the cloud login handoff + the control plane's uptime check depend on
+        ck("keeps auth_required/sources", h and "auth_required" in h and "sources" in h, h)
+        ck("pct_used is null with no limit configured (unknown, NOT 0)",
+           h and h.get("pct_used") is None, h)
+    finally:
+        proc.terminate(); proc.wait(timeout=10)
+
+    # A limit smaller than the db it measures → degraded, and pct_used reads as a percentage
+    # (0-100), not a fraction: a real db is thousands of bytes over a 1000-byte cap.
+    proc = _boot(OK_DB, PORT, NAVFLOW_MAX_DB_SIZE="1000")
+    try:
+        h = await _health(PORT)
+        ck("near-full instance reports degraded", h and h["status"] == "degraded", h)
+        ck("degraded says why", h and "detail" in h, h)
+        ck("pct_used is 0-100, not a fraction", h and (h.get("pct_used") or 0) > 1, h)
+    finally:
+        proc.terminate(); proc.wait(timeout=10)
+
+    # ── 2. hard failure: the db file exists but cannot be opened ──
+    from navflow.store import Store
+    Store(BAD_DB).con.close()                # a real, valid db file…
+    ck("seeded a db file to break", os.path.exists(BAD_DB))
+    os.chmod(BAD_DB, 0o000)
+
+    proc = _boot(BAD_DB, PORT)
+    try:
+        h = await _health(PORT)
+        ck("daemon STARTS with an unopenable db (no ERR_CONNECTION_REFUSED)", h is not None)
+        ck("status is not ok", h and h["status"] != "ok", h)
+        ck("names the problem", h and BAD_DB in (h.get("detail") or ""), h)
+        async with httpx.AsyncClient(base_url=f"http://127.0.0.1:{PORT}") as cx:
+            r = await cx.get("/api/views", timeout=5)
+            ck("/api/views is 503, not a bare 500", r.status_code == 503, r.status_code)
+            ck("…with a reason the console can render",
+               "unavailable" in (r.json().get("detail") or ""), r.text)
+            r = await cx.post("/query", json={"view": "x", "key": "y"}, timeout=5)
+            ck("/query is 503", r.status_code == 503, r.status_code)
+            r = await cx.post("/ingest/evt", json={}, timeout=5)
+            ck("ingest is 503 (a producer learns the write was refused)", r.status_code == 503,
+               r.status_code)
+            r = await cx.get("/", timeout=5)
+            # the console is what shows the user the error, so it must still be served
+            ck("the console SPA is still served", r.status_code == 200 or "console not built" in r.text,
+               r.status_code)
+    finally:
+        proc.terminate(); proc.wait(timeout=10)
+        os.chmod(BAD_DB, 0o644)
+
+    # ── 3. lock contention: a second daemon on the same db degrades, the first is untouched ──
+    first = _boot(LOCK_DB, PORT)
+    second = None
+    try:
+        h = await _health(PORT)
+        ck("first daemon is ok", h and h["status"] == "ok", h)
+        second = _boot(LOCK_DB, PORT2)
+        h2 = await _health(PORT2)
+        ck("second daemon starts instead of crashing", h2 is not None)
+        ck("second daemon is not ok", h2 and h2["status"] != "ok", h2)
+        async with httpx.AsyncClient() as cx:
+            r = await cx.get(f"http://127.0.0.1:{PORT2}/api/sources", timeout=5)
+            ck("second daemon 503s its API", r.status_code == 503, r.status_code)
+        h = await _health(PORT)
+        ck("first daemon still ok", h and h["status"] == "ok", h)
+    finally:
+        for p in (first, second):
+            if p:
+                p.terminate(); p.wait(timeout=10)
+
+    _rm(OK_DB, BAD_DB, LOCK_DB)
+    print(f"\n{P} passed, {F} failed")
+    sys.exit(1 if F else 0)
+
+
+asyncio.run(main())

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -61,7 +61,13 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
 export const api = {
   // login_url is present only on a cloud-managed cell (daemon NAVFLOW_LOGIN_URL) — it tells the
   // logged-out console where to send the browser to authenticate.
-  health: () => request<{ status: string; auth_required: boolean; login_url?: string }>("/health"),
+  // status: "ok" | "degraded" (running, storage nearly full) | "down" (no usable database — the
+  // daemon is serving the console and 503s so the failure is visible). `detail` says why when it
+  // isn't ok; `pct_used` is on /api/usage's 0-100 scale and null when no limit is configured.
+  health: () => request<{
+    status: string; auth_required: boolean; login_url?: string;
+    detail?: string; pct_used?: number | null;
+  }>("/health"),
   // Swap a one-time ?code= (handed to us in the redirect back from the control plane) for the real
   // cell key. Raw cross-origin fetch: no auth header yet, and the control plane's CORS allows POST
   // from *.<cell domain>. Deliberately NOT the `request` helper, which would attach the (absent)

--- a/ui/src/components/AuthGate.tsx
+++ b/ui/src/components/AuthGate.tsx
@@ -5,8 +5,21 @@ import { api, auth } from "../api";
 // Gates the console when the instance requires a token (NAVFLOW_AUTH_TOKEN). The SPA shell is served
 // publicly, so we ask /health whether auth is required; any 401 from an API call (token missing or
 // expired) flips us back to the login screen via the "navflow-auth-required" event.
+// A daemon that is up but broken (no database) still answers /health — it just doesn't say "ok".
+// A daemon that is down doesn't answer at all. Neither may leave the console blank, so the gate
+// always resolves: on timeout or failure we render the app and say what we know.
+const HEALTH_TIMEOUT_MS = 6000;
+
+function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
+  return Promise.race([
+    p,
+    new Promise<T>((_, rej) => setTimeout(() => rej(new Error("timeout")), ms)),
+  ]);
+}
+
 export default function AuthGate({ children }: { children: React.ReactNode }) {
   const [state, setState] = useState<"loading" | "ok" | "login">("loading");
+  const [banner, setBanner] = useState<string>();
 
   useEffect(() => {
     let alive = true;
@@ -23,7 +36,7 @@ export default function AuthGate({ children }: { children: React.ReactNode }) {
       const t = url.searchParams.get("token");
       if (t) { auth.set(t.trim()); strip("token"); }
 
-      const h = await api.health().catch(() => null);
+      const h = await withTimeout(api.health(), HEALTH_TIMEOUT_MS).catch(() => null);
 
       // Cloud: the control plane redirects back here with a one-time ?code=. Swap it for the real
       // cell key at the control plane (login_url tells us where). On failure we fall through to the
@@ -35,6 +48,16 @@ export default function AuthGate({ children }: { children: React.ReactNode }) {
       }
 
       if (!alive) return;
+
+      if (!h) {
+        setBanner("Can’t reach the NavFlow daemon — it may be starting, stopped, or blocked "
+                  + "between this browser and the server. Pages will keep retrying.");
+      } else if (h.status && h.status !== "ok") {
+        setBanner(h.detail
+          ? `NavFlow is ${h.status}: ${h.detail}`
+          : `NavFlow reports status “${h.status}”.`);
+      }
+
       if (h && h.auth_required && !auth.get()) {
         // Cloud cell: bounce to the hosted login, telling it which cell to return to. Self-host:
         // show the paste-token form.
@@ -53,9 +76,27 @@ export default function AuthGate({ children }: { children: React.ReactNode }) {
     return () => { alive = false; window.removeEventListener("navflow-auth-required", onAuth); };
   }, []);
 
-  if (state === "loading") return null;
+  if (state === "loading") {
+    return (
+      <div className="login-wrap">
+        <p className="dim">Connecting to NavFlow…</p>
+      </div>
+    );
+  }
   if (state === "login") return <Login onAuthed={() => setState("ok")} />;
-  return <>{children}</>;
+  return (
+    <>
+      {children}
+      {/* Fixed, not in flow: #root is the sidebar/content flex row, and a banner must not
+          become a third column. */}
+      {banner && (
+        <div className="daemon-banner alert error" role="status">
+          {banner}
+          <button className="btn" onClick={() => window.location.reload()}>Reload</button>
+        </div>
+      )}
+    </>
+  );
 }
 
 function Login({ onAuthed }: { onAuthed: () => void }) {

--- a/ui/src/components/bits.tsx
+++ b/ui/src/components/bits.tsx
@@ -30,18 +30,45 @@ export function usePolling<T>(fn: () => Promise<T>, intervalMs = 5000): {
 
   useEffect(() => {
     let live = true;
-    const load = () => {
-      if (document.hidden) return;
+    // The FIRST load always runs, even in a hidden tab: skipping it leaves data undefined, which
+    // every page renders as its empty state — a background tab would claim you have no views.
+    // Only the polling refreshes pause while hidden.
+    const load = (force = false) => {
+      if (document.hidden && !force) return;
       fnRef.current()
         .then((d) => { if (live) { setData(d); setError(undefined); } })
         .catch((e) => { if (live) setError(String(e.message ?? e)); });
     };
-    load();
-    const id = setInterval(load, intervalMs);
+    load(true);
+    const id = setInterval(() => load(), intervalMs);
     return () => { live = false; clearInterval(id); };
   }, [intervalMs, tick]);
 
   return { data, error, reload: () => setTick((t) => t + 1) };
+}
+
+/** A failed load, said out loud. The rule: a fetch that failed is NEVER rendered as an empty
+ *  state — "no views" and "the daemon couldn't answer" are different facts, and telling the user
+ *  the first when the second is true sends them off to fix nothing. Pair with usePolling's
+ *  `error` (which keeps the last good `data`, so this sits above stale rows). */
+export function ErrorState({ error, what, onRetry }: {
+  error: string;
+  what?: string;          // what failed to load, e.g. "views" — omit for the generic wording
+  onRetry?: () => void;   // usually usePolling's reload
+}) {
+  return (
+    <div className="alert error">
+      <strong>{what ? `Couldn’t load ${what}` : "Couldn’t load this page"}</strong> — {error}
+      {onRetry && (
+        <button className="btn" style={{ marginLeft: 10 }} onClick={onRetry}>Retry</button>
+      )}
+    </div>
+  );
+}
+
+/** "There is genuinely nothing here" — only ever rendered when the load SUCCEEDED. */
+export function EmptyState({ children }: { children: React.ReactNode }) {
+  return <div className="empty">{children}</div>;
 }
 
 /** Input with styled suggestions — replaces native <datalist> (which can't be themed).

--- a/ui/src/pages/Ask.tsx
+++ b/ui/src/pages/Ask.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import AskChat from "../components/AskChat";
 import OrganizePanel from "../components/OrganizePanel";
 import { api } from "../api";
-import { usePolling } from "../components/bits";
+import { ErrorState, usePolling } from "../components/bits";
 
 // One assistant, two doors: Chat (free-form explore/debug; also summonable with ⌘K) and
 // Organize (a goal-directed run that proposes labels/views as apply-or-skip cards). Same
@@ -39,7 +39,7 @@ export default function Ask() {
 // Start gate: state the goal (prefilled with the generic sweep), then the agent runs and
 // proposes. An explicit click, never on page load — a run spends model tokens.
 function OrganizeTab() {
-  const { data: sources } = usePolling(() => api.sources(), 15000);
+  const { data: sources, error, reload } = usePolling(() => api.sources(), 15000);
   const [intent, setIntent] = useState(DEFAULT_INTENT);
   const [started, setStarted] = useState<string>();   // the intent the run started with
 
@@ -51,6 +51,9 @@ function OrganizeTab() {
 
   return (
     <div className="panel" style={{ maxWidth: 680 }}>
+      {/* A failed /api/sources reads as "0 sources, 0 events" — say so, or the disabled Start
+          button below blames the user's data for a backend failure. */}
+      {error && <ErrorState error={error} what="your sources" onRetry={reload} />}
       <p className="help" style={{ whiteSpace: "normal", marginTop: 0 }}>
         The agent inspects your sources&rsquo; field profiles and sample events, then proposes
         labels &amp; keys per source and views across sources — as cards you apply or skip.
@@ -76,7 +79,7 @@ function OrganizeTab() {
               onClick={() => setStarted(intent.trim())}>
         ✨ Start
       </button>
-      {!total && <p className="help" style={{ marginTop: 8 }}>needs at least one source with data</p>}
+      {!total && !error && <p className="help" style={{ marginTop: 8 }}>needs at least one source with data</p>}
     </div>
   );
 }

--- a/ui/src/pages/ViewsTriggers.tsx
+++ b/ui/src/pages/ViewsTriggers.tsx
@@ -4,34 +4,35 @@ import { Link } from "react-router-dom";
 import { api } from "../api";
 import ConfirmDialog from "../components/ConfirmDialog";
 import { Search } from "../components/icons";
-import { TimeAgo, usePolling } from "../components/bits";
+import { EmptyState, ErrorState, TimeAgo, usePolling } from "../components/bits";
 import type { Trigger, View } from "../types";
 
 // Views and Triggers are two acts of "serve to agents": a view is a saved read; a trigger wakes
 // an agent when that read crosses a line. They are separate pages so each concept stands alone.
 
 export function ViewsPage() {
-  const { data: views, reload } = usePolling(() => api.views(), 10000);
+  const { data: views, error, reload } = usePolling(() => api.views(), 10000);
 
   return (
     <>
       <h1>Views</h1>
       <p className="subtitle">saved reads — <em>the queries you hand agents</em></p>
-      <ViewsSection views={views ?? []} onChange={reload} />
+      <ViewsSection views={views ?? []} loadError={error} onChange={reload} />
     </>
   );
 }
 
 export function TriggersPage() {
-  const { data: triggers, reload } = usePolling(() => api.triggers(), 10000);
-  const { data: views } = usePolling(() => api.views(), 10000);
+  const { data: triggers, error, reload } = usePolling(() => api.triggers(), 10000);
+  const { data: views, error: viewsError } = usePolling(() => api.views(), 10000);
 
   return (
     <>
       <h1>Triggers</h1>
       <p className="subtitle">conditions that <em>wake an agent</em> with a timeline</p>
+      {/* Either fetch failing is enough to make "no triggers" / "no views yet" a lie. */}
       <TriggersSection triggers={triggers ?? []} viewNames={(views ?? []).map((v) => v.name)}
-                       onChange={reload} />
+                       loadError={error ?? viewsError} onChange={reload} />
     </>
   );
 }
@@ -64,8 +65,8 @@ function AuthorBadge({ createdBy }: { createdBy?: string }) {
   );
 }
 
-function ViewsSection({ views, onChange }:
-  { views: View[]; onChange: () => void }) {
+function ViewsSection({ views, loadError, onChange }:
+  { views: View[]; loadError?: string; onChange: () => void }) {
   const [error, setError] = useState<string>();
   const [q, setQ] = useState("");
   const [confirmDelName, setConfirmDelName] = useState<string | null>(null);
@@ -91,8 +92,11 @@ function ViewsSection({ views, onChange }:
         <Link className="btn primary" to="/views/new">Add view</Link>
       </div>
       {error && <div className="alert error">{error}</div>}
+      {loadError && <ErrorState error={loadError} what="views" onRetry={onChange} />}
 
-      {!views.length && <div className="empty">no views — agents have nothing to query yet</div>}
+      {!views.length && !loadError && (
+        <EmptyState>no views — agents have nothing to query yet</EmptyState>
+      )}
       {!!views.length && (
         <>
           <FilterBar q={q} setQ={setQ} placeholder="Filter by name, key, source…" shown={shown.length} total={views.length} />
@@ -147,8 +151,8 @@ function ViewsSection({ views, onChange }:
 
 // ── triggers ─────────────────────────────────────────────────────────────────
 
-function TriggersSection({ triggers, viewNames, onChange }:
-  { triggers: Trigger[]; viewNames: string[]; onChange: () => void }) {
+function TriggersSection({ triggers, viewNames, loadError, onChange }:
+  { triggers: Trigger[]; viewNames: string[]; loadError?: string; onChange: () => void }) {
   const [error, setError] = useState<string>();
   const [q, setQ] = useState("");
   const [confirmDelName, setConfirmDelName] = useState<string | null>(null);
@@ -184,15 +188,18 @@ function TriggersSection({ triggers, viewNames, onChange }:
         </Link>
       </div>
       {error && <div className="alert error">{error}</div>}
+      {loadError && <ErrorState error={loadError} what="triggers" onRetry={onChange} />}
 
-      {!viewNames.length && (
+      {!viewNames.length && !loadError && (
         <div className="alert">
           A trigger is a condition evaluated over a <strong>view</strong>, and this instance has no
           views yet — <Link to="/views/new">create a view</Link> first (pick the sources and the
           entity key it correlates by), then come back and add a trigger on it.
         </div>
       )}
-      {!triggers.length && !!viewNames.length && <div className="empty">no triggers — nothing wakes agents yet</div>}
+      {!triggers.length && !!viewNames.length && !loadError && (
+        <EmptyState>no triggers — nothing wakes agents yet</EmptyState>
+      )}
       {!!triggers.length && (
         <>
           <FilterBar q={q} setQ={setQ} placeholder="Filter by name, view, condition…" shown={shown.length} total={triggers.length} />

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -532,6 +532,15 @@ button:focus-visible, .btn:focus-visible, .navlink:focus-visible, .navbtn:focus-
 .alert.ok { background: var(--ok-soft); color: var(--ok); border: 1px solid var(--ok-border); }
 .alert.info { background: var(--th-bg); color: var(--ink-soft); border: 1px solid var(--line); }
 
+/* Instance-wide banner (daemon unreachable / degraded). Fixed, because #root is the
+   sidebar+content flex row and an in-flow banner would become a third column. */
+.daemon-banner {
+  position: fixed; left: 0; right: 0; bottom: 0; z-index: 200; margin: 0;
+  display: flex; align-items: center; gap: 12px;
+  padding: 12px 20px; border-left: none; border-right: none; border-bottom: none;
+}
+.daemon-banner .btn { margin-left: auto; flex: none; }
+
 pre.payload {
   font-family: var(--mono);
   font-size: 12px;

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -535,7 +535,8 @@ button:focus-visible, .btn:focus-visible, .navlink:focus-visible, .navbtn:focus-
 /* Instance-wide banner (daemon unreachable / degraded). Fixed, because #root is the
    sidebar+content flex row and an in-flow banner would become a third column. */
 .daemon-banner {
-  position: fixed; left: 0; right: 0; bottom: 0; z-index: 200; margin: 0;
+  /* above the sticky topbar (20), below the ⌘K overlay (100) */
+  position: fixed; left: 0; right: 0; bottom: 0; z-index: 90; margin: 0;
   display: flex; align-items: center; gap: 12px;
   padding: 12px 20px; border-left: none; border-right: none; border-bottom: none;
 }


### PR DESCRIPTION
Closes NF-82.

"DuckDB fails and the user gets a blank page" was three bugs stacked on one symptom. All three are fixed here.

### 1. The daemon never started

`duckdb.connect` had no `try/except` and `Store(DB_PATH)` is built inside `make_app()` — *before* uvicorn binds. A locked/unreadable/full DB meant the process exited with a traceback and the browser showed `ERR_CONNECTION_REFUSED`; there was nothing left to render an error.

- `Store.__init__` now raises a typed `StoreUnavailable(reason)` (the DuckDB error is kept as `__cause__`).
- `make_app()` catches it, prints the full traceback plus a `DEGRADED` line, and returns a working app: the SPA is still served, `/health` answers `{"status": "down", "detail": …}` (HTTP 200, so a probe learns *what* is wrong), and every data route — `/api/*`, `/query`, `/read`, `/remember`, `/catalog*`, `/ingest/*`, `/v1/*` — returns **503 with the reason**, not a bare 500 and not `index.html`.
- Degraded mode explains the failure to the user; it does not hide it from the operator.

### 2. `/health` was meaningless

It never touched the store, so a wedged DuckDB still read as `ok` to the k8s probes and the control plane's uptime check.

- It now does a `SELECT 1` against the store plus a `stat()` of the db file — no table scan.
- Statuses: `ok` / `degraded` (at or above `NAVFLOW_DEGRADED_PCT`, default 90, of `NAVFLOW_MAX_DB_SIZE`) / `down`.
- `pct_used` is on `/api/usage`'s **0-100** scale and is `null` when no limit is configured — unknown, never 0, so a normal self-hosted install does not read as an empty disk.
- Existing keys (`auth_required`, `sources`, `login_url`) are untouched — `AuthGate` and the cloud login handoff depend on them.

### 3. The console hid the errors that did reach it

- Shared `<ErrorState>` / `<EmptyState>` in `bits.tsx`, next to `usePolling`.
- `ViewsTriggers.tsx` and `Ask.tsx` no longer drop `usePolling`'s `error`: a backend failure renders the error, never "no views — agents have nothing to query yet" / "no triggers" / "needs at least one source with data". Empty states are gated on the load having *succeeded*.
- `AuthGate.tsx`: the `/health` call gets a 6s timeout and the gate always resolves — `if (state === "loading") return null;` could leave the whole SPA blank forever. A fixed bottom banner names an unreachable or non-`ok` daemon.
- `usePolling`: the **first** load now runs even in a hidden tab (only the polling refreshes pause). Skipping it left `data` undefined, which every page renders as its empty state — a restored background tab claimed you had no views.

### Verified by hand

- `chmod 000` on the db: the daemon **starts**, `/health` is `down` with the path and `Permission denied`, `/api/views` is 503, and the console loads. In the browser: Views and Triggers show "Couldn't load views/triggers — database unavailable — …", Ask/Organize shows the same instead of blaming your data, and the bottom banner reads "NavFlow is down: cannot open the database at …".
- Two daemons on one `NAVFLOW_DB`: the second degrades (starts, `down`, 503s), the first stays `ok`.
- Healthy daemon: empty states still render, no banner.
- `tests/test_degraded.py` (new, added to CI) — 21/21. `test_auth.py` 14/14, `test_agents.py` 39/39, `test_usage.py` 25/25, `test_cli.py` 8/8. `npx tsc --noEmit` clean, `npm run build` clean.

### Out of scope / not done

- Storage caps, retention, and a render-time ErrorBoundary, per the ticket.
- Secondary `usePolling` call sites that drop `error` for *auxiliary* data (e.g. `ViewDetail`'s trigger list, `SourceDetail`'s events) are untouched — their primary fetch already handles errors, and `Activity.tsx` / `TriggerDetail.tsx` are being edited concurrently by NF-89.
