### PR TITLE
slack: signed inbound endpoint + /navflow ask slash command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Backend — install + tests
         run: |
           pip install -e .
-          for t in test_labels test_normalize test_auth test_api_keys test_agents test_catalog_sync test_cli test_usage test_slack test_degraded; do
+          for t in test_labels test_normalize test_auth test_api_keys test_agents test_catalog_sync test_cli test_usage test_slack test_slack_verify test_slack_ask test_degraded; do
             echo "== $t =="
             python "tests/$t.py"
           done

--- a/README.md
+++ b/README.md
@@ -90,6 +90,11 @@ Other clients, stdio transport, and auth are covered in
   like any other subscriber. One bot token per instance (`NAVFLOW_SLACK_BOT_TOKEN`, or set it under
   **Security**); the token is never returned by the API. This is the way forward for Slack: an
   agent's older per-agent `slack_webhook` still works, but it is not retried or logged.
+  Ask back from the same channel with the **`/navflow ask <question>`** slash command — point the
+  Slack app's command at `https://<your-navflow>/api/slack/events` and set the app's signing secret
+  (`NAVFLOW_SLACK_SIGNING_SECRET`, or under **Security**). Every inbound request is verified by
+  HMAC-SHA256 over the raw body within a 5-minute replay window; with no signing secret configured
+  the endpoint answers 503 rather than trusting anything.
 - **Console**: Sources (health + setup), **Explore** (pick an entity, read its timeline, human or
   agent view), Views & Triggers, **Agents** (create NavFlow agents + connect external ones), and
   **Ask** (an in-console assistant over your data, summonable with ⌘K).

--- a/navflow/daemon.py
+++ b/navflow/daemon.py
@@ -18,7 +18,9 @@ import traceback
 import uuid
 from contextlib import asynccontextmanager
 from pathlib import Path
+from urllib.parse import parse_qs
 
+import httpx
 from fastapi import Body, FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse, PlainTextResponse, StreamingResponse
@@ -35,6 +37,8 @@ from .envelope import now_utc
 from .builtin_agents import (PRESETS as AGENT_PRESETS, AgentRunner,
                              resolve_key as resolve_anthropic_key)
 from .runtime import Runtime
+from . import slack as slack_mod
+from . import slack_verify
 from .slack import SETTING_KEY as SLACK_TOKEN_SETTING, resolve_token as resolve_slack_token
 from .store import Store, StoreUnavailable
 from .views import resolve_query_full, resolve_read
@@ -69,12 +73,23 @@ def _bearer(auth: str | None) -> str:
     return auth[7:].strip() if auth and auth.lower().startswith("bearer ") else ""
 
 
+SLACK_EVENTS_PATH = "/api/slack/events"
+
+
 def _public(method: str, path: str) -> bool:
-    """Reachable without the auth token: CORS preflight, the health probe, ingest (own token), and
-    the console SPA shell + static assets (any GET that isn't an API/data route)."""
+    """Reachable without the auth token: CORS preflight, the health probe, ingest (own token), the
+    Slack inbound endpoint (own signature), and the console SPA shell + static assets (any GET that
+    isn't an API/data route)."""
     if method == "OPTIONS" or path == "/health":
         return True
     if _is_ingest(path):
+        return True
+    if method == "POST" and path == SLACK_EVENTS_PATH:
+        # Slack calls this from its own infrastructure and cannot carry our bearer token, so it has
+        # to be public to THIS middleware — but it is not unauthenticated. It is gated by an
+        # HMAC-SHA256 signature over the raw body plus a 5-minute replay window (slack_verify.py),
+        # and returns 503 rather than serving anything when no signing secret is configured.
+        # Exactly one method on exactly one path: no prefix match, so nothing else rides in on it.
         return True
     return method in ("GET", "HEAD") and not (
         path.startswith("/api/") or path.startswith("/catalog") or path == "/query")
@@ -118,6 +133,11 @@ UI_DIST = _ui_dist()
 # /health reports `degraded` at or above this share of NAVFLOW_MAX_DB_SIZE. On the 0-100 scale of
 # /api/usage's pct_used, so 90 means 90% — not 0.9. Unknown (no limit configured) is never degraded.
 DEGRADED_PCT = float(os.getenv("NAVFLOW_DEGRADED_PCT", "90"))
+
+# How long a `/navflow ask` may think before Slack gets an apology instead of an answer. The user
+# is staring at a "…" in a channel, so this is deliberately much shorter than the agent's own
+# round budget would allow.
+SLACK_ASK_TIMEOUT = float(os.getenv("NAVFLOW_SLACK_ASK_TIMEOUT", "120"))
 
 
 def _serve_ui(path: str):
@@ -250,6 +270,10 @@ class AnthropicKeyIn(BaseModel):
 
 class SlackTokenIn(BaseModel):
     token: str  # same contract as AnthropicKeyIn: set a new one, or DELETE to clear
+
+
+class SlackSigningSecretIn(BaseModel):
+    secret: str  # the signing secret behind POST /api/slack/events; same write-only contract
 
 
 def make_app() -> FastAPI:
@@ -1345,6 +1369,165 @@ def make_app() -> FastAPI:
         store.set_setting(SLACK_TOKEN_SETTING, None)
         token, origin = resolve_slack_token(store)
         return {"ok": True, "configured": bool(token), "source": origin}
+
+    # ── the Slack signing secret: the credential that makes inbound Slack safe ──
+    # Same write-only contract as the bot token. Without it POST /api/slack/events answers 503:
+    # there is no configuration in which accepting an unverified inbound request is correct.
+    @app.get("/api/settings/slack-signing-secret")
+    async def get_slack_signing_secret():
+        secret, origin = slack_verify.resolve_secret(store)
+        return {"configured": bool(secret), "source": origin,
+                "stored": bool(store.get_setting(slack_verify.SETTING_KEY)),
+                "env_overrides": origin.startswith("env:")}
+
+    @app.put("/api/settings/slack-signing-secret")
+    async def set_slack_signing_secret(body: SlackSigningSecretIn):
+        secret = body.secret.strip()
+        if not secret:
+            _err(ValueError("secret is required (use DELETE to remove the stored secret)"))
+        if secret.startswith("xox"):
+            # A bot token pasted into the wrong box would look configured and fail every signature.
+            _err(ValueError("that is a bot token, not the signing secret — take the Signing Secret "
+                            "from the Slack app's Basic Information page"))
+        store.set_setting(slack_verify.SETTING_KEY, secret)
+        _, origin = slack_verify.resolve_secret(store)
+        return {"ok": True, "source": origin,
+                **({"note": "an environment secret takes precedence and is still in use"}
+                   if origin.startswith("env:") else {})}
+
+    @app.delete("/api/settings/slack-signing-secret")
+    async def clear_slack_signing_secret():
+        store.set_setting(slack_verify.SETTING_KEY, None)
+        secret, origin = slack_verify.resolve_secret(store)
+        return {"ok": True, "configured": bool(secret), "source": origin}
+
+    # ── inbound Slack: the /navflow slash command ───────────────────────────
+    # The only route in this daemon that is public to the auth middleware AND accepts a body from
+    # the internet, so it carries its own authentication: an HMAC over the raw bytes.
+    _ask_cap = slack_mod.AskCap()
+    _ask_tasks: set = set()      # keeps background tasks referenced; asyncio only holds weak refs
+
+    async def _slack_respond(response_url: str, body: dict) -> None:
+        """Deliver one message to Slack's `response_url`. Best-effort with a couple of retries: the
+        user is waiting, and there is nowhere else to put the answer if this fails."""
+        for attempt in range(3):
+            try:
+                async with httpx.AsyncClient(timeout=10) as cx:
+                    r = await cx.post(response_url, json=body)
+                if r.status_code < 400:
+                    return
+                if r.status_code < 500:
+                    print(f"navflowd: slack response_url rejected the answer: "
+                          f"HTTP {r.status_code} {r.text[:200]}", flush=True)
+                    return
+            except Exception as e:
+                print(f"navflowd: slack response_url failed: {type(e).__name__}: {e}", flush=True)
+            if attempt < 2:
+                await asyncio.sleep(1.0 * (attempt + 1))
+
+    async def _slack_answer(question: str, response_url: str, thread_ts: str | None) -> None:
+        """Run the Ask agent for one slash command and post the result. Never raises: this runs
+        detached from the request, so an exception here would otherwise be pure silence in Slack."""
+        from .agent import run_agent
+        text, error = "", None
+        try:
+            key = resolve_anthropic_key(store)[0]
+            self_headers = {"Authorization": f"Bearer {AUTH_TOKEN}"} if AUTH_TOKEN else {}
+            async def _run():
+                nonlocal text, error
+                async for chunk in run_agent(key, [{"role": "user", "content": question}],
+                                             "explore", None, self_headers):
+                    for line in chunk.splitlines():
+                        if not line.startswith("data: "):
+                            continue
+                        ev = json.loads(line[6:])
+                        if ev.get("type") == "text":
+                            text += ev.get("text") or ""
+                        elif ev.get("type") == "error":
+                            error = ev.get("detail") or "the assistant failed"
+            await asyncio.wait_for(_run(), timeout=SLACK_ASK_TIMEOUT)
+        except asyncio.TimeoutError:
+            error = f"that took longer than {SLACK_ASK_TIMEOUT}s — try a narrower question"
+        except Exception as e:   # noqa: BLE001 — every failure has to reach the user as words
+            error = f"{type(e).__name__}: {e}"
+        if text.strip():
+            # Partial output plus an error still beats an error alone; say both.
+            body = slack_mod.build_answer(question, text + (f"\n\n_{error}_" if error else ""),
+                                          thread_ts)
+        else:
+            body = slack_mod.build_error(
+                f":warning: {error or 'the assistant returned nothing to say'}", thread_ts)
+        await _slack_respond(response_url, body)
+
+    @app.post(SLACK_EVENTS_PATH, include_in_schema=False)
+    async def slack_events(request: Request):
+        """Slack's inbound endpoint: the URL-verification handshake and `/navflow ask …`.
+
+        Two contracts shape this whole handler:
+
+        · **The signature covers the RAW body.** Read `await request.body()` and parse afterwards —
+          letting FastAPI decode and re-serialise changes the bytes and every HMAC fails.
+        · **Slack allows 3 seconds to ACK.** A model call cannot make that, so anything that has to
+          think ACKs immediately and posts the answer to `response_url` from a background task.
+          Anything we already know (usage, no key, over the cap) is answered in the ACK itself.
+        """
+        raw = await request.body()
+        secret, _origin = slack_verify.resolve_secret(store)
+        if not secret:
+            # Never "accept and hope". Refusing to serve is the only safe failure here.
+            return JSONResponse({"detail": "Slack is not configured on this instance: set "
+                                           f"{slack_verify.ENV_VAR} (or add the signing secret "
+                                           "under Security) and try again"}, status_code=503)
+        if (why := slack_verify.check(request.headers, raw, secret)) is not None:
+            # The reason goes to the operator's log, not to the caller: telling a forger which part
+            # of their forgery failed is free help.
+            print(f"navflowd: rejected an inbound Slack request ({why})", flush=True)
+            return JSONResponse({"detail": "invalid Slack signature"}, status_code=401)
+
+        ctype = request.headers.get("content-type", "")
+        if "json" in ctype:
+            try:
+                body = json.loads(raw or b"{}")
+            except ValueError:
+                return JSONResponse({"detail": "malformed JSON"}, status_code=400)
+            if body.get("type") == "url_verification":
+                # Without this the Slack app can never be pointed at this daemon at all.
+                return {"challenge": body.get("challenge", "")}
+            # Event subscriptions are out of scope (slash command only) — ACK so Slack doesn't
+            # retry, and say nothing.
+            return {"ok": True}
+
+        form = {k: v[0] for k, v in parse_qs(raw.decode("utf-8", "replace")).items()}
+        response_url = (form.get("response_url") or "").strip()
+        thread_ts = (form.get("thread_ts") or "").strip() or None
+        question, problem = slack_mod.parse_command(form.get("text", ""))
+        if problem:
+            return slack_mod.build_error(problem, thread_ts)
+        if not response_url:
+            return slack_mod.build_error(
+                ":warning: that request carried no response_url — NavFlow has nowhere to reply",
+                thread_ts)
+        if not resolve_anthropic_key(store)[0]:
+            return slack_mod.build_error(
+                ":warning: no Anthropic API key is configured on this NavFlow instance — set "
+                "`ANTHROPIC_API_KEY` or add one under Security in the console", thread_ts)
+        if not runtime.catalog.sources:
+            return slack_mod.build_error(
+                ":warning: this NavFlow instance has no sources configured yet, so there is "
+                "nothing to ask about", thread_ts)
+        if not _ask_cap.take(form.get("team_id", ""), form.get("user_id", "")):
+            return slack_mod.build_error(
+                f":warning: you've hit the cap of {_ask_cap.cap} NavFlow questions in 24h "
+                "(NAVFLOW_SLACK_DAILY_CAP)", thread_ts)
+
+        task = asyncio.create_task(_slack_answer(question, response_url, thread_ts))
+        _ask_tasks.add(task)
+        task.add_done_callback(_ask_tasks.discard)
+        # The ACK Slack shows while we think; the answer replaces it via response_url.
+        ack = {"response_type": "ephemeral", "text": ":hourglass_flowing_sand: asking NavFlow…"}
+        if thread_ts:
+            ack["thread_ts"] = thread_ts
+        return ack
 
     # ── management API: activity (what agents saw / what woke them) ──────────
     @app.get("/api/activity/queries")

--- a/navflow/slack.py
+++ b/navflow/slack.py
@@ -1,4 +1,9 @@
-"""Slack as a dispatch sink — resolve the bot token, format the message, post it.
+"""Slack — the bot token, the outbound message, and the `/navflow` slash command's replies.
+
+Outbound (the dispatch sink): resolve the bot token, format a firing as Block Kit, post it.
+Inbound (the slash command): parse `/navflow ask …`, bound its cost, and format the answer that
+goes back to Slack's `response_url`. Signature verification lives next door in `slack_verify.py`
+— it is the security boundary and is kept separately reviewable.
 
 This is the *generic* half of NavFlow's Slack support: a bot token that an operator configures
 (env or console) and one `chat.postMessage` call. Nothing here knows about OAuth or hosted
@@ -16,6 +21,9 @@ as a timeout rather than as "invalid_auth".
 from __future__ import annotations
 
 import os
+import re
+import time
+from collections import deque
 
 API_BASE = os.getenv("NAVFLOW_SLACK_API_BASE", "https://slack.com/api").rstrip("/")
 SETTING_KEY = "slack_bot_token"
@@ -122,3 +130,120 @@ def _error_detail(err: str, data: dict) -> str:
     if not hint and err == "missing_scope" and data.get("needed"):
         hint = f"needs scope {data['needed']}"
     return f" ({hint})" if hint else ""
+
+
+# ── inbound: the /navflow slash command ─────────────────────────────────────
+# Everything below serves `POST /api/slack/events`. It is deliberately pure — parsing, cost
+# bounding and message shaping — so the endpoint itself is only plumbing: verify, ACK, answer.
+
+USAGE = ("usage: `/navflow ask <question>` — e.g. "
+         "`/navflow ask what happened to checkout-svc in the last hour?`")
+
+# Cost ceiling, the same shape as `builtin_agents.DAILY_RUN_CAP`: a per-day count with an env
+# override, so one enthusiastic channel cannot run up an unbounded model bill. Counted per
+# (team, user) rather than per workspace — one person's loop must not lock out their colleagues.
+DAILY_ASK_CAP = int(os.getenv("NAVFLOW_SLACK_DAILY_CAP", "50"))
+
+
+class AskCap:
+    """A rolling 24h cap per (team, user).
+
+    Held in memory rather than in a table: unlike an agent run there is nothing to show in the
+    console for an ask, and a restart resetting the counter is an acceptable cost bound — the
+    ceiling exists to stop a runaway loop, not to bill anyone. Same knob shape as DAILY_RUN_CAP.
+    """
+
+    def __init__(self, cap: int = DAILY_ASK_CAP, window: float = 86400.0):
+        self.cap, self.window, self._seen = cap, window, {}
+
+    def take(self, team: str, user: str, now: float | None = None) -> bool:
+        """Record one ask; False when this user is already at the cap (nothing is recorded then)."""
+        now = time.time() if now is None else now
+        q = self._seen.setdefault((team or "-", user or "-"), deque())
+        while q and now - q[0] > self.window:
+            q.popleft()
+        if len(q) >= self.cap:
+            return False
+        q.append(now)
+        return True
+
+
+def parse_command(text: str) -> tuple[str, str | None]:
+    """`(question, error)` for the `text` of a `/navflow` slash command.
+
+    `/navflow ask <question>` is the documented form. A bare `/navflow <question>` is accepted as
+    the same thing — forgetting the subcommand is the overwhelmingly likely mistake, and answering
+    it beats a lecture. Empty, or `help`, gets the usage line; nothing gets a stack trace.
+    """
+    text = (text or "").strip()
+    if not text or text.lower() in ("help", "-h", "--help", "?"):
+        return "", USAGE
+    head, _, rest = text.partition(" ")
+    if head.lower() == "ask":
+        rest = rest.strip()
+        return (rest, None) if rest else ("", f"ask what? {USAGE}")
+    return text, None
+
+
+_MD_LINK = re.compile(r"\[([^\]]+)\]\((https?://[^)\s]+)\)")
+_MD_BOLD = re.compile(r"\*\*(.+?)\*\*", re.S)
+_MD_HEAD = re.compile(r"^#{1,6}\s*(.+)$", re.M)
+
+
+def to_mrkdwn(text: str) -> str:
+    """Markdown (what the model writes) → Slack mrkdwn (what Slack renders).
+
+    Only the three differences that actually show up as noise in a channel: `**bold**` is literal
+    asterisks in Slack, `[a](b)` is literal brackets, and `## heading` is a literal hash.
+    """
+    text = _MD_LINK.sub(r"<\2|\1>", text or "")
+    text = _MD_BOLD.sub(r"*\1*", text)
+    return _MD_HEAD.sub(r"*\1*", text)
+
+
+def _sections(text: str) -> list[dict]:
+    """Split a long answer across section blocks — one section caps at 3000 characters, and an
+    over-long block makes Slack reject the whole message (`invalid_blocks`) rather than truncate."""
+    out, buf = [], to_mrkdwn(text).strip()
+    while buf:
+        chunk, buf = buf[:_MAX_SECTION], buf[_MAX_SECTION:]
+        if buf:                       # prefer a line boundary so we don't cut mid-sentence
+            cut = chunk.rfind("\n")
+            if cut > _MAX_SECTION // 2:
+                chunk, buf = chunk[:cut], chunk[cut + 1:] + buf
+        out.append({"type": "section", "text": {"type": "mrkdwn", "text": chunk}})
+    return out or [{"type": "section", "text": {"type": "mrkdwn", "text": "_(no answer)_"}}]
+
+
+def build_answer(question: str, answer: str, thread_ts: str | None = None,
+                 in_channel: bool = True) -> dict:
+    """The `response_url` body carrying an answer back to Slack.
+
+    `replace_original` clears the "thinking…" ACK so a channel is left with the answer alone, and
+    `text` is always set for the notification and for clients that can't render blocks.
+    """
+    blocks = [{"type": "context", "elements": [
+        {"type": "mrkdwn", "text": f":mag: *{to_mrkdwn(question)[:180]}*"}]}]
+    blocks += _sections(answer)
+    body = {"response_type": "in_channel" if in_channel else "ephemeral",
+            "replace_original": True,
+            "text": _truncate(answer.strip() or "(no answer)", 500),
+            "blocks": blocks}
+    if thread_ts:
+        # Invoked inside a thread: the answer belongs in that thread, not adrift in the channel.
+        body["thread_ts"] = thread_ts
+    return body
+
+
+def build_error(message: str, thread_ts: str | None = None) -> dict:
+    """A failure the user can act on, ephemeral so a broken setup isn't broadcast to the channel.
+
+    Every failure mode goes through here. A slash command that answers with silence is
+    indistinguishable from an app that is down, which is the worst outcome of all.
+    """
+    body = {"response_type": "ephemeral", "replace_original": True,
+            "text": message,
+            "blocks": [{"type": "section", "text": {"type": "mrkdwn", "text": message}}]}
+    if thread_ts:
+        body["thread_ts"] = thread_ts
+    return body

--- a/navflow/slack_verify.py
+++ b/navflow/slack_verify.py
@@ -1,0 +1,97 @@
+"""Slack request signing — the *only* thing standing between the public internet and this daemon's
+inbound Slack endpoint.
+
+Kept in its own module on purpose: it is the one piece of NavFlow that is pure, security-critical
+and directly unit-testable, and it should be readable end to end without the daemon around it
+(tests/test_slack_verify.py drives it with known-good, tampered and replayed vectors).
+
+The scheme, per Slack:
+
+    basestring = "v0:" + X-Slack-Request-Timestamp + ":" + <raw request body>
+    X-Slack-Signature = "v0=" + hex(HMAC_SHA256(signing_secret, basestring))
+
+Three details decide whether this is real protection or theatre:
+
+1. **Raw bytes.** The HMAC covers the body exactly as sent. Parsing a form or JSON and
+   re-serialising it changes bytes (ordering, escaping, `+` vs `%20`) and every signature fails —
+   or worse, someone "fixes" that by loosening the check. Callers MUST hand us
+   `await request.body()` and parse afterwards.
+2. **`hmac.compare_digest`.** A `==` on the hex digest leaks the position of the first wrong byte
+   through timing; the digest is attacker-influenced, so that is a real oracle.
+3. **The timestamp window.** A signature stays valid forever, so without a freshness bound a
+   captured request can be replayed indefinitely. Slack's own guidance is five minutes; a request
+   from the future is rejected on the same rule (a clock far enough ahead would otherwise widen the
+   window arbitrarily).
+
+There is deliberately no "skip verification" switch. The endpoint's answer when no secret is
+configured is 503 — refusing to serve is a safe failure, accepting unverified requests is not.
+"""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import os
+import time
+
+ENV_VAR = "NAVFLOW_SLACK_SIGNING_SECRET"
+SETTING_KEY = "slack_signing_secret"
+
+VERSION = "v0"
+MAX_AGE_SECONDS = 300          # Slack's recommended replay window: 5 minutes
+
+TS_HEADER = "x-slack-request-timestamp"
+SIG_HEADER = "x-slack-signature"
+
+
+def resolve_secret(store) -> tuple[str, str]:
+    """(secret, where-it-came-from). Same env-wins rule as the bot token and the Anthropic key: an
+    operator's deployment config is never silently overridden by something typed into the console
+    months earlier."""
+    val = os.getenv(ENV_VAR, "").strip()
+    if val:
+        return val, f"env:{ENV_VAR}"
+    stored = ((store.get_setting(SETTING_KEY) or "") if store is not None else "").strip()
+    return (stored, "console") if stored else ("", "")
+
+
+def sign(timestamp: str, raw_body: bytes, signing_secret: str) -> str:
+    """The `v0=…` signature Slack would send for this exact body. Used by the verifier and by the
+    tests to build known-good vectors — one implementation, so a test can never pass against a
+    formula the server doesn't actually use."""
+    base = f"{VERSION}:{timestamp}:".encode() + (raw_body or b"")
+    digest = hmac.new(signing_secret.encode(), base, hashlib.sha256).hexdigest()
+    return f"{VERSION}={digest}"
+
+
+def check(headers, raw_body: bytes, signing_secret: str, now: float | None = None) -> str | None:
+    """None when the request is authentic, otherwise a short reason.
+
+    The reason is for the daemon's log, never for the response body: telling a caller *why* their
+    forgery failed helps only the forger. `headers` is any case-insensitive mapping (Starlette's
+    `request.headers`) or a plain dict with lowercase keys.
+    """
+    if not signing_secret:
+        # Caller error, not attacker error: the endpoint must 503 before it ever gets here.
+        return "no signing secret configured"
+    get = headers.get
+    ts = (get(TS_HEADER) or get(TS_HEADER.title()) or "").strip()
+    sig = (get(SIG_HEADER) or get(SIG_HEADER.title()) or "").strip()
+    if not ts or not sig:
+        return "missing signature headers"
+    try:
+        ts_val = float(ts)
+    except ValueError:
+        return "malformed timestamp"
+    age = (time.time() if now is None else now) - ts_val
+    if abs(age) > MAX_AGE_SECONDS:
+        # Both directions: stale (a replay) and far-future (a skewed or lying clock).
+        return f"timestamp outside the {MAX_AGE_SECONDS}s window ({int(age)}s)"
+    if not hmac.compare_digest(sign(ts, raw_body, signing_secret), sig):
+        return "signature mismatch"
+    return None
+
+
+def verify(headers, raw_body: bytes, signing_secret: str, now: float | None = None) -> bool:
+    """True iff this request was signed by the holder of `signing_secret` within the replay
+    window. Thin boolean over `check`, which carries the reason for logging."""
+    return check(headers, raw_body, signing_secret, now) is None

--- a/tests/test_slack_ask.py
+++ b/tests/test_slack_ask.py
@@ -1,0 +1,356 @@
+"""The inbound half of Slack: `POST /api/slack/events` and the `/navflow ask …` slash command.
+
+End to end against a real daemon, a stub Anthropic endpoint (streaming, because the Ask path
+streams) and a stub `response_url` standing in for Slack's reply hook.
+
+The three contracts this endpoint lives or dies by are each asserted directly:
+
+· **Signatures.** It is the only route public to the auth middleware that takes a body from the
+  internet. A tampered body, a forged signature, a stale timestamp and a missing signature are all
+  401 — and crucially the model is never called for any of them. With no signing secret configured
+  it is 503, never 200.
+· **Slack's 3-second ACK.** The command answers immediately and the model's answer arrives later
+  on `response_url`, in-thread when the command came from a thread.
+· **Never silence.** No Anthropic key, or hitting the daily cap, comes back as words a user can
+  act on.
+
+The HMAC here is computed independently of `navflow.slack_verify` (its own vectors live in
+tests/test_slack_verify.py) — the server and the test must agree on the wire format, not on an
+implementation.
+"""
+import asyncio, hashlib, hmac, json, os, signal, subprocess, sys, threading, time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import urlencode
+
+import httpx
+
+P = F = 0
+def ck(l, c, d=""):
+    global P, F; P += 1 if c else 0; F += 0 if c else 1
+    print(("  ok   " if c else "  FAIL ") + l + ("" if c else f"  {d}"))
+
+SEED = "/tmp/slack_ask_catalog.yaml"
+with open(SEED, "w") as fh:
+    fh.write(
+        "sources:\n  - name: evt\n    connector: webhook\n    poll: 5s\n"
+        "    config:\n      labels:\n        - name: service\n          field: service\n"
+        "          primary: true\n"
+        "views:\n  - name: svc\n    key_field: service\n    sources: [evt]\n")
+
+DB, PORT, STUB_PORT = "/tmp/slack_ask.duckdb", "8814", "8815"
+SECRET = "test-signing-secret-0123456789"   # gitleaks:allow — a test fixture, not a credential
+WRONG_SECRET = "not-the-signing-secret"
+AUTH = "test-auth-token"
+ANSWER = "**checkout-svc** logged 42 errors after the 14:02 deploy. See [the timeline](https://x/y)."
+B = f"http://127.0.0.1:{PORT}"
+RESPONSE_URL = f"http://127.0.0.1:{STUB_PORT}/response"
+
+MODEL_CALLS: list = []
+REPLIES: list = []
+
+
+class Stub(BaseHTTPRequestHandler):
+    """/v1/messages — the Anthropic streaming API the Ask path talks to.
+    /response      — Slack's response_url, where the answer must land."""
+
+    def do_POST(self):
+        raw = self.rfile.read(int(self.headers.get("content-length") or 0))
+        if self.path.startswith("/response"):
+            REPLIES.append(json.loads(raw))
+            return self._send(b'{"ok":true}', "application/json")
+        MODEL_CALLS.append(json.loads(raw or b"{}"))
+        self._send(_sse_answer(), "text/event-stream")
+
+    def _send(self, raw: bytes, ctype: str):
+        self.send_response(200)
+        self.send_header("content-type", ctype)
+        self.send_header("content-length", str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
+
+    def log_message(self, *a):
+        pass
+
+
+def _sse_answer() -> bytes:
+    """One text-only assistant turn as Anthropic server-sent events."""
+    ev = [
+        ("message_start", {"type": "message_start", "message": {
+            "id": "msg_1", "type": "message", "role": "assistant", "model": "claude-sonnet-4-6",
+            "content": [], "stop_reason": None, "stop_sequence": None,
+            "usage": {"input_tokens": 10, "output_tokens": 1}}}),
+        ("content_block_start", {"type": "content_block_start", "index": 0,
+                                 "content_block": {"type": "text", "text": ""}}),
+        ("content_block_delta", {"type": "content_block_delta", "index": 0,
+                                 "delta": {"type": "text_delta", "text": ANSWER}}),
+        ("content_block_stop", {"type": "content_block_stop", "index": 0}),
+        ("message_delta", {"type": "message_delta",
+                           "delta": {"stop_reason": "end_turn", "stop_sequence": None},
+                           "usage": {"output_tokens": 20}}),
+        ("message_stop", {"type": "message_stop"}),
+    ]
+    return "".join(f"event: {n}\ndata: {json.dumps(d)}\n\n" for n, d in ev).encode()
+
+
+# ── signing, computed here rather than imported: the wire format is the contract ──
+def sign(ts: str, body: bytes, secret: str = SECRET) -> str:
+    base = f"v0:{ts}:".encode() + body
+    return "v0=" + hmac.new(secret.encode(), base, hashlib.sha256).hexdigest()
+
+
+def signed_headers(body: bytes, ctype: str, ts: str | None = None, secret: str = SECRET,
+                   sig: str | None = None) -> dict:
+    ts = ts or str(int(time.time()))
+    return {"content-type": ctype, "x-slack-request-timestamp": ts,
+            "x-slack-signature": sig or sign(ts, body, secret)}
+
+
+def command_body(text: str, user: str = "U1", thread_ts: str | None = None,
+                 response_url: str = RESPONSE_URL) -> bytes:
+    form = {"token": "deprecated", "team_id": "T1", "user_id": user, "channel_id": "C1",
+            "command": "/navflow", "text": text, "response_url": response_url}
+    if thread_ts:
+        form["thread_ts"] = thread_ts
+    return urlencode(form).encode()
+
+
+async def post_raw(cx, body: bytes, headers: dict, url: str = f"{B}/api/slack/events"):
+    return await cx.post(url, content=body, headers=headers)
+
+
+async def slash(cx, text, **kw):
+    body = command_body(text, **{k: v for k, v in kw.items() if k in ("user", "thread_ts", "response_url")})
+    return await post_raw(cx, body, signed_headers(body, "application/x-www-form-urlencoded"))
+
+
+async def _wait(url, tries=80):
+    for _ in range(tries):
+        try:
+            async with httpx.AsyncClient() as cx:
+                if (await cx.get(url, timeout=1)).status_code == 200:
+                    return True
+        except Exception:
+            pass
+        await asyncio.sleep(0.25)
+    return False
+
+
+async def _until(fn, tries=60):
+    for _ in range(tries):
+        if fn():
+            return True
+        await asyncio.sleep(0.5)
+    return False
+
+
+def _spawn(env):
+    return subprocess.Popen([sys.executable, "-c", "from navflow.cli import run_daemon; run_daemon()"],
+                            env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+
+def _stop(proc):
+    proc.send_signal(signal.SIGTERM)
+    try: proc.wait(timeout=5)
+    except Exception: proc.kill()
+
+
+async def main():
+    for p in (DB, DB + ".wal"):
+        if os.path.exists(p):
+            os.remove(p)
+
+    stub = ThreadingHTTPServer(("127.0.0.1", int(STUB_PORT)), Stub)
+    threading.Thread(target=stub.serve_forever, daemon=True).start()
+
+    base_env = {**os.environ, "NAVFLOW_DB": DB, "NAVFLOW_CATALOG": SEED, "NAVFLOW_PORT": PORT,
+                "NAVFLOW_OTLP_GRPC_PORT": "off",
+                "ANTHROPIC_BASE_URL": f"http://127.0.0.1:{STUB_PORT}"}
+    for k in ("NAVFLOW_SLACK_SIGNING_SECRET", "NAVFLOW_AUTH_TOKEN", "ANTHROPIC_API_KEY"):
+        base_env.pop(k, None)
+
+    # ── phase 1: no signing secret configured — 503, never 200 ──────────────
+    # An unverifiable request must not be served at all. This is the failure mode that would
+    # silently turn the endpoint into an open, unauthenticated command runner.
+    proc = _spawn(base_env)
+    try:
+        if not await _wait(f"{B}/health"):
+            ck("daemon up (phase 1)", False); return
+        async with httpx.AsyncClient(timeout=20) as cx:
+            st = (await cx.get(f"{B}/api/settings/slack-signing-secret")).json()
+            ck("no signing secret configured to start with", st["configured"] is False, str(st))
+
+            body = command_body("ask anything")
+            r = await post_raw(cx, body, signed_headers(body, "application/x-www-form-urlencoded"))
+            ck("a correctly signed command with no secret configured -> 503",
+               r.status_code == 503, f"{r.status_code} {r.text[:200]}")
+            ck("...and says how to configure it", "SIGNING_SECRET" in r.text, r.text[:200])
+            r = await post_raw(cx, body, {"content-type": "application/x-www-form-urlencoded"})
+            ck("an unsigned request with no secret configured -> 503 (not 200)",
+               r.status_code == 503, str(r.status_code))
+            ck("nothing was executed", not MODEL_CALLS, str(MODEL_CALLS)[:200])
+
+            # the secret is a credential: write-only, exactly like the bot token
+            r = await cx.put(f"{B}/api/settings/slack-signing-secret", json={"secret": "xoxb-nope"})
+            ck("a bot token pasted as the signing secret is rejected", r.status_code == 400, r.text[:200])
+            r = await cx.put(f"{B}/api/settings/slack-signing-secret", json={"secret": "stored-secret"})
+            ck("PUT signing secret -> 200", r.status_code == 200, r.text)
+            ck("PUT never echoes the secret", "stored-secret" not in r.text, r.text)
+            st = (await cx.get(f"{B}/api/settings/slack-signing-secret")).json()
+            ck("the secret is never returned", "stored-secret" not in json.dumps(st), str(st))
+            ck("reported configured from the console",
+               st["configured"] and st["source"] == "console", str(st))
+
+            body = command_body("ask anything")
+            r = await post_raw(cx, body, signed_headers(body, "application/x-www-form-urlencoded",
+                                                        secret="stored-secret"))
+            ck("a command signed with the STORED secret is accepted", r.status_code == 200,
+               f"{r.status_code} {r.text[:200]}")
+            r = await cx.delete(f"{B}/api/settings/slack-signing-secret")
+            ck("DELETE clears the stored secret", r.status_code == 200, r.text)
+    finally:
+        _stop(proc)
+    REPLIES.clear(); MODEL_CALLS.clear()
+
+    # ── phase 2: signed, keyed, capped ──────────────────────────────────────
+    env2 = {**base_env, "NAVFLOW_SLACK_SIGNING_SECRET": SECRET, "ANTHROPIC_API_KEY": "sk-test",
+            "NAVFLOW_SLACK_DAILY_CAP": "2"}
+    proc = _spawn(env2)
+    try:
+        if not await _wait(f"{B}/health"):
+            ck("daemon up (phase 2)", False); return
+        async with httpx.AsyncClient(timeout=30) as cx:
+            st = (await cx.get(f"{B}/api/settings/slack-signing-secret")).json()
+            ck("the environment beats the stored secret",
+               st["source"] == "env:NAVFLOW_SLACK_SIGNING_SECRET" and st["env_overrides"] is True,
+               str(st))
+
+            # ── the handshake, without which the app can never be configured ──
+            hs = json.dumps({"type": "url_verification", "challenge": "abc123", "token": "x"}).encode()
+            r = await post_raw(cx, hs, signed_headers(hs, "application/json"))
+            ck("url_verification handshake -> 200", r.status_code == 200, r.text[:200])
+            ck("...echoes the challenge", r.json().get("challenge") == "abc123", r.text[:200])
+            r = await post_raw(cx, hs, {"content-type": "application/json"})
+            ck("an UNSIGNED handshake is rejected", r.status_code == 401, str(r.status_code))
+
+            # ── the negative cases: nothing runs, nothing leaks ──────────────
+            good = command_body("ask what happened to checkout-svc")
+            hdr = signed_headers(good, "application/x-www-form-urlencoded")
+
+            r = await post_raw(cx, command_body("ask something else"), hdr)
+            ck("a tampered body is rejected (401)", r.status_code == 401, str(r.status_code))
+            r = await post_raw(cx, good, {**hdr, "x-slack-signature": "v0=" + "0" * 64})
+            ck("a forged signature is rejected (401)", r.status_code == 401, str(r.status_code))
+            r = await post_raw(cx, good, signed_headers(good, "application/x-www-form-urlencoded",
+                                                        secret=WRONG_SECRET))
+            ck("a signature from the wrong secret is rejected (401)", r.status_code == 401,
+               str(r.status_code))
+            stale = str(int(time.time()) - 600)
+            r = await post_raw(cx, good, signed_headers(good, "application/x-www-form-urlencoded",
+                                                        ts=stale))
+            ck("a replayed request (10 min old) is rejected (401)", r.status_code == 401,
+               str(r.status_code))
+            r = await post_raw(cx, good, {"content-type": "application/x-www-form-urlencoded"})
+            ck("an unsigned request is rejected (401)", r.status_code == 401, str(r.status_code))
+            ck("the rejection does not explain itself to the caller",
+               "signature" in r.text and "timestamp" not in r.text, r.text[:200])
+            ck("no rejected request reached the model", not MODEL_CALLS, str(MODEL_CALLS)[:200])
+            ck("no rejected request produced a Slack reply", not REPLIES, str(REPLIES)[:200])
+
+            # ── usage: a malformed command is a message, not a stack trace ───
+            r = await slash(cx, "")
+            ck("an empty command -> 200 with usage", r.status_code == 200 and "usage" in r.text,
+               r.text[:200])
+            ck("...ephemeral, so it isn't broadcast to the channel",
+               r.json().get("response_type") == "ephemeral", r.text[:200])
+            ck("an empty command never calls the model", not MODEL_CALLS, str(MODEL_CALLS)[:200])
+            r = await slash(cx, "ask")
+            ck("`/navflow ask` with no question -> usage", "ask what?" in r.text, r.text[:200])
+
+            # ── the happy path: ACK inside Slack's 3s, answer via response_url ──
+            t0 = time.monotonic()
+            r = await slash(cx, "ask what happened to checkout-svc")
+            ack_ms = (time.monotonic() - t0) * 1000
+            ck("a valid command ACKs 200", r.status_code == 200, f"{r.status_code} {r.text[:200]}")
+            ck(f"...well inside Slack's 3s deadline ({ack_ms:.0f}ms)", ack_ms < 3000, f"{ack_ms:.0f}ms")
+            ck("...with something for the user to look at while it thinks",
+               bool(r.json().get("text")), r.text[:200])
+
+            ck("the answer arrives on response_url", await _until(lambda: bool(REPLIES)),
+               "nothing posted to response_url")
+            rep = REPLIES[0] if REPLIES else {}
+            ck("the answer is posted in-channel", rep.get("response_type") == "in_channel", str(rep)[:200])
+            ck("the answer replaces the thinking ACK", rep.get("replace_original") is True, str(rep)[:200])
+            ck("the answer carries the model's text", "checkout-svc" in json.dumps(rep), str(rep)[:300])
+            ck("the answer is Block Kit", bool(rep.get("blocks")), str(rep)[:200])
+            ck("...with a plain-text fallback for the notification", bool(rep.get("text")), str(rep)[:200])
+            blocks = json.dumps(rep.get("blocks") or [])
+            ck("markdown is converted to Slack mrkdwn (no ** or [](), no stray hashes)",
+               "**" not in blocks and "](" not in blocks and "<https://x/y|the timeline>" in blocks,
+               blocks[:300])
+            ck("the question is echoed with the answer", "checkout-svc" in blocks, blocks[:200])
+            ck("a reply outside a thread carries no thread_ts", "thread_ts" not in rep, str(rep)[:200])
+            ck("the model was asked exactly once", len(MODEL_CALLS) == 1, str(len(MODEL_CALLS)))
+            ck("the question reached the model",
+               "checkout-svc" in json.dumps(MODEL_CALLS[0].get("messages", [])),
+               str(MODEL_CALLS[:1])[:300])
+
+            # ── in a thread, the answer belongs in that thread ───────────────
+            REPLIES.clear()
+            r = await slash(cx, "ask what happened to checkout-svc", thread_ts="1700000000.000100")
+            ck("a threaded command ACKs 200", r.status_code == 200, r.text[:200])
+            ck("the threaded answer arrives", await _until(lambda: bool(REPLIES)), "no reply")
+            rep = REPLIES[0] if REPLIES else {}
+            ck("...in the thread it was asked in", rep.get("thread_ts") == "1700000000.000100",
+               str(rep)[:200])
+
+            # ── the cost cap (NAVFLOW_SLACK_DAILY_CAP=2 for this daemon) ─────
+            REPLIES.clear()
+            before = len(MODEL_CALLS)
+            r = await slash(cx, "ask a third question")
+            ck("over the daily cap -> 200 with a readable message",
+               r.status_code == 200 and "cap" in r.text.lower(), r.text[:200])
+            ck("...ephemeral", r.json().get("response_type") == "ephemeral", r.text[:200])
+            await asyncio.sleep(1)
+            ck("a capped command never calls the model", len(MODEL_CALLS) == before,
+               f"{len(MODEL_CALLS)} vs {before}")
+            r = await slash(cx, "ask a question", user="U2")
+            ck("the cap is per user, not per workspace", "cap" not in r.text.lower(), r.text[:200])
+    finally:
+        _stop(proc)
+    REPLIES.clear(); MODEL_CALLS.clear()
+
+    # ── phase 3: auth on, no model key — reachable, and it says why it can't answer ──
+    env3 = {**base_env, "NAVFLOW_SLACK_SIGNING_SECRET": SECRET, "NAVFLOW_AUTH_TOKEN": AUTH}
+    proc = _spawn(env3)
+    try:
+        if not await _wait(f"{B}/health"):
+            ck("daemon up (phase 3)", False); return
+        async with httpx.AsyncClient(timeout=20) as cx:
+            r = await cx.get(f"{B}/api/sources")
+            ck("with auth on, an ordinary API call still needs a token", r.status_code == 401,
+               str(r.status_code))
+            r = await cx.get(f"{B}/api/slack/events")
+            ck("the Slack path is public for POST only — GET still needs a token",
+               r.status_code == 401, str(r.status_code))
+
+            r = await slash(cx, "ask what happened to checkout-svc")
+            ck("a signed slash command is reachable with auth on (no bearer token)",
+               r.status_code == 200, f"{r.status_code} {r.text[:200]}")
+            ck("no Anthropic key -> a readable message, not silence",
+               "Anthropic" in r.text and "warning" in r.text, r.text[:300])
+            ck("...and the model was never called", not MODEL_CALLS, str(MODEL_CALLS)[:200])
+
+            body = command_body("ask anything")
+            r = await post_raw(cx, body, {"content-type": "application/x-www-form-urlencoded",
+                                          "authorization": f"Bearer {AUTH}"})
+            ck("a valid bearer token is NOT a substitute for a signature",
+               r.status_code == 401, f"{r.status_code} {r.text[:200]}")
+    finally:
+        _stop(proc)
+        stub.shutdown()
+
+    print(f"\n{P} passed, {F} failed")
+    raise SystemExit(1 if F else 0)
+
+
+asyncio.run(main())

--- a/tests/test_slack_verify.py
+++ b/tests/test_slack_verify.py
@@ -1,0 +1,141 @@
+"""Slack request signing, in isolation.
+
+`slack_verify` is the security boundary for the only route in this daemon that is public to the
+auth middleware and accepts a body from the internet, so it is tested directly rather than only
+through the endpoint: known-good, tampered, replayed, forged, and every malformed shape an
+attacker controls. Nothing here starts a daemon — that is the point, these are vectors.
+
+The signature is computed against the RAW bytes, so the tests keep bytes throughout: a body that
+survives a JSON round-trip proves nothing about the case that actually breaks (re-serialisation).
+"""
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from navflow import slack_verify as sv
+
+P = F = 0
+def ck(l, c, d=""):
+    global P, F; P += 1 if c else 0; F += 0 if c else 1
+    print(("  ok   " if c else "  FAIL ") + l + ("" if c else f"  {d}"))
+
+
+# Slack's own published example signing secret (api.slack.com "Verifying requests from Slack").
+# Not a credential — it is the fixture that lets us check our HMAC against the spec rather than
+# against itself, so it has to stay verbatim.
+SECRET = "8f742231b10e8888abcd99yyyzzz85a5"   # gitleaks:allow
+OTHER = "8f742231b10e8888abcd99yyyzzz85a6"   # gitleaks:allow
+BODY = (b"token=xyzz0WbapA4vBCDEFasx0q6G&team_id=T1DC2JH3J&user_id=U2147483697"
+        b"&command=%2Fnavflow&text=ask+what+happened+to+checkout-svc"
+        b"&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2F1234%2F5678")
+
+
+def hdrs(ts, sig):
+    return {"x-slack-request-timestamp": str(ts), "x-slack-signature": sig}
+
+
+now = time.time()
+ts = str(int(now))
+good = sv.sign(ts, BODY, SECRET)
+
+# ── the known-good vector ───────────────────────────────────────────────────
+ck("a correctly signed request verifies", sv.verify(hdrs(ts, good), BODY, SECRET, now))
+ck("...and reports no reason", sv.check(hdrs(ts, good), BODY, SECRET, now) is None)
+ck("the signature is the v0= hex HMAC-SHA256 over v0:{ts}:{body}",
+   good.startswith("v0=") and len(good) == 67, good)
+
+# Slack's own published example, so this is checked against the spec and not just against itself.
+# (api.slack.com/authentication/verifying-requests-from-slack)
+SLACK_TS = "1531420618"
+SLACK_BODY = (b"token=xyzz0WbapA4vBCDEFasx0q6G&team_id=T1DC2JH3J&team_domain=testteamnow"
+              b"&channel_id=G8PSS9T3V&channel_name=foobar&user_id=U2CERLKJA&user_name=roadrunner"
+              b"&command=%2Fwebhook-collect&text=&response_url=https%3A%2F%2Fhooks.slack.com%2F"
+              b"commands%2FT1DC2JH3J%2F397700885554%2F96rGlfmibIGlgcZRskXaIFfN&trigger_id="
+              b"398738663015.47445629121.803a0bc887a14d10d2c447fce8b6703c")
+SLACK_SECRET = "8f742231b10e8888abcd99yyyzzz85a5"   # gitleaks:allow — see note above
+SLACK_SIG = "v0=a2114d57b48eac39b9ad189dd8316235a7b4a8d21a10bd27519666489c69b503"
+ck("matches Slack's published example vector",
+   sv.verify(hdrs(SLACK_TS, SLACK_SIG), SLACK_BODY, SLACK_SECRET, float(SLACK_TS) + 1),
+   sv.sign(SLACK_TS, SLACK_BODY, SLACK_SECRET))
+
+# ── tampering: the body is what the signature is FOR ────────────────────────
+tampered = BODY.replace(b"checkout-svc", b"payments-svc")
+ck("a tampered body is rejected", not sv.verify(hdrs(ts, good), tampered, SECRET, now))
+ck("...for the right reason", sv.check(hdrs(ts, good), tampered, SECRET, now) == "signature mismatch")
+ck("one flipped byte anywhere in the body is rejected",
+   not sv.verify(hdrs(ts, good), BODY + b" ", SECRET, now))
+ck("an empty body against a real signature is rejected",
+   not sv.verify(hdrs(ts, good), b"", SECRET, now))
+ck("re-serialising the body breaks it (why the endpoint must use raw bytes)",
+   not sv.verify(hdrs(ts, good), BODY.replace(b"+", b"%20"), SECRET, now))
+
+# ── forgery: a signature made with the wrong secret ─────────────────────────
+ck("a signature from another secret is rejected",
+   not sv.verify(hdrs(ts, sv.sign(ts, BODY, OTHER)), BODY, SECRET, now))
+ck("signing with the wrong secret produces a different signature",
+   sv.sign(ts, BODY, OTHER) != good)
+
+# ── replay: a valid signature stays valid forever without the time bound ────
+old = str(int(now - sv.MAX_AGE_SECONDS - 1))
+ck("a replayed request older than the window is rejected",
+   not sv.verify(hdrs(old, sv.sign(old, BODY, SECRET)), BODY, SECRET, now))
+ck("...and says the window is why",
+   "window" in (sv.check(hdrs(old, sv.sign(old, BODY, SECRET)), BODY, SECRET, now) or ""))
+edge = str(int(now - sv.MAX_AGE_SECONDS + 5))
+ck("a request just inside the window still verifies",
+   sv.verify(hdrs(edge, sv.sign(edge, BODY, SECRET)), BODY, SECRET, now))
+future = str(int(now + sv.MAX_AGE_SECONDS + 60))
+ck("a far-future timestamp is rejected too (a skewed clock can't widen the window)",
+   not sv.verify(hdrs(future, sv.sign(future, BODY, SECRET)), BODY, SECRET, now))
+ck("the replay window is Slack's recommended 5 minutes", sv.MAX_AGE_SECONDS == 300)
+
+# ── the timestamp is signed, so it cannot be moved forward ──────────────────
+ck("refreshing the timestamp of a captured request invalidates it",
+   not sv.verify(hdrs(ts, sv.sign(old, BODY, SECRET)), BODY, SECRET, now))
+
+# ── malformed input is a rejection, never an exception ──────────────────────
+for label, h in (("no headers at all", {}),
+                 ("no signature", {"x-slack-request-timestamp": ts}),
+                 ("no timestamp", {"x-slack-signature": good}),
+                 ("a non-numeric timestamp", hdrs("not-a-time", good)),
+                 ("an empty signature", hdrs(ts, "")),
+                 ("a signature with no v0= prefix", hdrs(ts, good[3:])),
+                 ("a truncated signature", hdrs(ts, good[:20])),
+                 ("a non-hex signature", hdrs(ts, "v0=" + "z" * 64))):
+    try:
+        ok = sv.verify(h, BODY, SECRET, now)
+    except Exception as e:
+        ok, label = True, f"{label} (raised {type(e).__name__})"
+    ck(f"rejected: {label}", not ok)
+
+# ── no secret is never a pass ───────────────────────────────────────────────
+ck("an empty signing secret rejects even a well-formed request",
+   not sv.verify(hdrs(ts, good), BODY, "", now))
+ck("...and says the secret is missing",
+   sv.check(hdrs(ts, good), BODY, "", now) == "no signing secret configured")
+
+# ── header lookup survives Slack's actual casing ────────────────────────────
+ck("headers are matched case-insensitively as sent (X-Slack-Signature)",
+   sv.verify({"X-Slack-Request-Timestamp": ts, "X-Slack-Signature": good}, BODY, SECRET, now))
+
+# ── secret resolution: env wins over the stored value ───────────────────────
+class FakeStore:
+    def __init__(self, v): self.v = v
+    def get_setting(self, k): return self.v if k == sv.SETTING_KEY else None
+
+
+os.environ.pop(sv.ENV_VAR, None)
+ck("with nothing configured, no secret resolves", sv.resolve_secret(FakeStore(None)) == ("", ""))
+ck("a stored secret resolves as console", sv.resolve_secret(FakeStore("stored")) == ("stored", "console"))
+os.environ[sv.ENV_VAR] = "from-env"
+ck("the environment beats the stored secret",
+   sv.resolve_secret(FakeStore("stored")) == ("from-env", f"env:{sv.ENV_VAR}"))
+os.environ[sv.ENV_VAR] = "   "
+ck("a blank env var does not shadow the stored secret",
+   sv.resolve_secret(FakeStore("stored")) == ("stored", "console"))
+os.environ.pop(sv.ENV_VAR, None)
+
+print(f"\n{P} passed, {F} failed")
+raise SystemExit(1 if F else 0)

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -172,6 +172,18 @@ export const api = {
     request<{ ok: boolean; configured: boolean }>("/api/settings/slack-bot-token",
       { method: "DELETE" }),
 
+  // The signing secret that authenticates inbound Slack (`/navflow ask …`). Write-only like the
+  // others; without it POST /api/slack/events answers 503 rather than trusting the request.
+  slackSigningSecretStatus: () =>
+    request<{ configured: boolean; source: string; stored: boolean; env_overrides: boolean }>(
+      "/api/settings/slack-signing-secret"),
+  setSlackSigningSecret: (secret: string) =>
+    request<{ ok: boolean; source: string; note?: string }>("/api/settings/slack-signing-secret",
+      { method: "PUT", body: JSON.stringify({ secret }) }),
+  clearSlackSigningSecret: () =>
+    request<{ ok: boolean; configured: boolean }>("/api/settings/slack-signing-secret",
+      { method: "DELETE" }),
+
   agents: () => request<{ agents: AgentInfo[] }>("/api/agents"),
   unsubscribe: (subscription_id: string) =>
     request<{ ok: boolean }>("/unsubscribe",

--- a/ui/src/pages/Security.tsx
+++ b/ui/src/pages/Security.tsx
@@ -10,7 +10,8 @@ import type { ApiKey } from "../types";
 //   · Access     — is this instance open, or does it require a login? (navflow up --auth)
 //   · API keys   — scoped, revocable, show-once credentials the operator mints for machines
 //   · Anthropic  — the model key NavFlow agents (and Ask) run on
-//   · Slack      — the bot token behind slack:// trigger subscriptions
+//   · Slack      — the bot token behind slack:// trigger subscriptions (outbound), and the
+//                  signing secret that authenticates the /navflow slash command (inbound)
 // The per-source ingest URL is an address, not a secret — it lives on the source page, not here.
 export default function Security() {
   return (
@@ -21,6 +22,7 @@ export default function Security() {
       <ApiKeysPanel />
       <AnthropicKeyPanel />
       <SlackTokenPanel />
+      <SlackSigningSecretPanel />
     </>
   );
 }
@@ -192,6 +194,81 @@ function SlackTokenPanel() {
               <button className="danger" disabled={busy} onClick={async () => {
                 setBusy(true);
                 try { await api.clearSlackToken(); await load(); }
+                catch (e) { setErr(String((e as Error).message ?? e)); }
+                setBusy(false);
+              }}>Clear stored</button>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+// The other half of Slack: the signing secret that authenticates requests coming IN. Same
+// write-only contract again, and the same panel shape — but this one is the security boundary for
+// the only route that is public to the auth middleware, so the copy says what happens without it.
+function SlackSigningSecretPanel() {
+  const [st, setSt] = useState<{ configured: boolean; source: string; stored: boolean; env_overrides: boolean }>();
+  const [secret, setSecret] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string>();
+  const [msg, setMsg] = useState<string>();
+
+  const load = () =>
+    api.slackSigningSecretStatus().then(setSt).catch((e) => setErr(String((e as Error).message ?? e)));
+  useEffect(() => { load(); }, []);
+
+  const save = async () => {
+    setBusy(true); setErr(undefined); setMsg(undefined);
+    try {
+      const r = await api.setSlackSigningSecret(secret.trim());
+      setSecret("");
+      setMsg(r.note ?? "✓ saved");
+      await load();
+    } catch (e) { setErr(String((e as Error).message ?? e)); }
+    setBusy(false);
+  };
+
+  return (
+    <div className="panel">
+      <h2 style={{ marginTop: 0 }}>Slack signing secret</h2>
+      <p className="help" style={{ marginTop: 0 }}>
+        Lets your team ask NavFlow from Slack: point the Slack app's <code>/navflow</code> slash
+        command at <code>/api/slack/events</code> on this instance and run{" "}
+        <code>/navflow ask what happened to checkout-svc?</code> in any channel. Paste the app's{" "}
+        <strong>Signing Secret</strong> (Basic Information) here, or set{" "}
+        <code>NAVFLOW_SLACK_SIGNING_SECRET</code>. Every inbound request is verified against it and
+        replays older than 5 minutes are refused; with no secret configured the endpoint answers
+        503 rather than trusting anything. The secret is never returned by the API.
+      </p>
+
+      {err && <div className="alert error">{err}</div>}
+      {msg && <p className="help">{msg}</p>}
+
+      {!st ? <div className="muted">loading…</div> : (
+        <>
+          <p style={{ margin: "0 0 10px" }}>
+            {st.configured
+              ? <><span className="badge ok">configured</span>{" "}
+                  <span className="help">from <span className="mono">{st.source}</span></span></>
+              : <><span className="badge">not configured</span>{" "}
+                  <span className="help">inbound Slack requests are refused until one is set</span></>}
+          </p>
+          {st.env_overrides && st.stored && (
+            <div className="alert">
+              A signing secret is set in the environment and takes precedence — the one stored here
+              is not in use. Remove the environment variable, or clear the stored secret.
+            </div>
+          )}
+          <div className="btnrow" style={{ alignItems: "center", maxWidth: 720 }}>
+            <input type="password" className="mono" style={{ flex: 1 }} placeholder="signing secret"
+                   value={secret} onChange={(e) => setSecret(e.target.value)} />
+            <button className="primary" disabled={busy || !secret.trim()} onClick={save}>Save</button>
+            {st.stored && (
+              <button className="danger" disabled={busy} onClick={async () => {
+                setBusy(true);
+                try { await api.clearSlackSigningSecret(); await load(); }
                 catch (e) { setErr(String((e as Error).message ?? e)); }
                 setBusy(false);
               }}>Clear stored</button>


### PR DESCRIPTION
The inbound half of Slack (NF-90, child 2 of NF-85): `/navflow ask <question>` answered in-channel, behind the first signature-verified inbound path this daemon has ever had.

## Signature verification — `navflow/slack_verify.py`

Its own module because it is the security boundary and should be reviewable on its own:

- `v0:{timestamp}:{raw_body}`, HMAC-SHA256 with the signing secret, `hmac.compare_digest` against `X-Slack-Signature`.
- Requests outside a 5-minute window are refused in **both** directions — a stale one is a replay, a far-future one is a clock that would otherwise widen the window arbitrarily.
- Operates on `await request.body()`. The endpoint reads raw bytes and parses afterwards; letting FastAPI decode and re-serialise changes the bytes and every HMAC fails.
- The secret comes from `NAVFLOW_SLACK_SIGNING_SECRET` or the `settings` table, env wins — the same contract as the bot token and the Anthropic key, write-only over the API.
- **No secret configured is 503, not 200.** There is no configuration in which accepting an unverified request is correct, and no switch to turn verification off.
- The rejection reason goes to the daemon's log, never to the caller.

## The endpoint — `POST /api/slack/events`

- Public to the auth middleware (`_public`) for **POST on exactly this path** — no prefix match, so nothing else rides in on it — with a comment saying why. `GET /api/slack/events` still requires a credential, and a valid bearer token is not a substitute for a signature.
- Handles the `url_verification` handshake by echoing `challenge`, so the Slack app can actually be configured.
- Honours the 3-second ACK: anything requiring a model ACKs immediately with an ephemeral "asking NavFlow…" and answers later on `response_url` from a background task (structurally what the agent-runner Worker does in `ctx.waitUntil`). Anything already known — usage, no Anthropic key, no sources, over the cap — is answered in the ACK itself.
- Reuses the existing Ask path (`agent.run_agent` + `resolve_anthropic_key(store)`), replies in-thread when `thread_ts` is present, and converts the model's markdown to Slack mrkdwn so a channel doesn't fill with `**` and `[](…)`.
- **No failure is silent.** Usage, no key, no sources, over the cap, a query error and a timeout each produce a short readable Slack message; a partial answer plus an error says both.
- Cost is bounded by `NAVFLOW_SLACK_DAILY_CAP` (default 50) per Slack team+user over a rolling 24h — the same knob shape as `DAILY_RUN_CAP`.

Console: a "Slack signing secret" panel next to the bot token on Security, same write-only contract.

## Verified

- `tests/test_slack_verify.py` — **32 passed**. Known-good, tampered body, re-serialised body, forged signature, wrong secret, replayed, refreshed timestamp on a captured body, far-future, eight malformed header shapes, empty secret, env-vs-stored resolution. Includes **Slack's own published example vector**, so the formula is checked against the spec and not just against itself.
- `tests/test_slack_ask.py` — **55 passed**. A real daemon, a stub Anthropic streaming endpoint and a stub `response_url`. Covers 503 with no secret (signed *and* unsigned); 401 for tampered / forged / wrong-secret / stale / unsigned, with the model never called and no Slack reply produced; the handshake (and an unsigned handshake refused); ACK in 2ms with the answer arriving in-channel as Block Kit; in-thread replies; the per-user cap; auth-on reachability alongside `GET /api/sources` still 401; and a bearer token failing to substitute for a signature.
- Regressions: `test_slack` 41 passed, `test_agents` 39 passed, `test_auth` 14 passed, `test_degraded` 21 passed. `cd ui && npx tsc --noEmit && npm run build` clean.

Both new tests are in the CI list.

## Out of scope

OAuth install (NF-91, cloud-side), interactive components / modals / `app_mention`, and retrofitting signature verification onto `/ingest/{token}` or the GitHub webhook. This assumes a hand-configured bot token and signing secret.
