### PR TITLE
agents: don't count capped runs toward the cap; ui: stop dropping load errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ dist/
 
 # local staging creds — never commit
 .prometheus
+
+# Claude Code local config + agent worktrees — machine-local, never publish
+.claude/

--- a/navflow/store.py
+++ b/navflow/store.py
@@ -853,9 +853,17 @@ class Store:
     def agent_runs_today(self, agent: str, exclude_run_id: str | None = None) -> int:
         """Runs started in the last 24h — the cost ceiling's counter. `exclude_run_id` leaves out the
         run being checked: the row is inserted before the cap is evaluated, so the cap must count the
-        runs that came BEFORE this one or it lets one extra through."""
+        runs that came BEFORE this one or it lets one extra through.
+
+        `capped` rows are NOT counted. A capped run returns before any model call, so it costs
+        nothing, and counting it makes the cap self-sustaining: past the ceiling every further
+        trigger fire writes another capped row, which holds the count at the ceiling, so the agent
+        stays disabled for 24h after the last *attempt* instead of after the 50th real run. A
+        trigger in a hot loop — the exact case this cap exists for — would silence its agent
+        indefinitely. `failed` rows ARE counted: some of them failed after spending tokens, and
+        this is a cost ceiling, so the conservative direction is to count them."""
         sql = ("SELECT count(*) FROM agent_runs WHERE agent = ? "
-               "AND started_at > now() - INTERVAL 1 DAY")
+               "AND started_at > now() - INTERVAL 1 DAY AND status <> 'capped'")
         params: list = [agent]
         if exclude_run_id:
             sql += " AND id <> ?"

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -246,6 +246,33 @@ async def main():
         st.con.close()
     finally:
         stub.shutdown()
+
+    # ── a capped run must not count toward the cap that produced it ──────────
+    # Past the ceiling, every further trigger fire writes another `capped` row. If those counted,
+    # the count would never fall back below the ceiling while the trigger keeps firing, so the
+    # agent would stay disabled for 24h after the last ATTEMPT rather than after its last real
+    # run — a trigger in a hot loop (the case the cap exists for) would silence its agent for
+    # good. A capped run returns before any model call, so it costs nothing to begin with.
+    st = Store(DB)
+    st.upsert_catalog_agent("hot-loop", "incident", "Take a first look.")
+    st.start_agent_run("run_real", "hot-loop", "incident", "d_real", "checkout", "h")
+    st.finish_agent_run("run_real", "ok")
+    ck("a completed run counts toward the cap", st.agent_runs_today("hot-loop") == 1)
+
+    for i in range(5):
+        st.start_agent_run(f"run_capped_{i}", "hot-loop", "incident", "d_cap", "checkout", "h")
+        st.finish_agent_run(f"run_capped_{i}", "capped", error="cap reached")
+    ck("capped runs do not count toward the cap",
+       st.agent_runs_today("hot-loop") == 1, str(st.agent_runs_today("hot-loop")))
+
+    # Deliberately still counted: some failures happen after the model call, so they cost real
+    # tokens, and a cost ceiling should err towards counting.
+    st.start_agent_run("run_failed", "hot-loop", "incident", "d_fail", "checkout", "h")
+    st.finish_agent_run("run_failed", "failed", error="boom")
+    ck("failed runs still count", st.agent_runs_today("hot-loop") == 2,
+       str(st.agent_runs_today("hot-loop")))
+    st.con.close()
+
     print(f"\n{P} passed, {F} failed")
 
 asyncio.run(main())

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -6,7 +6,7 @@ import remarkGfm from "remark-gfm";
 import { api } from "../api";
 import AgentForm from "../components/AgentForm";
 import ConfirmDialog from "../components/ConfirmDialog";
-import { TimeAgo, usePolling } from "../components/bits";
+import { ErrorState, TimeAgo, usePolling } from "../components/bits";
 import type { AgentRun } from "../types";
 
 // Everything about one NavFlow agent: its prompt, wiring, and — the part that doesn't belong on the
@@ -29,7 +29,7 @@ export default function AgentDetail() {
   const [err, setErr] = useState<string>();
 
   const { data, error, reload } = usePolling(() => api.builtinAgents(), 10000);
-  const { data: runs } = usePolling(() => api.builtinAgentRuns(name, 20), 10000);
+  const { data: runs, error: runsError } = usePolling(() => api.builtinAgentRuns(name, 20), 10000);
   const { data: triggers } = usePolling(() => api.triggers(), 30000);
 
   if (error) return <div className="alert error">{error}</div>;
@@ -117,7 +117,8 @@ export default function AgentDetail() {
           </div>
 
           <h2>Runs &amp; findings</h2>
-          {!runs?.length && <p className="help">none yet — this agent runs when <span className="mono">{agent.trigger}</span> fires</p>}
+          {runsError && <ErrorState error={runsError} what="this agent’s runs" />}
+          {!runsError && !runs?.length && <p className="help">none yet — this agent runs when <span className="mono">{agent.trigger}</span> fires</p>}
           {runs?.map((r, i) => {
             const header = (
               <>

--- a/ui/src/pages/SourceDetail.tsx
+++ b/ui/src/pages/SourceDetail.tsx
@@ -5,7 +5,7 @@ import { api } from "../api";
 import ConfirmDialog from "../components/ConfirmDialog";
 import IngestSetup from "../components/IngestSetup";
 import SourceForm from "../components/SourceForm";
-import { StatusBadge, TimeAgo, usePolling } from "../components/bits";
+import { ErrorState, StatusBadge, TimeAgo, usePolling } from "../components/bits";
 import type { ConnectorSpec, Source } from "../types";
 
 export default function SourceDetail() {
@@ -27,7 +27,7 @@ export default function SourceDetail() {
   };
 
   const { data: source, error, reload } = usePolling(() => api.source(name));
-  const { data: events } = usePolling(() => api.sourceEvents(name, 30));
+  const { data: events, error: eventsError } = usePolling(() => api.sourceEvents(name, 30));
 
   useEffect(() => { api.connectors().then(setSpecs); }, []);
 
@@ -105,7 +105,8 @@ export default function SourceDetail() {
 
       {tab === "events" && (
         <>
-          {!events?.length && <div className="empty">nothing ingested from this source yet</div>}
+          {eventsError && <ErrorState error={eventsError} what="recent events" />}
+          {!eventsError && !events?.length && <div className="empty">nothing ingested from this source yet</div>}
           {!!events?.length && (
             <table>
               <thead><tr><th>ingested</th><th>key</th><th>type</th><th>text</th></tr></thead>

--- a/ui/src/pages/TriggerDetail.tsx
+++ b/ui/src/pages/TriggerDetail.tsx
@@ -4,7 +4,7 @@ import { Link, useNavigate, useParams, useSearchParams } from "react-router-dom"
 import { api } from "../api";
 import ConfirmDialog from "../components/ConfirmDialog";
 import TriggerEditor from "../components/TriggerEditor";
-import { TimeAgo, usePolling } from "../components/bits";
+import { ErrorState, TimeAgo, usePolling } from "../components/bits";
 
 // The home of one trigger: condition, the agents it wakes (wire more here), recent firings.
 // Read-only by default; Edit swaps in the editor in place (?edit=1 opens it directly).
@@ -16,8 +16,10 @@ export default function TriggerDetail() {
   const [confirmDel, setConfirmDel] = useState(false);
   const [delErr, setDelErr] = useState<string>();
   const { data: triggers, error, reload } = usePolling(() => api.triggers(), 10000);
-  const { data: agents } = usePolling(() => api.agents(), 10000);
-  const { data: dispatches } = usePolling(() => api.dispatches(100), 10000);
+  // Both errors are kept, not dropped: `agents` decides what the DELETE dialog tells you is at
+  // stake, and a failed load would otherwise silently read as "nothing depends on this".
+  const { data: agents, error: agentsError } = usePolling(() => api.agents(), 10000);
+  const { data: dispatches, error: dispatchesError } = usePolling(() => api.dispatches(100), 10000);
   const [url, setUrl] = useState("");
   const [channel, setChannel] = useState("");
   const [busy, setBusy] = useState(false);
@@ -176,7 +178,8 @@ export default function TriggerDetail() {
       {msg && <p className="help">{msg}</p>}
 
       <h2>Recent firings</h2>
-      {firings.length === 0 && <p className="help">none yet</p>}
+      {dispatchesError && <ErrorState error={dispatchesError} what="recent firings" />}
+      {!dispatchesError && firings.length === 0 && <p className="help">none yet</p>}
       {firings.length > 0 && (
         <table>
           <thead><tr><th>fired</th><th>entity</th><th className="num">subscribers</th><th className="num">delivered</th><th>error</th></tr></thead>
@@ -200,9 +203,13 @@ export default function TriggerDetail() {
       {confirmDel && (
         <ConfirmDialog
           title={`Delete trigger ${trigger.name}?`}
-          message={wired.length
-            ? `${wired.length} agent(s) are woken by this trigger and will stop receiving it. This can't be undone.`
-            : "This stops the condition from being evaluated. This can't be undone."}
+          message={agentsError
+            // Never reassure from a failed load. "No agents use this" and "we couldn't find out"
+            // are different facts, and only one of them is safe to delete on.
+            ? `Couldn’t check which agents this trigger wakes (${agentsError}) — deleting may break more than is shown here. This can’t be undone.`
+            : wired.length
+              ? `${wired.length} agent(s) are woken by this trigger and will stop receiving it. This can't be undone.`
+              : "This stops the condition from being evaluated. This can't be undone."}
           confirmLabel="Delete"
           danger
           onCancel={() => setConfirmDel(false)}

--- a/ui/src/pages/ViewDetail.tsx
+++ b/ui/src/pages/ViewDetail.tsx
@@ -4,7 +4,7 @@ import { Link, useNavigate, useParams, useSearchParams } from "react-router-dom"
 import { api } from "../api";
 import ConfirmDialog from "../components/ConfirmDialog";
 import ViewEditor from "../components/ViewEditor";
-import { TimeAgo, usePolling } from "../components/bits";
+import { ErrorState, TimeAgo, usePolling } from "../components/bits";
 
 // The home of one view: read-only by default (definition, usage, watching triggers), with
 // in-place editing via the Edit button (?edit=1 opens it directly, e.g. from the list).
@@ -16,7 +16,9 @@ export default function ViewDetail() {
   const [confirmDel, setConfirmDel] = useState(false);
   const [delErr, setDelErr] = useState<string>();
   const { data: views, error, reload } = usePolling(() => api.views(), 10000);
-  const { data: triggers } = usePolling(() => api.triggers(), 10000);
+  // Error kept: this drives what the DELETE dialog says is at stake, and a failed load must not
+  // read as "no triggers watch this view".
+  const { data: triggers, error: triggersError } = usePolling(() => api.triggers(), 10000);
   const { data: sources } = usePolling(() => api.sources(), 15000);
 
   if (error) return <div className="alert error">{error}</div>;
@@ -86,7 +88,8 @@ export default function ViewDetail() {
       )}
 
       <h2>Triggers watching this view</h2>
-      {watchers.length === 0 && (
+      {triggersError && <ErrorState error={triggersError} what="the triggers watching this view" />}
+      {!triggersError && watchers.length === 0 && (
         <p className="help" style={{ whiteSpace: "normal" }}>
           none — <Link to={`/triggers/new?view=${encodeURIComponent(view.name)}`}>create one</Link> to
           wake agents when a condition trips on this timeline
@@ -112,9 +115,12 @@ export default function ViewDetail() {
       {confirmDel && (
         <ConfirmDialog
           title={`Delete view ${view.name}?`}
-          message={watchers.length
-            ? `${watchers.length} trigger(s) watch this view and will stop working. Agents querying it will start failing.`
-            : "Agents querying this view will start failing. This can't be undone."}
+          message={triggersError
+            // A failed load must never produce the calmer of the two messages — see TriggerDetail.
+            ? `Couldn’t check which triggers watch this view (${triggersError}) — deleting may break more than is shown here. This can’t be undone.`
+            : watchers.length
+              ? `${watchers.length} trigger(s) watch this view and will stop working. Agents querying it will start failing.`
+              : "Agents querying this view will start failing. This can't be undone."}
           confirmLabel="Delete"
           danger
           onCancel={() => setConfirmDel(false)}


### PR DESCRIPTION
Two bugs found reviewing what shipped in 0.3.0. Both are cases of a failed read being presented as a fact.

## 1. Capped runs counted toward the cap that produced them

`store.agent_runs_today()` counted every `agent_runs` row in the last 24h, including rows with `status = 'capped'`. A capped run returns before any model call, so it costs nothing — and counting it makes the ceiling self-sustaining: past the cap, every further trigger fire writes another `capped` row, which holds the count at the ceiling. The agent then stays disabled for 24h after the last *attempt* rather than after its 50th *real* run, so a trigger in a hot loop — the exact case `DAILY_RUN_CAP` exists for — silences its agent indefinitely.

`failed` runs are still counted, deliberately: some fail after the model call and cost real tokens, and a cost ceiling should err towards counting.

Covered by three new checks in `tests/test_agents.py`. Verified they fail without the fix (count reads 6 instead of 1) and pass with it.

## 2. UI dropped `usePolling` errors on data that makes claims

`bits.tsx` states the rule: *"a fetch that failed is NEVER rendered as an empty state"*. NF-82 fixed the three primary call sites; the auxiliary ones still discarded `error`. Fixed the five where the discarded error produced a false statement:

**Destructive, and the reason this is not cosmetic** — both delete dialogs branch on a count derived from a dropped-error fetch:

- `TriggerDetail` — if `/api/agents` fails, `wired.length` is 0 and the dialog shows the reassuring *"This stops the condition from being evaluated"* instead of *"3 agent(s) are woken by this trigger"*. The user confirms an irreversible delete believing nothing depends on it.
- `ViewDetail` — same shape via `/api/triggers` and `watchers.length`.

Both now say explicitly that the dependency check failed and that deleting may break more than is shown.

**False "nothing here" claims:**

- `AgentDetail` — a failed runs load rendered *"none yet — this agent runs when X fires"*
- `SourceDetail` — a failed events load rendered *"nothing ingested from this source yet"*
- `TriggerDetail` — a failed dispatches load rendered *"none yet"* under Recent firings

Each now renders `ErrorState` instead.

## Not addressed here

Eight further `usePolling` sites still drop `error`, but they feed pickers and capability flags rather than claims (`ViewNew`/`ViewDetail`/`SourceClaudeCode` source lists, `Explore` view lenses, `SourceDetail` fields, `caps` in two places). Lower severity — worth a follow-up rather than widening this diff.

## Verification

- 314 → 317 OSS checks, all 12 suites green
- `tsc --noEmit` clean, `npm run build` green