### PR TITLE
ui: the last three native dropdowns in the app become Pickers

### DIFF
--- a/ui/src/components/TriggerEditor.tsx
+++ b/ui/src/components/TriggerEditor.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 
 import { api } from "../api";
-import { Combo } from "./bits";
+import { Combo, Picker } from "./bits";
 import type { Trigger } from "../types";
 
 // The one trigger editor — used in place on /triggers/new and /triggers/<name>.
@@ -85,12 +85,11 @@ export default function TriggerEditor({ initial, presetView, onSaved, onCancel }
         </div>
       </div>
       <div className="row2">
-        <label className="field">
+        <div className="field">
           <span className="lbl">aggregate</span>
-          <select value={t.condition.aggregate} onChange={(e) => cond({ aggregate: e.target.value })}>
-            {AGGREGATES.map((a) => <option key={a} value={a}>{a}</option>)}
-          </select>
-        </label>
+          <Picker value={t.condition.aggregate} options={AGGREGATES} ariaLabel="aggregate"
+                  onChange={(v) => cond({ aggregate: v })} />
+        </div>
         <div className="field">
           <span className="lbl">field</span>
           <Combo value={t.condition.field ?? ""} options={fieldOpts}

--- a/ui/src/components/ViewEditor.tsx
+++ b/ui/src/components/ViewEditor.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 
 import { api } from "../api";
-import { Combo } from "./bits";
+import { Combo, Picker } from "./bits";
 import type { ConnectorSpec, View, ViewFilter } from "../types";
 
 // The one view editor, used in place: on /views/new (create) and on /views/<name> (edit).
@@ -165,10 +165,10 @@ export default function ViewEditor({ initial, sourceNames, onSaved, onCancel }: 
             <Combo value={r.field} options={fieldOpts} placeholder="field"
                    style={{ maxWidth: 200, flex: 1 }}
                    onChange={(v) => setFRows(fRows.map((x, j) => j === i ? { ...x, field: v } : x))} />
-            <select value={r.op} style={{ maxWidth: 130 }}
-                    onChange={(e) => setFRows(fRows.map((x, j) => j === i ? { ...x, op: e.target.value } : x))}>
-              {["eq", "neq", "contains", "gt", "lt", "gte", "lte"].map((o) => <option key={o} value={o}>{o}</option>)}
-            </select>
+            {/* Picker, not <select>: the native menu is drawn by the OS and can't take our theme. */}
+            <Picker value={r.op} style={{ maxWidth: 130 }} ariaLabel="filter operator"
+                    options={["eq", "neq", "contains", "gt", "lt", "gte", "lte"]}
+                    onChange={(v) => setFRows(fRows.map((x, j) => j === i ? { ...x, op: v } : x))} />
             <input type="text" className="mono" style={{ maxWidth: 180 }} placeholder="value" value={r.value}
                    onChange={(e) => setFRows(fRows.map((x, j) => j === i ? { ...x, value: e.target.value } : x))} />
             <button type="button" className="danger" onClick={() => setFRows(fRows.filter((_, j) => j !== i))}>×</button>

--- a/ui/src/pages/Explore.tsx
+++ b/ui/src/pages/Explore.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 
 import { api } from "../api";
 import { Close, Search } from "../components/icons";
-import { usePolling } from "../components/bits";
+import { Picker, usePolling } from "../components/bits";
 import type { LabelFacet, TimelineEventRow, View } from "../types";
 
 // Explore — the hero, selector-first. Pick an entity on the left to start a selector, optionally
@@ -229,13 +229,17 @@ export default function Explore() {
                 </div>
 
                 <div className="tl-controls">
-                  <label className="tl-ctl">
+                  {/* A div, not a label — as the `window` control beside it already is. Picker
+                      renders a <button>, which IS labelable, so a wrapping <label> forwards clicks
+                      on the word "lens" into opening the menu. */}
+                  <div className="tl-ctl">
                     <span className="lbl">lens</span>
-                    <select value={effectiveLens} onChange={(e) => setLens(e.target.value)}>
-                      <option value={RAW}>All sources (raw)</option>
-                      {lensViews.map((v) => <option key={v.name} value={v.name}>{v.name}</option>)}
-                    </select>
-                  </label>
+                    {/* Picker, not a native <select>: the OS draws a <select>'s open menu and won't
+                        let us theme it, so it lands as a light box in the dark console. */}
+                    <Picker value={effectiveLens} onChange={setLens} ariaLabel="lens"
+                            options={[RAW, ...lensViews.map((v) => v.name)]}
+                            labels={{ [RAW]: "All sources (raw)" }} />
+                  </div>
                   <div className="tl-ctl">
                     <span className="lbl">window</span>
                     <div className="seg small">


### PR DESCRIPTION
Closes NF-127.

A native `<select>`'s **open** menu is drawn by the OS and cannot be themed at any price, so each of these arrived as a light system popup in the middle of the console. `Picker` already existed for exactly this — these three had been missed.

| Where | Control |
| --- | --- |
| `ui/src/components/ViewEditor.tsx:168` | view filter **operator** — eq / neq / contains / gt / lt / gte / lte |
| `ui/src/components/TriggerEditor.tsx:90` | trigger condition **aggregate** |
| `ui/src/pages/Explore.tsx:234` | **lens** |

Same option values in the same order everywhere; no behaviour change. Only the lens needed a `labels` map — its `RAW` sentinel is the empty string displayed as "All sources (raw)", which a straight swap would have dropped.

## The wrapper had to change, in both

`Picker` renders a `<button>`, and **a `<button>` is a labelable element**. So a wrapping `<label>` forwards a click on the word "aggregate" or "lens" straight into opening the menu — the label and the control fight each other. Both became `<div>`, keeping the `field` / `tl-ctl` class and the `lbl` span so the layout holds. In `Explore` that also makes it match the `window` control sitting right beside it, which was already a `<div>`.

## Verified

`npx tsc --noEmit` clean, console builds. Driven in a browser against a local daemon seeded with a source, three events and two views, in **both light and dark** — each menu opens in-theme, and the `RAW` sentinel renders as "All sources (raw)" rather than blank.

## Still native, deliberately not fixed here

The ticket asked for a first pass over its own list, then a sweep. The sweep is [a comment on NF-127](https://linear.app/glassflow/issue/NF-127); in short, four remain:

- `SourceForm.tsx:375` — Postgres column picker. Has a placeholder option (`— select —` / `— none —`) and keeps a stale value selectable.
- `SourceForm.tsx:515` — poll interval unit; display text differs from the value (`s`/`m`/`h`), so it needs a `labels` map.
- `SourceForm.tsx:997` — normalize rule kind; its `onChange` branches (early-returns for `custom`), so it is not a straight swap.
- `Sources.tsx:98` — status filter on the sources list.

Excluded on purpose: `Explore.tsx:298` (`AddTerm`) is **not** a `Picker` reimplementation despite the similar comment — it is a two-level popover emitting a `(label, value)` pair, with its own outside-click and Escape handling. Folding it in would be a different change. The `<input type="file">` at `SourceForm.tsx:1148` is already hidden behind a styled trigger, and `window.confirm` was replaced by `ConfirmDialog.tsx` some time ago. No `<datalist>` or native date/time/color inputs remain.