### PR TITLE
ask: constrain view filters in the schema; vercel: stop discarding the status code

### DIFF
--- a/tares/agent.py
+++ b/tares/agent.py
@@ -102,7 +102,24 @@ PROPOSAL_TOOLS = [
          "name": {"type": "string"},
          "key_field": {"type": "string"},
          "sources": {"type": "array", "items": {"type": "string"}},
-         "filters": {"type": "array", "items": {"type": "object"}},
+         # Left as a bare {"type": "object"} the model had to guess the shape, and guessed wrong
+         # twice in a row on the same view — a flat {"service": "x"}, then "==" for the operator.
+         # The schema is the only place a guess can be prevented; prose in the prompt is not.
+         "filters": {"type": "array",
+                     "description": "Optional. Restricts which events the view carries. Each entry "
+                                    "is an object with exactly field, op and value.",
+                     "items": {"type": "object", "properties": {
+                         "field": {"type": "string",
+                                   "description": "a label the chosen sources expose, or one of the "
+                                   "built-in columns event_type, source, text, key_value"},
+                         "op": {"type": "string",
+                                "enum": ["eq", "neq", "contains", "gt", "gte", "lt", "lte"],
+                                "description": "the operator NAME, never a symbol: 'eq' not '==', "
+                                "'neq' not '!=', 'gt' not '>'. `contains` is a case-insensitive "
+                                "substring match; gt/gte/lt/lte need a numeric value and only "
+                                "match events whose field parses as a number."},
+                         "value": {"type": ["string", "number"]}},
+                         "required": ["field", "op", "value"]}},
          "reasoning": {"type": "string"}},
          "required": ["name", "key_field", "sources", "reasoning"]}},
     {"name": "propose_trigger",
@@ -233,6 +250,12 @@ applies to its result). This is often the highest-value fix available.
 a label the chosen sources EXPOSE. To correlate on something that isn't a label yet, promote it \
 first, then build the view. When sources share nothing but belong together, propose const labels \
 (same name and value) on each and key by that.
+· A view FILTER is always {"field": …, "op": …, "value": …} — three keys, never a flat \
+{"service": "checkout"} pair — and `op` is a NAME from eq / neq / contains / gt / gte / lt / lte. \
+Symbols are not operators here: write "eq", not "==". `field` may also be one of the built-in \
+columns event_type, source, text, key_value. Example: to keep only ingress-nginx events, \
+{"field": "service", "op": "eq", "value": "ingress-nginx"}. A view that needs no restriction takes \
+no filters at all — don't invent one.
 · To match a label across sources, ADD a new label — there is no rename, and a source's label set \
 is declared whole. If source B should join A on `service`, propose a NEW label named `service` on \
 B reading B's matching field, keep B's other labels, and normalize B's values so they agree \

--- a/tares/connectors/vercel.py
+++ b/tares/connectors/vercel.py
@@ -29,10 +29,23 @@ class VercelConnector(Connector):
         {"name": "project", "primary": True, "help": "Vercel project (projectName, else projectId)"},
         {"name": "environment", "help": "production | preview"},
         {"name": "source", "help": "lambda | build | edge | static | external | redirect"},
-        {"name": "path", "help": "request path"},
+        {"name": "path", "help": "rewritten path (a Next.js segment on prerendered routes)"},
         {"name": "host", "help": "request host"},
         {"name": "deployment", "help": "deployment id"},
         {"name": "branch", "help": "git branch"},
+        # --- the request (`proxy`) block. Absent on build entries, so these are simply missing
+        # there rather than empty. The status code was previously computed in _map_one and thrown
+        # away, so there was no field to label on: the only 3-digit-ish thing in reach was `path`,
+        # which is why a status label could not be built without a regex over the wrong field.
+        {"name": "status_code", "help": "HTTP status code (proxy.statusCode). Label it as "
+                                        "type=number to filter >= 400 and aggregate in triggers"},
+        {"name": "url", "help": "the request URL as asked for, with query string — unlike `path`, "
+                                "which is rewritten (/tares?_rsc=… vs tares.segments/_head.segment)"},
+        {"name": "method", "help": "GET | POST | HEAD | …"},
+        {"name": "referer", "help": "what linked here — the axis that finds the source of a 404"},
+        {"name": "path_type", "help": "PRERENDER | STATIC | FUNCTION | …"},
+        {"name": "region", "help": "edge region that served it, e.g. hnd1"},
+        {"name": "cache", "help": "Vercel cache result: HIT | MISS | STALE | BYPASS (lambda only)"},
     ]
 
     async def poll(self) -> list[Envelope]:
@@ -49,10 +62,20 @@ class VercelConnector(Connector):
         # None when genuinely absent (not faked to "unknown"), so field coverage is honest.
         e = e or {}
         proxy = e.get("proxy") or {}
+        status = e.get("statusCode")
+        if status is None:            # observed: real drains carry it only in the proxy block
+            status = proxy.get("statusCode")
         return {"project": e.get("projectName") or e.get("projectId"),
                 "environment": e.get("environment"), "source": e.get("source"),
                 "deployment": e.get("deploymentId"), "host": e.get("host"),
-                "branch": e.get("branch"), "path": e.get("path") or proxy.get("path")}
+                "branch": e.get("branch"), "path": e.get("path") or proxy.get("path"),
+                "status_code": status,
+                # `path` above prefers the REWRITTEN top-level value; this is what the client
+                # actually requested, which is the one you want when asking what 404'd.
+                "url": proxy.get("path"),
+                "method": proxy.get("method"), "referer": proxy.get("referer"),
+                "path_type": proxy.get("pathType"), "region": proxy.get("region"),
+                "cache": proxy.get("vercelCache")}
 
     def _map_one(self, e: dict) -> Envelope:
         ctx = self.label_context(e)
@@ -65,9 +88,8 @@ class VercelConnector(Connector):
         if not msg:
             msg = json.dumps(e, default=str)[:300]
 
-        status = e.get("statusCode")
-        if status is None:
-            status = proxy.get("statusCode")
+        # (the status code used to be computed here and never passed on — it is a label now,
+        # resolved in label_context so ingest and backfill agree)
         ts = e.get("timestamp")
         try:
             event_time = datetime.fromtimestamp(int(ts) / 1000, tz=timezone.utc)

--- a/ui/src/components/proposals.tsx
+++ b/ui/src/components/proposals.tsx
@@ -18,6 +18,24 @@ export type Proposal =
   | { id: string; kind: "trigger"; name: string; view: string; condition: TriggerCondition;
       emit?: { kind?: string; context_window?: string }; cooldown?: string; reasoning: string };
 
+// The operators a view filter may use — the set `tares/config.py` validates against on Apply.
+const FILTER_OPS = ["eq", "neq", "contains", "gt", "gte", "lt", "lte"];
+
+/** One filter as it will be sent, plus whether it is well-formed.
+ *
+ *  The card used to say "2 filter(s)" and nothing else, which is the one place a human could have
+ *  caught a bad filter before pressing Apply — and it was showing a count. A filter the assistant
+ *  got wrong (a flat {label: value} pair, or "==" for the operator) renders as its raw JSON and is
+ *  marked, so the mistake is visible on the card rather than arriving as a 400 afterwards. */
+export function filterText(f: Record<string, unknown>): { text: string; ok: boolean } {
+  const { field, op, value } = f as { field?: unknown; op?: unknown; value?: unknown };
+  const ok = typeof field === "string" && typeof op === "string"
+    && FILTER_OPS.includes(op) && value !== undefined && value !== null;
+  return ok
+    ? { text: `${field as string} ${op as string} ${String(value)}`, ok: true }
+    : { text: JSON.stringify(f), ok: false };
+}
+
 export type Decision = "applied" | "skipped" | "error";
 export type DecisionMap = Record<string, { status: Decision; detail?: string }>;
 
@@ -138,7 +156,21 @@ export function ProposalCard({ proposal, decision, onApply, onSkip }: {
         <p style={{ margin: "0 0 8px" }}>
           key <span className="chip mono">{proposal.key_field}</span> over{" "}
           {proposal.sources.map((s) => <span className="chip mono" key={s}>{s}</span>)}
-          {!!proposal.filters?.length && <> · {proposal.filters.length} filter(s)</>}
+          {!!proposal.filters?.length && (
+            <> · keeping only{" "}
+              {proposal.filters.map((f, i) => {
+                const { text, ok } = filterText(f);
+                return (
+                  <span key={i} className={"chip" + (ok ? "" : " invalid")}
+                        title={ok ? undefined
+                                  : "not a valid filter — needs field, op and value, with op one of "
+                                    + FILTER_OPS.join(", ") + ". Apply will be rejected."}>
+                    {text}
+                  </span>
+                );
+              })}
+            </>
+          )}
         </p>
       )}
 

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -405,6 +405,12 @@ a.chip:hover { border-color: var(--accent); }
   margin: 0 4px 4px 0;
 }
 
+/* A chip whose content is malformed — today: a view filter the assistant got wrong, shown as raw
+   JSON so the mistake is visible before Apply. Scoped to `.chip` deliberately: the bare `.invalid`
+   rules elsewhere are all scoped to their own element (label.field, .fld-row), so nothing here
+   collides the way `.badge.empty` did with the empty-state panel. */
+.chip.invalid { background: var(--err-soft); color: var(--err); border-color: var(--danger-border); }
+
 /* ── buttons & forms: square, hairline; primary is the sand fill ── */
 button, .btn {
   font: inherit;


### PR DESCRIPTION
Two fixes that came out of using the assistant against a live docs cell.

## The assistant had to guess the shape of a view filter, and guessed wrong twice

Asked to build a view, it proposed a filter as a flat pair:

```json
{"service": "ingress-nginx"}
```

then, on the retry, with a symbol for the operator:

```json
{"field": "service", "op": "==", "value": "ingress-nginx"}
```

Both were rejected by `validate_view_dict` on Apply. It had to guess because `propose_view` typed the parameter as:

```python
"filters": {"type": "array", "items": {"type": "object"}},
```

The shape was stated nowhere the model could see it. Note the contrast with `propose_trigger`, whose `condition` object already enumerates its `aggregate` values — that one has never been got wrong.

**The schema is the only place a guess can be prevented.** `filters` now requires `field`, `op` and `value`, with `op` as a JSON Schema `enum`. An enum is enforced at the tool-call layer, so `"=="` cannot be emitted at all; prose in a prompt can only ask nicely.

The enum is the set the code actually validates against — `config.py:538` and the `_FILTER_OPS` table in `store.py:193`, which agree: `eq, neq, contains, gt, gte, lt, lte`. I asserted all three match rather than trusting the list.

The prompt gains a matching bullet, because the schema alone doesn't explain *why* the mistake is tempting. I think the flat-pair guess came from inside the toolset: `query` takes `where`, which genuinely **is** `{"service": "checkout"}`. So the bullet names that trap directly. It also documents something the model could not have known — `field` may be one of the built-in columns `event_type`, `source`, `text`, `key_value`, not only a label.

I swept the rest of the toolset for the same class of under-specified schema. The only other bare objects are `query.where` and `propose_labels`' `map`, both legitimately free-form maps.

### The card was showing a count where the content mattered

A view proposal rendered its filters as `· 2 filter(s)`. That was the one place a human could have caught a bad filter before pressing Apply, and it was showing a number.

It now renders each filter — `service eq ingress-nginx` — and a malformed one as its raw JSON in a marked chip with a tooltip naming the requirement. Deliberately: it renders *everything* and marks what's wrong, rather than only what it can parse. A card that silently dropped a malformed filter would be worse than the count it replaces.

`.chip.invalid` is scoped on purpose. The existing `.invalid` rules are all bound to their own element (`label.field.invalid`, `.fld-row.invalid`), so there is no bare `.invalid` for it to lose to — the failure mode `.badge.blanked` hit in #59.

## The Vercel connector was throwing the status code away

`_map_one` computed it and never passed it to the `Envelope`:

```python
status = e.get("statusCode")
if status is None:
    status = proxy.get("statusCode")
# ...never referenced again
```

Dead since it was written. Consequently `label_context()` had no status field, and neither did `PROVIDES`. On a real docs drain this produced a `status_code` label built as a regex over `path`, because `path` was the only thing in reach that ever contains digits. That label:

- fires only when the request path is **literally** `404` — hits on the 404 page asset, not requests that returned 404
- reports the 404 page as the entity, losing the URL that actually failed
- is empty on live traffic, including a genuine `-> 499`

It also explains historical junk values in that label (`/tares/deployment`, `assets/favicon.png`): its `replace` is `""` with no capture group, and `_normalize_value` treats a group-less replace as a *substitution*, keeping the raw value on no-match. A `$1` replace would drop the label instead.

**Seven fields off the `proxy` block:** `status_code`, `url`, `method`, `referer`, `path_type`, `region`, `cache`. Resolved in `label_context()` rather than `_map_one`, so ingest and backfill agree and relabelling from stored payloads picks them up.

Two deserve their own note:

- **`url` is `proxy.path`** — what the client actually asked for. Top-level `path` is the **rewritten** value, a Next.js segment on prerendered routes: a request for `/tares?_rsc=19hu7` logs `path=tares.segments/_head.segment`. Keying on it cannot answer which page 404'd.
- **`referer`** finds the *source* of a 404 rather than its victim.

**Left out on purpose:** `userAgent` is a JSON array, not a string, so a label would stringify a list; `clientIp` is near-unique and personal data; `vercelId` is unique per request and would blow the 10,000-value entity cardinality cap; `cacheId` was `"-"` on every sampled event; `scheme` had one distinct value.

### Verified against a live drain

Real entries, not synthetic ones:

- **lambda 200** → `status_code=200` as an `int`, `url=/tares?_rsc=19hu7`, `cache=HIT`
- **static 499** → `status_code=499`, and **no `cache` label** — `vercelCache` is absent on static entries, so it is omitted rather than blank
- **build** (no `proxy` block) → no request labels at all

Worth recording for whoever writes the label: use `{"name": "status_code", "field": "status_code", "type": "number"}`. `store.aggregate()` casts with a hard `CAST(... AS DOUBLE)`, so a trigger needs the values guaranteed numeric; `_filter_sql` uses `TRY_CAST`, so `gte 400` works either way. The cost is that `_accum_entity` skips numeric values, so `status_code` will not appear in the entity facets — a number label is a measurement to aggregate, not an axis to facet by.

## Verified

12 CI tests pass, plus `test_vercel.py` (19) and `test_ingest_key`, which are not in the CI list — `test_vercel.py` in particular covers this connector and is worth adding to `ci.yml` separately. `npx tsc --noEmit` clean and the console builds.

## Not covered

- Existing events do not gain `status_code`: labels apply at ingest. The payloads are lossless so nothing is lost, but I have not verified the relabel-from-payload path end to end.
- The filter chips are verified as logic and typing, not rendered in a browser.
