### PR TITLE
console: an Overview page for the instance numbers; Sources is just the list

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -4,7 +4,7 @@ import { Link, NavLink, Outlet, useLocation } from "react-router-dom";
 import { api, auth } from "./api";
 import CommandPalette from "./components/CommandPalette";
 import {
-  Activity, Bolt, Book, Chat, ChevronRight, Database, Filter, GitHub, Lock, Moon,
+  Activity, Bolt, Book, Chat, ChevronRight, Database, Filter, GitHub, Grid, Lock, Moon,
   SignOut, Sun, Terminal,
 } from "./components/icons";
 import { applyTheme, currentTheme, type Theme } from "./theme";
@@ -22,9 +22,14 @@ type NavItem = {
 };
 
 // The nav is the product story, in three acts: data in → the timeline → serve to agents.
+// Overview sits above the story rather than inside it — it is where you land and where you check
+// the instance's numbers, not one of the acts.
 const NAV_GROUPS: { section: string; items: NavItem[] }[] = [
+  { section: "", items: [
+    { to: "/", end: true, label: "Overview", icon: Grid },
+  ] },
   { section: "Data in", items: [
-    { to: "/", end: true, label: "Sources", icon: Database },
+    { to: "/sources", label: "Sources", icon: Database },
     { to: "/ask", label: "Ask", icon: Chat, kbd: "⌘K" },
   ] },
   { section: "The timeline", items: [
@@ -40,6 +45,7 @@ const NAV_GROUPS: { section: string; items: NavItem[] }[] = [
 ];
 
 const SECTION_LABEL: Record<string, string> = {
+  sources: "Sources",
   explore: "Explore",
   views: "Views",
   triggers: "Triggers",
@@ -54,13 +60,14 @@ const SECTION_LABEL: Record<string, string> = {
 
 type Crumb = { label: string; to?: string; mono?: boolean };
 
-/** Derive breadcrumbs from the current path. Sources is the root section, so its
- *  second-level pages (/sources/:name, /new, /discover) link back to the list. */
+/** Derive breadcrumbs from the current path. `/` is Overview; every section is a sibling of it,
+ *  so second-level pages link back to their own list (/sources/:name → Sources) rather than to
+ *  the root the way they did when Sources *was* the root. */
 function useCrumbs(): Crumb[] {
   const { pathname } = useLocation();
   const parts = pathname.replace(/^\/+|\/+$/g, "").split("/").filter(Boolean);
 
-  if (parts.length === 0) return [{ label: "Sources" }];
+  if (parts.length === 0) return [{ label: "Overview" }];
 
   if (parts[0] === "sources") {
     if (parts.length === 1) return [{ label: "Sources" }];
@@ -70,7 +77,7 @@ function useCrumbs(): Crumb[] {
       : sub === "new" ? { label: "Add source" }
       : sub === "claude-code" ? { label: "Claude Code" }
       : { label: sub, mono: true };
-    return [{ label: "Sources", to: "/" }, last];
+    return [{ label: "Sources", to: "/sources" }, last];
   }
 
   if (parts[0] === "agents" && parts.length > 1) {
@@ -136,7 +143,8 @@ export default function App() {
 
         {NAV_GROUPS.map(({ section, items }) => (
           <div className="nav-group" key={section}>
-            <div className="nav-section">{section}</div>
+            {/* Overview has no section heading — it sits above the three acts, not in one. */}
+            {section && <div className="nav-section">{section}</div>}
             {items.map(({ to, end, label, icon: Icon, badge, locked, kbd }) => (
               <NavLink key={to} to={to} end={end} className={link}>
                 <Icon className="ico" />

--- a/ui/src/components/icons.tsx
+++ b/ui/src/components/icons.tsx
@@ -19,6 +19,17 @@ function S(props: SVGProps<SVGSVGElement>) {
 
 type P = SVGProps<SVGSVGElement>;
 
+// Overview: four panes, i.e. the instance at a glance — not a house. The nav's other icons all
+// name what the page shows rather than where it sits, and "home" is a location.
+export const Grid = (p: P) => (
+  <S {...p}>
+    <rect x="3" y="3" width="7" height="7" rx="1" />
+    <rect x="14" y="3" width="7" height="7" rx="1" />
+    <rect x="3" y="14" width="7" height="7" rx="1" />
+    <rect x="14" y="14" width="7" height="7" rx="1" />
+  </S>
+);
+
 export const Database = (p: P) => (
   <S {...p}>
     <ellipse cx="12" cy="5" rx="9" ry="3" />

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -22,6 +22,7 @@ import TriggerNew from "./pages/TriggerNew";
 import SourceDiscover from "./pages/SourceDiscover";
 import SourceNew from "./pages/SourceNew";
 import Security from "./pages/Security";
+import Home from "./pages/Home";
 import Sources from "./pages/Sources";
 import { TriggersPage, ViewsPage } from "./pages/ViewsTriggers";
 import "./styles.css";
@@ -31,7 +32,10 @@ const router = createBrowserRouter([
     path: "/",
     element: <App />,
     children: [
-      { index: true, element: <Sources /> },
+      // `/` is Overview, not the source list. The cloud login handoff (NAVFLOW_LOGIN_URL) lands
+      // here, so a customer arrives at the instance at a glance rather than at a table.
+      { index: true, element: <Home /> },
+      { path: "sources", element: <Sources /> },
       { path: "sources/discover", element: <SourceDiscover /> },
       { path: "sources/claude-code", element: <SourceClaudeCode /> },
       { path: "sources/new", element: <SourceNew /> },
@@ -54,12 +58,13 @@ const router = createBrowserRouter([
       { path: "agents/:name", element: <AgentDetail /> },
       { path: "ask", element: <Ask /> },
       { path: "security", element: <Security /> },
-      { path: "settings", element: <Navigate to="/" replace /> },
+      { path: "settings", element: <Navigate to="/sources" replace /> },
       // legacy paths → new homes (bookmarks, the old Entities/Activity/Catalog nav). Catalog
       // dissolved: source schema/freshness now lives on the source detail; the agent's-eye read
       // is Explore's Agent-view toggle.
       { path: "entities", element: <Navigate to="/explore" replace /> },
-      { path: "catalog", element: <Navigate to="/" replace /> },
+      // These two meant "the source list" when `/` was the source list — they still do.
+      { path: "catalog", element: <Navigate to="/sources" replace /> },
     ],
   },
 ]);

--- a/ui/src/pages/CatalogExport.tsx
+++ b/ui/src/pages/CatalogExport.tsx
@@ -56,7 +56,7 @@ export default function CatalogExport() {
     <>
       <div className="pagehead">
         <div>
-          <p className="subtitle" style={{ marginBottom: 4 }}><Link to="/">Sources</Link> ›</p>
+          <p className="subtitle" style={{ marginBottom: 4 }}><Link to="/sources">Sources</Link> ›</p>
           <h1>Export catalog</h1>
           <p className="subtitle">the portable form of your catalog — sources, views and triggers as YAML</p>
         </div>

--- a/ui/src/pages/CatalogImport.tsx
+++ b/ui/src/pages/CatalogImport.tsx
@@ -26,7 +26,7 @@ export default function CatalogImport() {
     <>
       <div className="pagehead">
         <div>
-          <p className="subtitle" style={{ marginBottom: 4 }}><Link to="/">Sources</Link> ›</p>
+          <p className="subtitle" style={{ marginBottom: 4 }}><Link to="/sources">Sources</Link> ›</p>
           <h1>Import catalog</h1>
           <p className="subtitle">paste a catalog YAML — sources, views and triggers</p>
         </div>

--- a/ui/src/pages/Home.tsx
+++ b/ui/src/pages/Home.tsx
@@ -1,0 +1,159 @@
+import { Link } from "react-router-dom";
+
+import { api } from "../api";
+import { ErrorState, formatBytes, usePolling } from "../components/bits";
+import type { Usage } from "../types";
+
+// The instance at a glance. This exists because the numbers that describe the WHOLE instance —
+// how full the disk is, how much has been ingested, how hard the agents are working — were living
+// at the bottom of the Sources page, under a list that is 10 rows on a real cell and pushes them
+// below the fold. They aren't source data; they're instance data, and the source list is now just
+// a source list.
+//
+// Numbers only, deliberately: no activity feed. A feed makes the page busier than the question it
+// answers ("is this instance healthy and how full is it?"), and Activity already exists for the
+// narrative view.
+//
+// Degraded state is NOT surfaced here — AuthGate already renders a global banner when /health is
+// anything but ok, and a second copy would just be one more thing to keep in sync.
+
+export default function Home() {
+  const { data: u, error: usageError, reload: reloadUsage } = usePolling(() => api.usage(), 30000);
+  const { data: sources, error: sourcesError } = usePolling(() => api.sources(), 30000);
+
+  const onDisk = u ? u.db_bytes + u.wal_bytes : 0;
+  // Both are null together, but it's the denominator that decides whether a percentage means
+  // anything — an instance with no NAVFLOW_MAX_DB_SIZE has nothing to be a percentage of.
+  const pct = u && u.max_bytes != null && u.pct_used != null ? u.pct_used : null;
+  const erroring = sources?.filter((s) => s.health?.status === "error").length ?? 0;
+
+  return (
+    <>
+      <div className="pagehead">
+        <div>
+          <h1>Overview</h1>
+          <p className="subtitle">
+            what this instance holds — <em>and how much room is left</em>
+          </p>
+        </div>
+      </div>
+
+      {/* One row for the whole instance. `events` comes from the metering endpoint rather than
+          summing the source list: it is the same number, but maintained as a counter rather than
+          recomputed here, and it still reads correctly while /api/sources is failing. */}
+      <div className="cards">
+        <div className="card">
+          <div className="k">sources</div>
+          <div className="v">{sources ? sources.length : <span className="dim">—</span>}</div>
+        </div>
+        <div className="card">
+          <div className="k">events stored</div>
+          <div className="v">{u ? u.events.toLocaleString() : <span className="dim">—</span>}</div>
+        </div>
+        <div className="card">
+          <div className="k">erroring</div>
+          <div className="v" style={erroring ? { color: "var(--err)" } : undefined}>
+            {sources ? erroring : <span className="dim">—</span>}
+          </div>
+        </div>
+        <div className="card">
+          <div className="k">agent runs</div>
+          <div className="v">{u ? u.agent_runs.toLocaleString() : <span className="dim">—</span>}</div>
+        </div>
+        <div className="card">
+          <div className="k">dispatch deliveries</div>
+          <div className="v">
+            {u ? u.dispatch_deliveries.toLocaleString() : <span className="dim">—</span>}
+          </div>
+        </div>
+      </div>
+
+      {/* A failed load is never rendered as a zero: the cards above fall back to "—", and the
+          reason is said out loud here. See the rule in components/bits.tsx. */}
+      {sourcesError && <ErrorState error={sourcesError} what="the source list" />}
+
+      <StoragePanel
+        usage={u}
+        error={usageError}
+        reload={reloadUsage}
+        onDisk={onDisk}
+        pct={pct}
+      />
+
+      {sources && sources.length === 0 && !sourcesError && (
+        <div className="empty">
+          Nothing is being ingested yet — <Link to="/sources/new">add a source</Link> to start
+          filling the timeline.
+        </div>
+      )}
+    </>
+  );
+}
+
+// How full is my database? — asked *before* it breaks, not after. Which story you get depends on
+// whether an operator configured a cap (NAVFLOW_MAX_DB_SIZE; the Helm chart sets it for hosted
+// cells, a self-hosted install usually has not):
+//   · cap set  → the percentage of it, a bar, and a warning from 80% up. The daemon only flips
+//                /health to `degraded` at NAVFLOW_DEGRADED_PCT (90 by default); the console warns
+//                earlier, while there is still room to act.
+//   · no cap   → no percentage and no bar, because there is no denominator to measure against.
+//                Absolute size, with headroom taken from the free space on the volume instead.
+// pct_used is on a 0-100 scale, so the threshold is 80, not 0.8. Per-source bytes are deliberately
+// absent: DuckDB keeps every source in one events table and cannot attribute storage per source.
+function StoragePanel({ usage, error, reload, onDisk, pct }: {
+  usage: Usage | undefined;
+  error?: string;
+  reload: () => void;
+  onDisk: number;
+  pct: number | null;
+}) {
+  const u = usage;
+  return (
+    <div className="panel">
+      <h2 style={{ marginTop: 0 }}>Storage</h2>
+      <p className="help" style={{ marginTop: 0 }}>
+        What this instance is using on disk — the DuckDB file plus its write-ahead log. Nothing is
+        pruned today, so agent runs and dispatch deliveries grow with every firing.
+      </p>
+
+      {error && <ErrorState error={error} what="storage usage" onRetry={reload} />}
+      {!u && !error && <div className="muted">loading…</div>}
+
+      {u && (
+        <>
+          {pct !== null && pct >= 80 && (
+            <div className="alert warn">
+              <strong>Storage {pct}% full</strong> — {formatBytes(onDisk)} of the{" "}
+              {formatBytes(u.max_bytes)} limit for this instance. Ingest keeps working until it
+              runs out; free space or raise <code>NAVFLOW_MAX_DB_SIZE</code> before it does.
+            </div>
+          )}
+
+          {pct !== null ? (
+            <>
+              <div className="usage-bar" aria-hidden="true">
+                <span className={pct >= 80 ? "hot" : undefined}
+                      style={{ width: `${Math.min(100, Math.max(0, pct))}%` }} />
+              </div>
+              <p className="help" style={{ marginBottom: 0 }}>
+                <strong>{formatBytes(onDisk)}</strong> of {formatBytes(u.max_bytes)} used ({pct}%)
+                {u.disk_free != null && <> · {formatBytes(u.disk_free)} free on the volume</>}
+              </p>
+            </>
+          ) : (
+            // No cap configured: no percentage, no bar — there is nothing to be a percentage of.
+            <p className="help" style={{ marginBottom: 0 }}>
+              <strong>{formatBytes(onDisk)}</strong> on disk. No size limit is configured for this
+              instance, so there is no percentage to show.{" "}
+              {u.disk_free != null
+                ? <>The volume it sits on has <strong>{formatBytes(u.disk_free)}</strong> free
+                   {u.disk_total != null && <> of {formatBytes(u.disk_total)}</>}.</>
+                : <>Free space on its volume could not be read.</>}{" "}
+              Set <code>NAVFLOW_MAX_DB_SIZE</code> to be warned against a budget instead.
+            </p>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/ui/src/pages/SourceClaudeCode.tsx
+++ b/ui/src/pages/SourceClaudeCode.tsx
@@ -104,7 +104,7 @@ export default function SourceClaudeCode() {
         <p className="help" style={{ marginTop: 0 }}>
           Sessions stream <strong>from install onward</strong> (existing sessions aren&rsquo;t
           backfilled). Once you run a session, the <span className="mono">claude_code</span> source
-          shows up under <Link to="/">Sources</Link>.
+          shows up under <Link to="/sources">Sources</Link>.
         </p>
       </div>
     </>

--- a/ui/src/pages/SourceDetail.tsx
+++ b/ui/src/pages/SourceDetail.tsx
@@ -134,7 +134,7 @@ export default function SourceDetail() {
           onConfirm={async () => {
             setConfirmDel(false);
             setActionError(undefined);
-            try { await api.deleteSource(name, purge); nav("/"); }
+            try { await api.deleteSource(name, purge); nav("/sources"); }
             catch (e) { setActionError(String((e as Error).message ?? e)); }
           }}
         >

--- a/ui/src/pages/SourceDiscover.tsx
+++ b/ui/src/pages/SourceDiscover.tsx
@@ -50,7 +50,7 @@ export default function SourceDiscover() {
   // are now listed). If any failed, stay put so the user can fix and retry.
   useEffect(() => {
     if (!allOk) return;
-    const t = setTimeout(() => nav("/"), 1400);
+    const t = setTimeout(() => nav("/sources"), 1400);
     return () => clearTimeout(t);
   }, [allOk, nav]);
 
@@ -123,7 +123,7 @@ export default function SourceDiscover() {
                     <span className="help">
                       created {created} of {Object.keys(results).length}
                       {failed ? `, ${failed} failed — fix and retry` : ""} ·{" "}
-                      <a href="#" onClick={(e) => { e.preventDefault(); nav("/"); }}>view sources</a>
+                      <a href="#" onClick={(e) => { e.preventDefault(); nav("/sources"); }}>view sources</a>
                     </span>
                   )}
                 </>

--- a/ui/src/pages/Sources.tsx
+++ b/ui/src/pages/Sources.tsx
@@ -28,85 +28,9 @@ function CatalogMenu() {
   );
 }
 
-// The console's answer to "how full is my database?" — asked *before* it breaks, not after.
-// Which story you get depends on whether an operator configured a cap (NAVFLOW_MAX_DB_SIZE; the
-// Helm chart sets it for hosted cells, a self-hosted install usually has not):
-//   · cap set  → the percentage of it, a bar, and a warning from 80% up. The daemon only flips
-//                /health to `degraded` at NAVFLOW_DEGRADED_PCT (90 by default); the console warns
-//                earlier, while there is still room to act.
-//   · no cap   → no percentage and no bar, because there is no denominator to measure against.
-//                Absolute size, with headroom taken from the free space on the volume instead.
-// pct_used is on a 0-100 scale, so the threshold is 80, not 0.8. Per-source bytes are deliberately
-// absent: DuckDB keeps every source in one events table and cannot attribute storage per source.
-function StoragePanel() {
-  const { data: u, error, reload } = usePolling(() => api.usage(), 30000);
-  const onDisk = u ? u.db_bytes + u.wal_bytes : 0;
-  // Both null together, but check the denominator: it is what makes a percentage meaningful.
-  const pct = u && u.max_bytes != null && u.pct_used != null ? u.pct_used : null;
-
-  return (
-    <div className="panel">
-      <h2 style={{ marginTop: 0 }}>Storage</h2>
-      <p className="help" style={{ marginTop: 0 }}>
-        What this instance is using on disk — the DuckDB file plus its write-ahead log. Nothing is
-        pruned today, so agent runs and dispatch deliveries grow with every firing.
-      </p>
-
-      {error && <ErrorState error={error} what="storage usage" onRetry={reload} />}
-      {!u && !error && <div className="muted">loading…</div>}
-
-      {u && (
-        <>
-          {pct !== null && pct >= 80 && (
-            <div className="alert warn">
-              <strong>Storage {pct}% full</strong> — {formatBytes(onDisk)} of the{" "}
-              {formatBytes(u.max_bytes)} limit for this instance. Ingest keeps working until it
-              runs out; free space or raise <code>NAVFLOW_MAX_DB_SIZE</code> before it does.
-            </div>
-          )}
-
-          <div className="cards" style={{ marginBottom: 12 }}>
-            <div className="card">
-              <div className="k">on disk</div>
-              <div className="v">
-                {formatBytes(onDisk)}{" "}
-                {/* the denominator is spelled out under the bar; the card just glances */}
-                {pct !== null && <small>{pct}%</small>}
-              </div>
-            </div>
-            <div className="card"><div className="k">events</div><div className="v">{u.events.toLocaleString()}</div></div>
-            <div className="card"><div className="k">agent runs</div><div className="v">{u.agent_runs.toLocaleString()}</div></div>
-            <div className="card"><div className="k">dispatch deliveries</div><div className="v">{u.dispatch_deliveries.toLocaleString()}</div></div>
-          </div>
-
-          {pct !== null ? (
-            <>
-              <div className="usage-bar" aria-hidden="true">
-                <span className={pct >= 80 ? "hot" : undefined}
-                      style={{ width: `${Math.min(100, Math.max(0, pct))}%` }} />
-              </div>
-              <p className="help" style={{ marginBottom: 0 }}>
-                {formatBytes(onDisk)} of {formatBytes(u.max_bytes)} used
-                {u.disk_free != null && <> · {formatBytes(u.disk_free)} free on the volume</>}
-              </p>
-            </>
-          ) : (
-            // No cap configured: no percentage, no bar — there is nothing to be a percentage of.
-            <p className="help" style={{ marginBottom: 0 }}>
-              No size limit is configured for this instance, so there is no percentage to show.{" "}
-              {u.disk_free != null
-                ? <>The volume it sits on has <strong>{formatBytes(u.disk_free)}</strong> free
-                   {u.disk_total != null && <> of {formatBytes(u.disk_total)}</>}.</>
-                : <>Free space on its volume could not be read.</>}{" "}
-              Set <code>NAVFLOW_MAX_DB_SIZE</code> to be warned against a budget instead.
-            </p>
-          )}
-        </>
-      )}
-    </div>
-  );
-}
-
+// Just the source list. Instance-wide numbers (storage, totals, agent runs) used to sit at the
+// bottom of this page; they now live on Overview (pages/Home.tsx), because on a real cell this
+// list is long enough to push them below the fold — and they were never about the sources anyway.
 export default function Sources() {
   const nav = useNavigate();
   const { data: sources, error } = usePolling(() => api.sources());
@@ -116,9 +40,6 @@ export default function Sources() {
 
   const [q, setQ] = useState("");
   const [status, setStatus] = useState("all");
-
-  const total = sources?.reduce((n, s) => n + (s.health?.events_total ?? 0), 0) ?? 0;
-  const erroring = sources?.filter((s) => s.health?.status === "error").length ?? 0;
 
   const statuses = useMemo(
     () => Array.from(new Set((sources ?? []).map((s) => s.health?.status ?? "starting"))).sort(),
@@ -151,14 +72,6 @@ export default function Sources() {
       </div>
 
       {error && <div className="alert error">daemon unreachable: {error}</div>}
-
-      {sources && (
-        <div className="cards">
-          <div className="card"><div className="k">sources</div><div className="v">{sources.length}</div></div>
-          <div className="card"><div className="k">events stored</div><div className="v">{total.toLocaleString()}</div></div>
-          <div className="card"><div className="k">erroring</div><div className="v" style={erroring ? { color: "var(--err)" } : {}}>{erroring}</div></div>
-        </div>
-      )}
 
       {sources && sources.length === 0 && (
         <div className="empty">
@@ -221,8 +134,6 @@ export default function Sources() {
         </>
       )}
 
-      {/* Instance state, under the roster it explains: the sources above are what fills it. */}
-      <StoragePanel />
     </>
   );
 }


### PR DESCRIPTION
On a real cell the Sources list is long enough that the Storage panel — added by NF-97 — sits below the fold, under ten rows of source data it has nothing to do with. Those numbers describe the *instance*, not the sources.

## What changed

**New `/` = Overview.** The source list moves to `/sources`.

Overview carries the instance-level facts, all from endpoints that already exist (`/api/usage`, `/api/sources`) — no backend work:

- one row of counters: sources, events stored, erroring, agent runs, dispatch deliveries
- the Storage panel, moved from the bottom of Sources: the bar, used-of-limit, free space, and the ≥80% warning

Numbers only — no activity feed. Activity already exists for the narrative view, and a feed makes the page busier than the question it answers.

Degraded state is deliberately *not* repeated here: `AuthGate` already renders a global banner when `/health` is anything but `ok`, and a second copy would be one more thing to keep in sync.

**Sources is now just the list** — title, filter, table. Its three summary cards moved to Overview for the same reason the storage panel did.

## The routing change is the fiddly part

`/` used to *be* Sources, and that was baked into several places:

- `useCrumbs()` hardcoded "Sources is the root section"; second-level pages (`/sources/:name`, `/new`, `/discover`) linked back to `/`. They now link to `/sources`.
- `SECTION_LABEL` gained a `sources` entry.
- Six links/redirects meaning "the source list" pointed at `/` — `SourceDetail` after delete, `SourceDiscover` (×2), `CatalogImport`, `CatalogExport`, `SourceClaudeCode`. All repointed.
- The `settings` and `catalog` legacy redirects also meant "the source list", so they now go to `/sources` rather than landing on Overview.

**The cloud login handoff lands on `/`.** After Auth0, `NAVFLOW_LOGIN_URL` returns a customer to the cell root — now Overview rather than a table. That's the intended improvement, and `tests/login-handoff.e2e.cjs` still passes end to end.

## Also

- New `Grid` icon for the nav (four panes — the instance at a glance, not a house; the other nav icons all name what the page shows).
- Overview sits above the "data in → the timeline → serve to agents" story rather than becoming a fourth act, so its nav group renders without a section heading.

## Verification

- 317 OSS checks across all 12 suites, green
- `tests/login-handoff.e2e.cjs` — 8/8, including "logged-out console redirects to login_url" and "stays on the cell once authed"
- `tsc --noEmit` clean, `npm run build` green