### PR TITLE
slack: pick a channel from a list instead of pasting an ID

### DIFF
--- a/tares/daemon.py
+++ b/tares/daemon.py
@@ -1375,6 +1375,26 @@ def make_app() -> FastAPI:
         token, origin = resolve_slack_token(store)
         return {"ok": True, "configured": bool(token), "source": origin}
 
+    # ── the channels the bot can post to ─────────────────────────────────────
+    # Feeds the console's channel picker, so that subscribing a trigger to Slack does not require
+    # the operator to go and dig a channel ID out of Slack's own UI.
+    #
+    # ALWAYS 200, never an exception: the console branches on `reason` and falls back to the
+    # free-text channel box when the list can't be trusted. A Slack outage, or the very common
+    # token issued before `channels:read`/`groups:read` were requested, must not blank the page.
+    @app.get("/api/slack/channels")
+    async def list_slack_channels():
+        try:
+            token, _origin = resolve_slack_token(store)
+            channels, reason, detail = await slack_mod.list_channels(token)
+        except Exception as e:                      # belt and braces — list_channels swallows too
+            return {"channels": [], "reason": "error",
+                    "detail": f"{type(e).__name__}: {e}"[:200]}
+        out = {"channels": channels, "reason": reason}
+        if detail:
+            out["detail"] = detail
+        return out
+
     # ── the Slack signing secret: the credential that makes inbound Slack safe ──
     # Same write-only contract as the bot token. Without it POST /api/slack/events answers 503:
     # there is no configuration in which accepting an unverified inbound request is correct.

--- a/tares/slack.py
+++ b/tares/slack.py
@@ -25,6 +25,8 @@ import re
 import time
 from collections import deque
 
+import httpx
+
 API_BASE = os.getenv("TARES_SLACK_API_BASE", "https://slack.com/api").rstrip("/")
 SETTING_KEY = "slack_bot_token"
 ENV_VAR = "TARES_SLACK_BOT_TOKEN"
@@ -130,6 +132,90 @@ def _error_detail(err: str, data: dict) -> str:
     if not hint and err == "missing_scope" and data.get("needed"):
         hint = f"needs scope {data['needed']}"
     return f" ({hint})" if hint else ""
+
+
+# ── the channel picker ────────────────────────────────────────────────────
+# The console offers a list instead of a free-text box for the channel ID, which nobody can find
+# without leaving the app. One page is 200 channels and a real workspace has more, so this
+# paginates — but bounded, because a cursor that never terminates would spin here forever.
+
+_CHANNEL_PAGE = 200
+_CHANNEL_MAX_PAGES = 10          # 2000 channels; past that the picker is the wrong UI anyway
+
+
+async def list_channels(token: str, timeout: float = 10.0
+                        ) -> tuple[list[dict], str | None, str | None]:
+    """`(channels, reason, detail)` — the channels this bot is a **member of**.
+
+    `users.conversations`, not `conversations.list`. The latter lists every public channel in the
+    workspace, including the ones the bot was never invited to: picking one of those produces a
+    subscription that fails at its first firing with `not_in_channel`, which is exactly the failure
+    the picker exists to prevent. `users.conversations` returns only conversations reachable "via
+    membership of the channel" for the presented token, so everything it offers can actually be
+    posted to. It also covers private channels, which `conversations.list` cannot return at all.
+
+    Both `public_channel` and `private_channel` are asked for; the app holds `channels:read` and
+    `groups:read`. Each channel carries `is_private` so the console can render a lock rather than
+    a `#`.
+
+    `reason` is None when the list is trustworthy (an empty list then means the bot has not been
+    invited anywhere), otherwise it names why the caller should not believe it: "no_token",
+    "missing_scope", "error". Nothing raises: the console renders whatever this returns, and a
+    Slack outage must degrade to the free-text box rather than to a stack trace.
+
+    `missing_scope` is called out separately because it is the *expected* failure — a token issued
+    before these scopes were requested has it, and the only fix is reconnecting Slack.
+    """
+    if not (token or "").strip():
+        return [], "no_token", None
+    headers = {"authorization": f"Bearer {token.strip()}"}
+    params = {"types": "public_channel,private_channel", "exclude_archived": "true",
+              "limit": str(_CHANNEL_PAGE)}
+    out: list[dict] = []
+    cursor = ""
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as cx:
+            for _ in range(_CHANNEL_MAX_PAGES):
+                q = {**params, **({"cursor": cursor} if cursor else {})}
+                r = await cx.get(f"{API_BASE}/users.conversations", params=q, headers=headers)
+                try:
+                    data = r.json()
+                except Exception:
+                    data = None
+                if r.status_code == 429 or r.status_code >= 500:
+                    return [], "error", f"slack: HTTP {r.status_code}"
+                if not isinstance(data, dict):
+                    return [], "error", f"slack: HTTP {r.status_code} (non-JSON response)"
+                if not data.get("ok"):
+                    err = str(data.get("error") or "unknown_error")
+                    if err == "missing_scope":
+                        # Not _error_detail's hint: that one names chat:write, which is the scope
+                        # this token almost certainly *does* have. Two scopes are in play here, so
+                        # the missing one can be either — take Slack's `needed` when it says, and
+                        # only name both when it doesn't.
+                        needed = str(data.get("needed") or "").strip() or "channels:read and groups:read"
+                        return [], "missing_scope", (
+                            f"slack: missing_scope (the bot token is missing {needed} — "
+                            "reconnect Slack to grant it)")
+                    return [], "error", f"slack: {err}{_error_detail(err, data)}"
+                for c in data.get("channels") or []:
+                    if isinstance(c, dict) and c.get("id") and c.get("name"):
+                        # id, name and is_private only: the console needs nothing else and a
+                        # conversation object carries a few hundred bytes of purpose, topic and
+                        # membership. `is_private` is absent on some payloads — a channel that
+                        # doesn't say it is private isn't.
+                        out.append({"id": str(c["id"]), "name": str(c["name"]),
+                                    "is_private": bool(c.get("is_private"))})
+                cursor = str(((data.get("response_metadata") or {}).get("next_cursor") or "")).strip()
+                if not cursor:
+                    break
+            # Falling out of the loop with a cursor still set means the bound was hit. A partial
+            # list is a usable picker; an error here would take the whole feature away.
+    except Exception as e:
+        return [], "error", ("slack: " + type(e).__name__
+                             + (f": {e}" if str(e).strip() else ""))[:200]
+    out.sort(key=lambda c: c["name"])
+    return out, None, None
 
 
 # ── inbound: the /tares slash command ─────────────────────────────────────

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -10,9 +10,20 @@ The failure modes are the point of the ticket, so they are asserted directly: `i
 with that reason in the ledger — not five timeouts. A transient Slack fault must still retry.
 
 The token is a credential: it is write-only over the API, and the environment beats the stored one.
+
+`GET /api/slack/channels` feeds the console's channel picker and is asserted here too. It always
+answers 200 and puts the verdict in `reason`, because the console branches on the data rather than
+catching exceptions — most importantly on `missing_scope`, which a token issued before the read
+scopes were requested returns and which sends the console back to the free-text box.
+
+The endpoint it calls is itself under test: it must be `users.conversations` (channels the bot is
+a *member* of, public and private) and not `conversations.list`, which happily lists public
+channels the bot was never invited to — subscribing to one of those can only ever fail with
+`not_in_channel`, which is the failure the picker exists to prevent.
 """
 import asyncio, json, os, signal, subprocess, sys, threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import parse_qsl
 
 import httpx
 
@@ -44,20 +55,54 @@ PUBLIC_URL = "https://tares.example.com"
 CALLS: list = []
 MODE = "ok"
 
+# users.conversations behind the console's channel picker. Two pages, deliberately out of
+# alphabetical order and fat with the fields Slack really sends, so the endpoint has to sort and
+# strip. One private channel and two public ones — and `alerts` omits `is_private` entirely, the
+# way some Slack payloads do, so the default has to hold. CH_MODE switches the whole call to a
+# failure the way MODE does for chat.postMessage.
+GETS: list = []
+CH_MODE = "ok"
+CH_PAGES = {
+    "": {"channels": [{"id": "C300", "name": "zeta", "is_channel": True, "is_private": False,
+                       "num_members": 4, "purpose": {"value": "x" * 400}},
+                      {"id": "C100", "name": "alerts", "is_channel": True, "num_members": 12,
+                       "topic": {"value": "incidents"}}],       # no is_private key at all
+         "response_metadata": {"next_cursor": "page2"}},
+    "page2": {"channels": [{"id": "C200", "name": "ops", "is_group": True, "is_private": True}],
+              "response_metadata": {"next_cursor": ""}},
+}
+
 
 class Stub(BaseHTTPRequestHandler):
-    def do_POST(self):
-        body = json.loads(self.rfile.read(int(self.headers["content-length"])))
-        CALLS.append({"path": self.path, "body": body,
-                      "auth": self.headers.get("authorization", "")})
-        out = ({"ok": True, "channel": body.get("channel"), "ts": "1700000000.000100"}
-               if MODE == "ok" else {"ok": False, "error": MODE})
+    def _json(self, out):
         raw = json.dumps(out).encode()
         self.send_response(200)
         self.send_header("content-type", "application/json")
         self.send_header("content-length", str(len(raw)))
         self.end_headers()
         self.wfile.write(raw)
+
+    def do_POST(self):
+        body = json.loads(self.rfile.read(int(self.headers["content-length"])))
+        CALLS.append({"path": self.path, "body": body,
+                      "auth": self.headers.get("authorization", "")})
+        self._json({"ok": True, "channel": body.get("channel"), "ts": "1700000000.000100"}
+                   if MODE == "ok" else {"ok": False, "error": MODE})
+
+    def do_GET(self):
+        path, _, query = self.path.partition("?")
+        q = dict(parse_qsl(query))
+        GETS.append({"path": path, "query": q, "auth": self.headers.get("authorization", "")})
+        if CH_MODE.startswith("missing_scope"):
+            # "missing_scope:<scope>" lets each phase pick which scope Slack says it wants —
+            # with two read scopes in play the detail must echo Slack, not a hardcoded name.
+            needed = CH_MODE.partition(":")[2] or "channels:read"
+            self._json({"ok": False, "error": "missing_scope", "needed": needed,
+                        "provided": "chat:write"})
+        elif CH_MODE != "ok":
+            self._json({"ok": False, "error": CH_MODE})
+        else:
+            self._json({"ok": True, **CH_PAGES.get(q.get("cursor", ""), CH_PAGES[""])})
 
     def log_message(self, *a):
         pass
@@ -111,7 +156,7 @@ async def _fire(cx, n=3, tag=""):
 
 
 async def main():
-    global MODE
+    global MODE, CH_MODE
     for p in (DB, DB + ".wal"):
         if os.path.exists(p):
             os.remove(p)
@@ -134,6 +179,14 @@ async def main():
             st = (await cx.get(f"{B}/api/settings/slack-bot-token")).json()
             ck("no token configured to start with", st["configured"] is False and st["stored"] is False, str(st))
 
+            # ── the channel picker with no token: 200 and a reason, never an exception ──
+            # The console branches on `reason`; a 500 here would blank the whole settings page.
+            r = await cx.get(f"{B}/api/slack/channels")
+            ch = r.json()
+            ck("channels with no token -> 200", r.status_code == 200, r.text)
+            ck("channels with no token says reason=no_token",
+               ch.get("reason") == "no_token" and ch.get("channels") == [], r.text)
+
             r = await cx.post(f"{B}/subscribe", json={"trigger": "incident",
                                                       "url": f"slack://channel/{CHANNEL}"})
             ck("subscribing a channel with no token is rejected (400)", r.status_code == 400, r.text)
@@ -150,6 +203,77 @@ async def main():
             ck("token value is never returned", TOKEN not in json.dumps(st), str(st))
             caps = (await cx.get(f"{B}/api/capabilities")).json()
             ck("capabilities advertises Slack as configured", caps.get("slack_configured") is True, str(caps))
+
+            # ── the channel picker, the happy path ───────────────────────────
+            GETS.clear()
+            r = await cx.get(f"{B}/api/slack/channels")
+            ch = r.json()
+            ck("channels -> 200", r.status_code == 200, r.text)
+            ck("a good list carries reason=null", ch.get("reason") is None, r.text)
+            names = [c["name"] for c in ch.get("channels", [])]
+            ck("every page is included — pagination follows next_cursor",
+               names == ["alerts", "ops", "zeta"], str(names))
+            ck("...which took two calls, the second carrying the cursor",
+               len(GETS) == 2 and GETS[0]["query"].get("cursor") is None
+               and GETS[1]["query"].get("cursor") == "page2", str(GETS))
+            ck("channels are sorted by name, not by Slack's order",
+               names == sorted(names), str(names))
+            ck("ids come through with the names",
+               [c["id"] for c in ch["channels"]] == ["C100", "C200", "C300"], str(ch["channels"]))
+            ck("only id, name and is_private are returned — Slack's payload is not passed through",
+               all(set(c) == {"id", "name", "is_private"} for c in ch["channels"]),
+               str(ch["channels"]))
+
+            # ── public vs private: the console renders a lock instead of a # ──
+            priv = {c["name"]: c["is_private"] for c in ch["channels"]}
+            ck("a private channel comes back is_private=true", priv.get("ops") is True, str(priv))
+            ck("a public channel comes back is_private=false", priv.get("zeta") is False, str(priv))
+            ck("a channel with no is_private field defaults to public",
+               priv.get("alerts") is False, str(priv))
+
+            ck("the listing is authenticated with the bot token",
+               GETS[0]["auth"] == f"Bearer {TOKEN}", GETS[0]["auth"])
+            # The endpoint is the whole point of the picker: conversations.list would also answer
+            # here, and would offer channels the bot isn't in — every one of which fails its first
+            # firing with not_in_channel. users.conversations returns membership only.
+            ck("it asks users.conversations, not conversations.list",
+               GETS[0]["path"].endswith("/users.conversations")
+               and not GETS[0]["path"].endswith("/conversations.list"), str(GETS[0]))
+            ck("...for unarchived public AND private channels",
+               GETS[0]["query"].get("types") == "public_channel,private_channel"
+               and GETS[0]["query"].get("exclude_archived") == "true", str(GETS[0]))
+            ck("...on every page, cursor included",
+               all(g["path"].endswith("/users.conversations")
+                   and g["query"].get("types") == "public_channel,private_channel"
+                   for g in GETS), str(GETS))
+
+            # ── the important failure: a token predating the read scopes ──
+            # Every existing install has one. The console falls back to the free-text box on this
+            # reason and prompts a reconnect, so it must be told apart from a generic error.
+            CH_MODE = "missing_scope:channels:read"
+            r = await cx.get(f"{B}/api/slack/channels")
+            ch = r.json()
+            ck("a token without channels:read is still a 200", r.status_code == 200, r.text)
+            ck("...with reason=missing_scope and an empty list",
+               ch.get("reason") == "missing_scope" and ch.get("channels") == [], r.text)
+            ck("...and names the scope it needs", "channels:read" in str(ch.get("detail") or ""),
+               str(ch.get("detail")))
+
+            # Two scopes are in play now, so the detail must echo whichever one Slack names — a
+            # hardcoded "channels:read" would send the operator to grant the scope they already have.
+            CH_MODE = "missing_scope:groups:read"
+            ch = (await cx.get(f"{B}/api/slack/channels")).json()
+            detail = str(ch.get("detail") or "")
+            ck("missing groups:read is reported as groups:read, not channels:read",
+               ch.get("reason") == "missing_scope" and "groups:read" in detail
+               and "channels:read" not in detail, detail)
+
+            CH_MODE = "invalid_auth"
+            ch = (await cx.get(f"{B}/api/slack/channels")).json()
+            ck("any other Slack failure is reason=error with a readable detail",
+               ch.get("reason") == "error" and "invalid_auth" in str(ch.get("detail") or "")
+               and ch.get("channels") == [], str(ch))
+            CH_MODE = "ok"
 
             # ── subscribing a channel ────────────────────────────────────────
             r = await cx.post(f"{B}/subscribe", json={"trigger": "incident", "url": "slack://channel/not a channel!"})

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -30,6 +30,16 @@ export function authHeader(): Record<string, string> {
 // carrying one (say, a release or two after 1.0.2).
 try { localStorage.removeItem("tares_anthropic_key"); } catch { /* private mode */ }
 
+// Only channels the bot is a member of are listed, so a private one appearing here is expected.
+// `is_private` exists because Slack never shows a private channel as "#name" — labelling it that
+// way would name something the user can't find by that name.
+export type SlackChannel = { id: string; name: string; is_private: boolean };
+export type SlackChannels = {
+  channels: SlackChannel[];
+  reason: null | "no_token" | "missing_scope" | "error";
+  detail?: string;
+};
+
 function unauthorized() {
   auth.clear();
   window.dispatchEvent(new Event("tares-auth-required"));
@@ -186,6 +196,11 @@ export const api = {
   clearSlackSigningSecret: () =>
     request<{ ok: boolean; configured: boolean }>("/api/settings/slack-signing-secret",
       { method: "DELETE" }),
+
+  // The channels the bot can post to, for picking one instead of pasting an ID. Answers 200 even
+  // when it can't list them — `reason` says why the list is empty — so a workspace we can't read
+  // stays a fallback to typing the channel in, not an error the console has to render.
+  slackChannels: () => request<SlackChannels>("/api/slack/channels"),
 
   agents: () => request<{ agents: AgentInfo[] }>("/api/agents"),
   unsubscribe: (subscription_id: string) =>

--- a/ui/src/pages/TriggerDetail.tsx
+++ b/ui/src/pages/TriggerDetail.tsx
@@ -1,10 +1,10 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Link, useNavigate, useParams, useSearchParams } from "react-router-dom";
 
-import { api } from "../api";
+import { api, type SlackChannels } from "../api";
 import ConfirmDialog from "../components/ConfirmDialog";
 import TriggerEditor from "../components/TriggerEditor";
-import { ErrorState, TimeAgo, usePolling } from "../components/bits";
+import { ErrorState, Picker, TimeAgo, usePolling } from "../components/bits";
 
 // The home of one trigger: condition, the agents it wakes (wire more here), recent firings.
 // Read-only by default; Edit swaps in the editor in place (?edit=1 opens it directly).
@@ -25,6 +25,27 @@ export default function TriggerDetail() {
   const [busy, setBusy] = useState(false);
   const [msg, setMsg] = useState<string>();
   const { data: caps } = usePolling(() => api.capabilities(), 60000);
+  // Fetched once, not polled: a workspace's channel list doesn't move while you're on this page.
+  // It does move when you invite the bot to a channel in Slack, which is what Refresh below is for.
+  const [slack, setSlack] = useState<SlackChannels>();
+  const [refreshing, setRefreshing] = useState(false);
+  useEffect(() => {
+    let live = true;
+    api.slackChannels()
+      .then((r) => { if (live) setSlack(r); })
+      .catch(() => { if (live) setSlack({ channels: [], reason: "error" }); });
+    return () => { live = false; };
+  }, []);
+  // Re-lists channels without reloading the page — you're mid-way through wiring up a trigger and
+  // a reload would throw the rest of that away. A failed refresh keeps the list we already have,
+  // so trying is never worse than not trying; a *successful* one is followed even when it comes
+  // back worse (a token revoked meanwhile drops us to the text box, which is the truth).
+  const refreshChannels = async () => {
+    setRefreshing(true);
+    try { setSlack(await api.slackChannels()); } catch { /* keep the current list */ }
+    setRefreshing(false);
+  };
+  const channels = slack?.reason === null ? slack.channels : [];
 
   if (error) return <div className="alert error">{error}</div>;
   if (!triggers) return <div className="dim">loading…</div>;
@@ -156,19 +177,54 @@ export default function TriggerDetail() {
         other delivery:
       </p>
       <div className="btnrow" style={{ alignItems: "center", maxWidth: 720 }}>
-        <input type="text" className="mono" style={{ flex: 1 }}
-               placeholder="C0123456789 — the channel ID, from Slack's “Copy link”"
-               value={channel} onChange={(e) => setChannel(e.target.value)} />
+        {channels.length > 0 ? (
+          // One flex child, not two: .btnrow wraps, and a bare Refresh button beside the picker
+          // would drop the Subscribe button onto its own line at narrow widths.
+          <div style={{ flex: 1, minWidth: 0, display: "flex", gap: 8, alignItems: "center" }}>
+            {/* Shows the name but submits the ID: a channel renamed later keeps its ID, so the
+                subscription survives the rename instead of quietly pointing at nothing. */}
+            <Picker value={channel} onChange={setChannel} ariaLabel="Slack channel"
+                    style={{ flex: 1, minWidth: 0 }}
+                    options={channels.map((c) => c.id)}
+                    labels={{ "": "choose a channel…",
+                              ...Object.fromEntries(channels.map(
+                                (c) => [c.id, c.is_private ? `🔒 ${c.name}` : `#${c.name}`])) }} />
+            <button type="button" disabled={refreshing} onClick={refreshChannels}
+                    style={{ flexShrink: 0 }}>
+              {refreshing ? "Refreshing…" : "Refresh"}
+            </button>
+          </div>
+        ) : (
+          <input type="text" className="mono" style={{ flex: 1 }}
+                 placeholder="C0123456789 (the channel ID, from Slack's “Copy link”) or its lowercase name"
+                 value={channel} onChange={(e) => setChannel(e.target.value)} />
+        )}
         <button className="primary" disabled={!channel.trim() || busy} onClick={async () => {
           setBusy(true); setMsg(undefined);
+          // The picker already hands us a bare ID; only typed-in text can carry a leading "#".
+          const target = channels.length > 0 ? channel : channel.trim().replace(/^#/, "");
           try {
-            const r = await api.subscribe(name, `slack://channel/${channel.trim().replace(/^#/, "")}`);
+            const r = await api.subscribe(name, `slack://channel/${target}`);
             setMsg(`✓ subscribed (${r.subscription_id})`);
             setChannel("");
           } catch (e) { setMsg(`⚠️ ${String((e as Error).message ?? e)}`); }
           setBusy(false);
         }}>Subscribe channel</button>
       </div>
+      {/* The list only contains channels the bot has been invited to, so a missing one almost
+          always means exactly this — a 10-second fix in Slack, but only if we say so. */}
+      {channels.length > 0 && (
+        <p className="help" style={{ margin: "4px 0", whiteSpace: "normal" }}>
+          not seeing a channel? add the bot to it in Slack, then hit Refresh.
+        </p>
+      )}
+      {slack?.reason === "missing_scope" && (
+        <p className="help" style={{ margin: "4px 0", whiteSpace: "normal" }}>
+          this Slack token predates the <span className="mono">channels:read</span> and{" "}
+          <span className="mono">groups:read</span> scopes — reinstall the Slack app to pick a
+          channel from a list instead of typing one.
+        </p>
+      )}
       {caps && caps.slack_configured === false && (
         <p className="help" style={{ margin: "4px 0", whiteSpace: "normal" }}>
           no Slack bot token is configured yet — add one under{" "}


### PR DESCRIPTION
Closes NF-118.

Subscribing a trigger to Slack meant typing into a bare text box, so the user went to Slack, right-clicked the channel, Copy link, and pulled the ID out of the URL. It's a picker now.

## The design turns on *which* Slack method

It lists via **`users.conversations`**, not `conversations.list`.

`conversations.list` returns every public channel — including the ones the bot has never been invited to. Posting to one of those fails at the first firing with `not_in_channel`: a subscription that can never deliver, which is precisely what `validate_slack_channel` exists to prevent. Offering it in a picker is worse than not offering it.

`users.conversations` returns only what the bot is a member of. On a real workspace that was the difference between offering **32 channels and offering the 2 that work**.

## Which makes absence meaningful

If a channel is missing, it's because the bot isn't in it — a 5-second fix in Slack, but only if we say so. So:

- a line under the picker: *"not seeing a channel? add the bot to it in Slack, then hit Refresh."*
- a **Refresh** beside the picker that re-runs only this fetch

Refresh rather than "reload the page" because someone doing this is mid-way through wiring up a trigger, and a reload throws the rest of that away. A failed refresh keeps the list it had — a failed refresh must not be worse than not refreshing. A refresh that comes back with a worse `reason` follows it down to the text box, so a revoked token doesn't leave a stale picker.

## Details

- **Private channels included**, labelled `🔒 name` rather than `#name` — Slack doesn't show them with a `#`. Needs `groups:read`; the manifest change is [glassflow/tares-cloud#…](https://github.com/glassflow/tares-cloud) (see below).
- **The value submitted is the channel ID, displayed as the name.** IDs survive a rename.
- **Placeholder fixed** — it promised only "the channel ID" while `validate_slack_channel` has always accepted a lowercase name too.

## Existing installs keep working

Scopes are baked into the token at install, so every token issued before `channels:read` / `groups:read` fails the listing with `missing_scope`. This is why it isn't a straight swap.

`GET /api/slack/channels` always answers **200** with a `reason` (`null` / `no_token` / `missing_scope` / `error`) rather than an error, so the console branches on data. Anything but `null` falls back to the same text box it always had, plus a line saying to reinstall. Nobody loses the ability to subscribe.

The `missing_scope` message names the scope from Slack's own `needed` field rather than guessing — worth it, and verified: a `channels:read`-only token correctly reported `groups:read`.

## Verified against a real workspace, not a stub

A stub would only have confirmed my own assumptions about Slack's API, so this was driven against a real install:

| | Result |
| --- | --- |
| membership filter | 32 channels → the 2 the bot is in |
| `groups:read` + private | `🔒 test-tares` listed |
| Refresh loop | invite bot → Refresh → appears, sorted in, no page reload |
| `missing_scope` fallback | text box + reconnect hint, on a real pre-scope token |
| `no_token` | empty list, text box |

`tests/test_slack.py` is at 62 assertions (was 42) and pins the endpoint itself — the new assertions fail against `conversations.list`, so the change can't silently regress. All 12 suites green, `tsc --noEmit` clean, console builds.

## Merge order

The cloud manifest PR adds `channels:read` + `groups:read` to the Slack app. **This should land and be released first** — otherwise new installs consent to scopes nothing uses yet.