### PR TITLE
OSS: show storage usage on the cell console

### DIFF
--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -4,7 +4,7 @@ import type {
   CatalogDescribe, CatalogList, ConnectorSpec, DiscoverProposal, DispatchDetail, DispatchLogEntry, Entity, EnvScan,
   AgentPreset, AgentRun, BuiltinAgent,
   LabelFacet, QueryLogEntry,
-  Source, SourceEvent, SourceFieldsProfile, Subscription, TestResult,
+  Source, SourceEvent, SourceFieldsProfile, Subscription, TestResult, Usage,
   TimelineEventRow, Trigger, View,
 } from "./types";
 
@@ -186,6 +186,10 @@ export const api = {
   dispatch: (id: string) => request<DispatchDetail>(`/api/activity/dispatches/${id}`),
   subscriptions: () => request<Subscription[]>("/api/subscriptions"),
   mcpTools: () => request<{ name: string; description: string }[]>("/api/mcp/tools"),
+
+  // What this instance is using on disk. `max_bytes`/`pct_used` are null unless the operator set
+  // NAVFLOW_MAX_DB_SIZE — see the Usage type before rendering any of it.
+  usage: () => request<Usage>("/api/usage"),
 
   catalog: () => request<CatalogList>("/catalog"),
   describe: (handle: string) => request<CatalogDescribe>(`/catalog/${handle}`),

--- a/ui/src/components/bits.tsx
+++ b/ui/src/components/bits.tsx
@@ -71,6 +71,19 @@ export function EmptyState({ children }: { children: React.ReactNode }) {
   return <div className="empty">{children}</div>;
 }
 
+/** Bytes as a human size, binary units ("2.4 GiB"). Null/undefined is *unknown*, not zero — the
+ *  metering API returns null for numbers it genuinely cannot know (no configured limit, a stat()
+ *  that failed), and rendering those as "0 B" would be a lie. */
+export function formatBytes(n: number | null | undefined): string {
+  if (n == null || !Number.isFinite(n)) return "—";
+  if (n < 1024) return `${Math.round(n)} B`;
+  const units = ["KiB", "MiB", "GiB", "TiB", "PiB"];
+  let v = n / 1024;
+  let i = 0;
+  while (v >= 1024 && i < units.length - 1) { v /= 1024; i += 1; }
+  return `${v >= 10 ? Math.round(v) : v.toFixed(1)} ${units[i]}`;
+}
+
 /** Input with styled suggestions — replaces native <datalist> (which can't be themed).
  *  Free text stays allowed; suggestions filter as you type. */
 export function Combo({ value, onChange, options, placeholder, style, className, hints, hintClass }: {

--- a/ui/src/pages/Sources.tsx
+++ b/ui/src/pages/Sources.tsx
@@ -3,7 +3,7 @@ import { Link, useNavigate } from "react-router-dom";
 
 import { api } from "../api";
 import { Search, Settings as SettingsIco } from "../components/icons";
-import { StatusBadge, TimeAgo, usePolling } from "../components/bits";
+import { ErrorState, StatusBadge, TimeAgo, formatBytes, usePolling } from "../components/bits";
 
 // Gear dropdown next to "Add source" — catalog import/export, each on its own page.
 function CatalogMenu() {
@@ -22,6 +22,85 @@ function CatalogMenu() {
             <Link className="menu-item" role="menuitem" to="/sources/export" onClick={() => setOpen(false)}>Export catalog</Link>
             <Link className="menu-item" role="menuitem" to="/sources/import" onClick={() => setOpen(false)}>Import catalog</Link>
           </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+// The console's answer to "how full is my database?" — asked *before* it breaks, not after.
+// Which story you get depends on whether an operator configured a cap (NAVFLOW_MAX_DB_SIZE; the
+// Helm chart sets it for hosted cells, a self-hosted install usually has not):
+//   · cap set  → the percentage of it, a bar, and a warning from 80% up. The daemon only flips
+//                /health to `degraded` at NAVFLOW_DEGRADED_PCT (90 by default); the console warns
+//                earlier, while there is still room to act.
+//   · no cap   → no percentage and no bar, because there is no denominator to measure against.
+//                Absolute size, with headroom taken from the free space on the volume instead.
+// pct_used is on a 0-100 scale, so the threshold is 80, not 0.8. Per-source bytes are deliberately
+// absent: DuckDB keeps every source in one events table and cannot attribute storage per source.
+function StoragePanel() {
+  const { data: u, error, reload } = usePolling(() => api.usage(), 30000);
+  const onDisk = u ? u.db_bytes + u.wal_bytes : 0;
+  // Both null together, but check the denominator: it is what makes a percentage meaningful.
+  const pct = u && u.max_bytes != null && u.pct_used != null ? u.pct_used : null;
+
+  return (
+    <div className="panel">
+      <h2 style={{ marginTop: 0 }}>Storage</h2>
+      <p className="help" style={{ marginTop: 0 }}>
+        What this instance is using on disk — the DuckDB file plus its write-ahead log. Nothing is
+        pruned today, so agent runs and dispatch deliveries grow with every firing.
+      </p>
+
+      {error && <ErrorState error={error} what="storage usage" onRetry={reload} />}
+      {!u && !error && <div className="muted">loading…</div>}
+
+      {u && (
+        <>
+          {pct !== null && pct >= 80 && (
+            <div className="alert warn">
+              <strong>Storage {pct}% full</strong> — {formatBytes(onDisk)} of the{" "}
+              {formatBytes(u.max_bytes)} limit for this instance. Ingest keeps working until it
+              runs out; free space or raise <code>NAVFLOW_MAX_DB_SIZE</code> before it does.
+            </div>
+          )}
+
+          <div className="cards" style={{ marginBottom: 12 }}>
+            <div className="card">
+              <div className="k">on disk</div>
+              <div className="v">
+                {formatBytes(onDisk)}{" "}
+                {/* the denominator is spelled out under the bar; the card just glances */}
+                {pct !== null && <small>{pct}%</small>}
+              </div>
+            </div>
+            <div className="card"><div className="k">events</div><div className="v">{u.events.toLocaleString()}</div></div>
+            <div className="card"><div className="k">agent runs</div><div className="v">{u.agent_runs.toLocaleString()}</div></div>
+            <div className="card"><div className="k">dispatch deliveries</div><div className="v">{u.dispatch_deliveries.toLocaleString()}</div></div>
+          </div>
+
+          {pct !== null ? (
+            <>
+              <div className="usage-bar" aria-hidden="true">
+                <span className={pct >= 80 ? "hot" : undefined}
+                      style={{ width: `${Math.min(100, Math.max(0, pct))}%` }} />
+              </div>
+              <p className="help" style={{ marginBottom: 0 }}>
+                {formatBytes(onDisk)} of {formatBytes(u.max_bytes)} used
+                {u.disk_free != null && <> · {formatBytes(u.disk_free)} free on the volume</>}
+              </p>
+            </>
+          ) : (
+            // No cap configured: no percentage, no bar — there is nothing to be a percentage of.
+            <p className="help" style={{ marginBottom: 0 }}>
+              No size limit is configured for this instance, so there is no percentage to show.{" "}
+              {u.disk_free != null
+                ? <>The volume it sits on has <strong>{formatBytes(u.disk_free)}</strong> free
+                   {u.disk_total != null && <> of {formatBytes(u.disk_total)}</>}.</>
+                : <>Free space on its volume could not be read.</>}{" "}
+              Set <code>NAVFLOW_MAX_DB_SIZE</code> to be warned against a budget instead.
+            </p>
+          )}
         </>
       )}
     </div>
@@ -141,6 +220,9 @@ export default function Sources() {
           </table>
         </>
       )}
+
+      {/* Instance state, under the roster it explains: the sources above are what fills it. */}
+      <StoragePanel />
     </>
   );
 }

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -531,6 +531,13 @@ button:focus-visible, .btn:focus-visible, .navlink:focus-visible, .navbtn:focus-
 .alert.error { background: var(--err-soft); color: var(--err); border: 1px solid var(--danger-border); }
 .alert.ok { background: var(--ok-soft); color: var(--ok); border: 1px solid var(--ok-border); }
 .alert.info { background: var(--th-bg); color: var(--ink-soft); border: 1px solid var(--line); }
+/* "heading for trouble, not in it yet" — storage nearly full, a paused source */
+.alert.warn { background: var(--warn-soft); color: var(--warn); border: 1px solid var(--warn); }
+
+/* Storage meter — only ever rendered when there IS a limit to be a percentage of. */
+.usage-bar { height: 6px; background: var(--wash-2); border-radius: 0; overflow: hidden; }
+.usage-bar > span { display: block; height: 100%; background: var(--accent); }
+.usage-bar > span.hot { background: var(--warn); }
 
 /* Instance-wide banner (daemon unreachable / degraded). Fixed, because #root is the
    sidebar+content flex row and an in-flow banner would become a third column. */

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -310,6 +310,27 @@ export interface SourceEvent {
   ingest_time: string;
 }
 
+// GET /api/usage — what this instance is using on disk.
+// Three things the renderer must respect:
+//  · `pct_used` is 0-100, NOT a 0-1 fraction — "warn at 80%" compares against 80.
+//  · `pct_used` and `max_bytes` are null unless the operator set NAVFLOW_MAX_DB_SIZE (the Helm
+//    chart does it for hosted cells), so a self-hosted install has no denominator at all: show
+//    absolute bytes and fall back to `disk_free` for headroom. Null is unknown, never 0.
+//  · `sources[].bytes` is always null — DuckDB keeps every source in one events table and cannot
+//    attribute storage per source. Only the per-source event counts are real.
+export interface Usage {
+  db_bytes: number;
+  wal_bytes: number;
+  disk_total: number | null;
+  disk_free: number | null;
+  max_bytes: number | null;
+  pct_used: number | null;
+  events: number;
+  sources: { name: string; events: number; bytes: number | null }[];
+  agent_runs: number;
+  dispatch_deliveries: number;
+}
+
 export interface TestResult {
   ok: boolean;
   events?: number;


### PR DESCRIPTION
Closes NF-97 (split out of NF-87, whose "same number on the OSS cell console" item was deferred).

Storage visibility was cloud-only. This brings it to the OSS cell console, so a self-hosted user can see how full their DuckDB is *before* it breaks — NF-82 made a full or broken database survivable after the fact; this makes it visible in advance.

## What

A **Storage** panel at the bottom of the Sources page (the console's home, where the instance-wide totals already live), fed by NF-88's `GET /api/usage`:

* absolute size on disk (db + WAL), event count, `agent_runs` and `dispatch_deliveries` — the last two are the honest answer to "why is my database big?", since nothing prunes them today;
* **with `NAVFLOW_MAX_DB_SIZE`**: the percentage, a meter, and a warning from 80% up. The daemon only flips `/health` to `degraded` at `NAVFLOW_DEGRADED_PCT` (90 by default), so the console warns while there is still room to act;
* **without it** — the common self-hosted case, since only the Helm chart sets that var for hosted cells — no percentage and no bar at all, because there is no denominator: absolute size, with headroom taken from `disk_free`. A null is rendered as unknown, never as `0`, and there is no progress bar secretly measuring nothing;
* no per-source storage breakdown: `sources[].bytes` is always null (DuckDB keeps every source in one `events` table and cannot attribute storage per source). Per-source event counts already live in the table above.

`pct_used` is on a 0-100 scale, so the threshold is `80`, not `0.8`.

## How

* `ui/src/types.ts` — the `Usage` response type, with the three gotchas written down where the next reader will hit them.
* `ui/src/api.ts` — `api.usage()`.
* `ui/src/components/bits.tsx` — one new helper, `formatBytes` (null/undefined → `—`, never `0 B`). `usePolling` and NF-82's `<ErrorState>` are reused as-is; no competing versions, no restyling.
* `ui/src/pages/Sources.tsx` — the `StoragePanel`. No second poll of `/health`: AuthGate already renders the daemon's own degraded banner.
* `ui/src/styles.css` — `.alert.warn` and a `.usage-bar` that only ever renders when there is a limit to be a percentage of.

## Verified first-hand, in a browser

* **no limit** → `18 KiB` on disk and "the volume it sits on has 438 GiB free of 926 GiB"; no percentage, no bar, no warning.
* **`NAVFLOW_MAX_DB_SIZE=100Mi`**, 136,000 events ingested to actually cross the threshold rather than assert it → `82 MiB` / `82.47%`, meter and "Storage 82.47% full — 82 MiB of the 100 MiB limit" warning, matching `/api/usage` exactly. Correct on the 0-100 scale.
* **failing `/api/usage`** (daemon serving the console on an unopenable DB, so the route 503s) → `<ErrorState>` with a Retry — never an empty state, never a zero.
* Both light and dark.

`cd ui && npx tsc --noEmit && npm run build` clean. Regressions: `tests/test_usage.py` 25 passed / 0 failed, `tests/test_degraded.py` 21 passed / 0 failed.

## Out of scope

Retention, pruning and `CHECKPOINT` (a real gap, its own ticket); enforcing any cap — `/api/usage` reports, it does not police; anything in `navflow-cloud`.
