### PR TITLE
ui: three more native dropdowns become Pickers

### DIFF
--- a/ui/src/components/SourceForm.tsx
+++ b/ui/src/components/SourceForm.tsx
@@ -512,11 +512,10 @@ export default function SourceForm({ connector, spec, initial, lockName, submitL
             <div style={{ display: "flex", gap: 8 }}>
               <input type="number" min="1" step="1" value={num} style={{ flex: 1 }}
                      onChange={(e) => setPoll(`${e.target.value}${unit}`)} />
-              <select value={unit} onChange={(e) => setPoll(`${num}${e.target.value}`)} style={{ width: 120 }}>
-                <option value="s">seconds</option>
-                <option value="m">minutes</option>
-                <option value="h">hours</option>
-              </select>
+              <Picker value={unit} onChange={(v) => setPoll(`${num}${v}`)} style={{ width: 120 }}
+                      ariaLabel="poll interval unit"
+                      options={["s", "m", "h"]}
+                      labels={{ s: "seconds", m: "minutes", h: "hours" }} />
             </div>
             <span className="help">how often to poll the source</span>
           </div>
@@ -994,14 +993,12 @@ function PatternRule({ row, onChange }:
         The table shows its effect live.
       </span>
       <div className="btnrow" style={{ alignItems: "center" }}>
-        <select value={kind} style={{ maxWidth: 260 }}
-                onChange={(e) => { const k = e.target.value as RuleKind; setKind(k);
-                                   if (k === "custom") return; apply(k, text); }}>
-          <option value="suffix">remove this ending</option>
-          <option value="prefix">remove this beginning</option>
-          <option value="after">cut everything from … onwards</option>
-          <option value="custom">custom (regular expression)</option>
-        </select>
+        <Picker value={kind} style={{ maxWidth: 260 }} ariaLabel="pattern rule kind"
+                options={["suffix", "prefix", "after", "custom"]}
+                labels={{ suffix: "remove this ending", prefix: "remove this beginning",
+                          after: "cut everything from … onwards", custom: "custom (regular expression)" }}
+                onChange={(v) => { const k = v as RuleKind; setKind(k);
+                                   if (k === "custom") return; apply(k, text); }} />
         {kind !== "custom" ? (
           <input className="mono" style={{ flex: 1 }}
                  placeholder={kind === "suffix" ? "e.g. -svc" : kind === "prefix" ? "e.g. prod-" : "e.g. ."}

--- a/ui/src/pages/Sources.tsx
+++ b/ui/src/pages/Sources.tsx
@@ -3,7 +3,7 @@ import { Link, useNavigate } from "react-router-dom";
 
 import { api } from "../api";
 import { Search, Settings as SettingsIco } from "../components/icons";
-import { ErrorState, StatusBadge, TimeAgo, formatBytes, usePolling } from "../components/bits";
+import { ErrorState, Picker, StatusBadge, TimeAgo, formatBytes, usePolling } from "../components/bits";
 
 // Gear dropdown next to "Add source" — catalog import/export, each on its own page.
 function CatalogMenu() {
@@ -95,10 +95,12 @@ export default function Sources() {
                 onChange={(e) => setQ(e.target.value)}
               />
             </div>
-            <select value={status} onChange={(e) => setStatus(e.target.value)}>
-              <option value="all">All statuses</option>
-              {statuses.map((s) => <option key={s} value={s}>{s}</option>)}
-            </select>
+            {/* Fixed width so the search box and count don't shift when you pick a status —
+                the picker sizes to its selected text, unlike a native select. */}
+            <Picker value={status} onChange={setStatus} ariaLabel="filter by status"
+                    style={{ width: 150 }}
+                    options={["all", ...statuses]}
+                    labels={{ all: "All statuses" }} />
             <span className="grow" />
             <span className="count">{shown.length} of {sources.length}</span>
           </div>


### PR DESCRIPTION
NF-127, second pass — follows #61. Three of the four listed in [the sweep comment](https://linear.app/glassflow/issue/NF-127); the fourth is deliberately left alone.

| Where | Control |
| --- | --- |
| `ui/src/components/SourceForm.tsx` | poll interval **unit** — s / m / h |
| `ui/src/components/SourceForm.tsx` | normalize **rule kind** |
| `ui/src/pages/Sources.tsx` | **status filter** on the sources list |

All three had display text differing from their value, so each carries a `labels` map. A straight swap would have shown `s` instead of "seconds" and `suffix` instead of "remove this ending" — the sweep flagged this, and it's the reason these weren't in the first pass.

## Two that weren't element swaps

**The rule kind's `onChange` branches.** It casts to `RuleKind`, sets it, early-returns for `custom`, and otherwise applies the rule immediately. That logic is preserved verbatim; only the source of the value moved from `e.target.value` to the value `Picker` hands back.

**The status filter needed an explicit width.** `styles.css:355` has `.toolbar select { width: auto }`, which exists to stop the global `input, select, textarea { width: 100% }` from stretching it. `.picker` is matched by neither rule, so the button would size to its own text and shift the search box and count every time the selection changed. Fixed at `width: 150` rather than editing `styles.css`, since the global rules there affect every form in the app.

## Still native, on purpose

`SourceForm.tsx:375` — the Postgres column picker. Parked pending a look at what it actually does; it's the only native `<select>` left in the app.

## Verified

`npx tsc --noEmit` clean, `npm run build` succeeds, rebased onto `main` after #61 merged.