### PR TITLE
slack: stop unfurling, link the firing, and render what the model writes

### DIFF
--- a/tares/dispatch.py
+++ b/tares/dispatch.py
@@ -54,7 +54,7 @@ class Dispatcher:
             channel = slack_channel_from_url(url)
             if channel is not None:
                 ok, error = await self._slack_post(channel, trigger.name, key, payload,
-                                                   body["fired_at"])
+                                                   body["fired_at"], dispatch_id)
             else:
                 ok, error = await self._post(url, body)
             self.store.log_delivery(dispatch_id, sid, url, ok, error)   # per-agent delivery history
@@ -88,7 +88,7 @@ class Dispatcher:
         return False, error
 
     async def _slack_post(self, channel: str, trigger: str, key: str, payload: str,
-                          fired_at: str | None = None,
+                          fired_at: str | None = None, dispatch_id: str | None = None,
                           attempts: int = 5) -> tuple[bool, str | None]:
         """Deliver one firing to a Slack channel. Same contract as `_post` — (ok, error), same
         five attempts and the same capped exponential backoff — so a Slack subscription's delivery
@@ -103,7 +103,8 @@ class Dispatcher:
         if not token:
             # Not retryable and not transient: nothing about waiting 30s makes a token appear.
             return False, "slack: no bot token configured (set TARES_SLACK_BOT_TOKEN or add one under Security)"
-        msg = {"channel": channel, **slack.build_message(trigger, key, payload, fired_at)}
+        msg = {"channel": channel,
+               **slack.build_message(trigger, key, payload, fired_at, dispatch_id)}
         headers = {"authorization": f"Bearer {token}", "content-type": "application/json"}
         delay = 1.0
         error = None

--- a/tares/slack.py
+++ b/tares/slack.py
@@ -24,6 +24,7 @@ import os
 import re
 import time
 from collections import deque
+from datetime import datetime, timezone
 
 import httpx
 
@@ -57,34 +58,88 @@ def resolve_token(store) -> tuple[str, str]:
     return (stored, "console") if stored else ("", "")
 
 
+def public_base() -> str:
+    """The instance's reachable address, or "". A link to 127.0.0.1 is worse than no link, so
+    nothing is linked until the operator says the instance is reachable (TARES_PUBLIC_URL)."""
+    return os.getenv("TARES_PUBLIC_URL", "").strip().rstrip("/")
+
+
 def deep_link(key: str) -> str:
-    """The `<url|label>` suffix appended to a Slack message, or "" when this instance has no
-    reachable address. A link to 127.0.0.1 is worse than no link, so it is only emitted when the
-    operator has told us the instance is reachable (TARES_PUBLIC_URL)."""
-    base = os.getenv("TARES_PUBLIC_URL", "").strip().rstrip("/")
+    """The `<url|label>` suffix appended to an agent's FINDING — the entity is what a finding is
+    about, so the entity's timeline is where it should land."""
+    base = public_base()
     return f"\n\n<{base}/explore?key={key}|Open {key} in Tares>" if base else ""
+
+
+def dispatch_link(dispatch_id: str | None) -> str:
+    """The `<url|label>` for one firing. A trigger alert is about the firing, not the entity: the
+    dispatch page is the thing that answers "what actually fired, and what did it carry" — which is
+    the question someone reading the alert in Slack has."""
+    base = public_base()
+    return f"<{base}/dispatches/{dispatch_id}|Open in Tares>" if base and dispatch_id else ""
+
+
+# `[T-1734s]` on every event line. Correct, and what an agent wants; unreadable at a glance in a
+# chat client. Rewritten in the SLACK COPY ONLY — the payload itself is the agent-facing contract
+# (it goes out over MCP verbatim), so it keeps its exact seconds.
+_AGE = re.compile(r"\[T-(\d+)s\]")
+
+
+def _humanize_ages(text: str) -> str:
+    def one(m: re.Match) -> str:
+        s = int(m.group(1))
+        if s < 90:
+            return f"[{s}s ago]"
+        if s < 5400:
+            return f"[{round(s / 60)}m ago]"
+        if s < 172800:
+            return f"[{round(s / 3600)}h ago]"
+        return f"[{round(s / 86400)}d ago]"
+    return _AGE.sub(one, text)
+
+
+def _slack_date(iso: str) -> str:
+    """Slack's `<!date^…>` token, which renders in each READER's timezone. A raw ISO string with
+    microseconds and a UTC offset is not a timestamp anyone reads in a chat client. Falls back to
+    the original string if it can't be parsed — a wrong-looking date beats a broken token."""
+    try:
+        dt = datetime.fromisoformat(iso.strip().replace("Z", "+00:00"))
+    except (TypeError, ValueError, AttributeError):
+        return iso
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return f"<!date^{int(dt.timestamp())}^{{date_short_pretty}} at {{time}}|{iso}>"
 
 
 def _truncate(text: str, limit: int = _MAX_SECTION) -> str:
     return text if len(text) <= limit else text[:limit - 1].rstrip() + "…"
 
 
-def build_message(trigger: str, key: str, payload: str, fired_at: str | None = None) -> dict:
+def build_message(trigger: str, key: str, payload: str, fired_at: str | None = None,
+                  dispatch_id: str | None = None) -> dict:
     """Block Kit body for a fired trigger. `text` is always set as well — Slack uses it for the
     notification and for clients that can't render blocks, so a blocks-only message shows up as an
-    empty push notification."""
+    empty push notification.
+
+    `unfurl_links`/`unfurl_media` are off. The body carries every label on the event, so a source
+    with a `host` or `url` label — web traffic, CDN logs, deploys nearly always have one — made
+    Slack fetch that site and staple a preview card to the alert. It roughly doubled the height with
+    nothing about the incident, read as though Tares were linking somewhere relevant, and meant
+    alerting had the side effect of Slack fetching a customer's URLs.
+    """
     headline = f"*{trigger}* fired for *{key}*"
-    link = deep_link(key)
+    link = dispatch_link(dispatch_id)
     blocks: list[dict] = [{"type": "section", "text": {"type": "mrkdwn", "text": headline}}]
-    body = (payload or "").strip()
+    body = _humanize_ages((payload or "").strip())
     if body:
         blocks.append({"type": "section", "text": {
             "type": "mrkdwn", "text": "```" + _truncate(body) + "```"}})
-    context = f"Tares · {fired_at}" if fired_at else "Tares"
+    context = f"Tares · {_slack_date(fired_at)}" if fired_at else "Tares"
     if link:
-        context += " ·" + link.strip()
+        context += " · " + link
     blocks.append({"type": "context", "elements": [{"type": "mrkdwn", "text": context}]})
-    return {"text": f"{trigger} fired for {key}", "blocks": blocks}
+    return {"text": f"{trigger} fired for {key}", "blocks": blocks,
+            "unfurl_links": False, "unfurl_media": False}
 
 
 def classify(status: int, data: dict | None) -> tuple[bool, str | None, bool]:
@@ -274,17 +329,90 @@ def parse_command(text: str) -> tuple[str, str | None]:
 _MD_LINK = re.compile(r"\[([^\]]+)\]\((https?://[^)\s]+)\)")
 _MD_BOLD = re.compile(r"\*\*(.+?)\*\*", re.S)
 _MD_HEAD = re.compile(r"^#{1,6}\s*(.+)$", re.M)
+# A horizontal rule. Slack has no such thing, so `---` arrives as three literal dashes on a line of
+# their own. Excludes anything containing a pipe, which is a table's separator row, not a rule.
+_MD_RULE = re.compile(r"^[ \t]*([-*_])(?:[ \t]*\1){2,}[ \t]*$", re.M)
+_MD_BULLET = re.compile(r"^([ \t]*)[-*][ \t]+(?=\S)", re.M)
+# A table row: starts and ends with a pipe. The separator row is the one that is only dashes,
+# colons, pipes and spaces — it carries alignment, which monospace output cannot express anyway.
+_TBL_ROW = re.compile(r"^[ \t]*\|.*\|[ \t]*$")
+_TBL_SEP = re.compile(r"^[ \t]*\|[\s\-:|]+\|[ \t]*$")
+# Emphasis and code ticks inside a table cell: a code block renders them literally, so `**ok**`
+# would read as asterisks. Stripped rather than converted — inside ``` there is nothing to convert to.
+_CELL_NOISE = re.compile(r"(\*\*|__|`)")
+_BLANKS = re.compile(r"\n{3,}")
+
+
+def _cells(row: str) -> list[str]:
+    return [_CELL_NOISE.sub("", c).strip() for c in row.strip().strip("|").split("|")]
+
+
+def _table_to_code(rows: list[str]) -> str:
+    """A markdown table as an aligned monospace block.
+
+    Slack renders no tables at all — a pipe table arrives as raw pipes plus a `|---|---|` row, which
+    on a three-column answer is most of the message. A code block is the only place Slack keeps
+    columns lined up, so the table becomes text that is at least readable as a table.
+    """
+    grid = [_cells(r) for r in rows if not _TBL_SEP.match(r)]
+    if not grid:
+        return ""
+    width = max(len(r) for r in grid)
+    grid = [r + [""] * (width - len(r)) for r in grid]
+    cols = [max(len(r[i]) for r in grid) for i in range(width)]
+    lines = ["  ".join(c.ljust(cols[i]) for i, c in enumerate(r)).rstrip() for r in grid]
+    if len(grid) > 1:                 # keep the header visually separate, without markdown's pipes
+        lines.insert(1, "  ".join("-" * cols[i] for i in range(width)).rstrip())
+    return "```\n" + "\n".join(lines) + "\n```"
+
+
+def _extract_tables(text: str) -> tuple[str, list[str]]:
+    """Replace each markdown table with a placeholder, returning the rendered blocks separately.
+
+    Done before the emphasis and link substitutions so those never rewrite a table's contents —
+    inside a code block their output would be literal asterisks and angle brackets.
+    """
+    out, tables, run = [], [], []
+
+    def flush():
+        # One row and a separator is a table; a single pipe-ish line is prose and stays prose.
+        if len(run) >= 2 and any(_TBL_SEP.match(r) for r in run):
+            out.append(f"\x00TBL{len(tables)}\x00")
+            tables.append(_table_to_code(run))
+        else:
+            out.extend(run)
+        run.clear()
+
+    for line in (text or "").splitlines():
+        if _TBL_ROW.match(line):
+            run.append(line)
+            continue
+        flush()
+        out.append(line)
+    flush()
+    return "\n".join(out), tables
 
 
 def to_mrkdwn(text: str) -> str:
     """Markdown (what the model writes) → Slack mrkdwn (what Slack renders).
 
-    Only the three differences that actually show up as noise in a channel: `**bold**` is literal
-    asterisks in Slack, `[a](b)` is literal brackets, and `## heading` is a literal hash.
+    Slack's dialect is close enough to markdown to be misleading: `**bold**` is literal asterisks,
+    `[a](b)` is literal brackets, `## heading` is a literal hash, `---` is three dashes, and a pipe
+    table is the raw pipes. All of those were showing up verbatim in `/tares ask` answers — the
+    assistant is told to use small tables where they help, so the table case is not an edge case.
     """
-    text = _MD_LINK.sub(r"<\2|\1>", text or "")
+    text, tables = _extract_tables(text)
+    text = _MD_LINK.sub(r"<\2|\1>", text)
     text = _MD_BOLD.sub(r"*\1*", text)
-    return _MD_HEAD.sub(r"*\1*", text)
+    text = _MD_HEAD.sub(r"*\1*", text)
+    text = _MD_RULE.sub("", text)
+    text = _MD_BULLET.sub(r"\1•  ", text)
+    # A dropped rule leaves the blank line either side of it, so the gap doubles. Collapse any run
+    # of blank lines back to one — nothing in Slack needs more than a paragraph break.
+    text = _BLANKS.sub("\n\n", text)
+    for i, block in enumerate(tables):
+        text = text.replace(f"\x00TBL{i}\x00", block)
+    return text
 
 
 def _sections(text: str) -> list[dict]:
@@ -314,7 +442,10 @@ def build_answer(question: str, answer: str, thread_ts: str | None = None,
     body = {"response_type": "in_channel" if in_channel else "ephemeral",
             "replace_original": True,
             "text": _truncate(answer.strip() or "(no answer)", 500),
-            "blocks": blocks}
+            "blocks": blocks,
+            # Same reason as build_message: an answer that mentions one of the user's hostnames
+            # should not make Slack go and fetch it.
+            "unfurl_links": False, "unfurl_media": False}
     if thread_ts:
         # Invoked inside a thread: the answer belongs in that thread, not adrift in the channel.
         body["thread_ts"] = thread_ts

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -307,8 +307,14 @@ async def main():
                "incident" in str(call["body"].get("text", "")), str(call["body"].get("text")))
             ck("blocks name the trigger and the entity",
                "incident" in blocks and "checkout" in blocks, blocks[:300])
-            ck("blocks carry a deep link when TARES_PUBLIC_URL is set",
-               f"{PUBLIC_URL}/explore?key=checkout" in blocks, blocks[:400])
+            # The alert links the FIRING, not the entity: "what fired and what did it carry" is
+            # the question someone reading it in Slack has. Agent findings still link the entity.
+            ck("blocks link the dispatch when TARES_PUBLIC_URL is set",
+               f"{PUBLIC_URL}/dispatches/" in blocks, blocks[:400])
+            ck("the alert does not link the entity instead",
+               f"{PUBLIC_URL}/explore?key=" not in blocks, blocks[:400])
+            ck("the posted message does not unfurl",
+               call["body"].get("unfurl_links") is False, str(call["body"])[:200])
 
             async def _counted():
                 a = await _slack_row(cx)
@@ -382,6 +388,50 @@ async def main():
     finally:
         _stop(proc)
         stub.shutdown()
+
+    # ── NF-126: the message a human actually reads ────────────────────────────
+    import os as _os
+    from tares import slack as _s
+
+    _os.environ["TARES_PUBLIC_URL"] = "https://cell.example.com"
+    m = _s.build_message("t1", "svc-a", "[T-1734s] something happened",
+                         "2026-08-07T11:47:17.162746+00:00", "ab41d2bbfeec4319bf288abe607fa8ab")
+    ck("unfurling is off — a host label must not make Slack fetch the customer's site",
+       m.get("unfurl_links") is False and m.get("unfurl_media") is False, str(m)[:200])
+    ctx = m["blocks"][-1]["elements"][0]["text"]
+    ck("footer uses Slack's date token, not a raw ISO string",
+       "<!date^" in ctx and "{time}" in ctx, ctx)
+    ck("footer links the DISPATCH, not the entity",
+       "/dispatches/ab41d2bbfeec4319bf288abe607fa8ab" in ctx, ctx)
+    ck("event ages are readable in the Slack copy", "[29m ago]" in m["blocks"][1]["text"]["text"],
+       m["blocks"][1]["text"]["text"])
+
+    _os.environ["TARES_PUBLIC_URL"] = ""
+    ck("no link when the instance has no reachable address",
+       "Open in Tares" not in _s.build_message("t1", "k", "p", None, "abc")["blocks"][-1]
+       ["elements"][0]["text"])
+    ck("a firing with no dispatch id still builds",
+       "blocks" in _s.build_message("t1", "k", "p"))
+
+    md = ("You have **3 sources**:\n\n"
+          "| # | Name | Status |\n|---|------|--------|\n"
+          "| 1 | `docs-github` | ok |\n| 2 | `rius-prod` | push |\n\n"
+          "---\n\n- first\n- second\n")
+    out = _s.to_mrkdwn(md)
+    ck("a markdown table becomes a monospace block, not raw pipes",
+       "```" in out and "|---|" not in out and "| 1 |" not in out, out)
+    ck("table columns are aligned", "docs-github  ok" in out.replace("   ", "  "), out)
+    ck("backticks inside a cell are stripped — a code block renders them literally",
+       "`docs-github`" not in out, out)
+    ck("a horizontal rule does not survive as three dashes",
+       not any(l.strip() == "---" for l in out.splitlines()), out)
+    ck("bullets render as bullets", "•  first" in out, out)
+    ck("bold still converts", "*3 sources*" in out and "**" not in out, out)
+    ck("a lone pipe line is prose, not a table",
+       "```" not in _s.to_mrkdwn("use a | b to split"), _s.to_mrkdwn("use a | b to split"))
+    a = _s.build_answer("q", "answer")
+    ck("answers do not unfurl either",
+       a.get("unfurl_links") is False and a.get("unfurl_media") is False, str(a)[:160])
 
     print(f"\n{P} passed, {F} failed")
     raise SystemExit(1 if F else 0)


### PR DESCRIPTION
Closes NF-126. Everything here came out of watching real deliveries in prod, not from reading the code.

## Unfurling is off

The alert body carries every label on the event. A source with a `host` label — web traffic, CDN logs and deploys nearly always have one — made Slack fetch that site and staple a preview card onto the alert:

> **docs.glassflow.ai** — GlassFlow® documentation

Nothing in Tares added that; `chat.postMessage` unfurls by default and the sink never opted out. It roughly doubled the height of every alert with content carrying no information about the incident, it read as though Tares were linking somewhere relevant when it was echoing a label value, and it meant **alerting had the side effect of Slack fetching a customer's URLs**. Off for `/tares ask` answers too, for the same reason.

## The alert links the firing, not the entity

"What fired, and what did it carry" is the question someone reading the alert has, and `/dispatches/<id>` answers it. So `dispatch_link()` is a **second** helper rather than a change to `deep_link()` — an agent's *finding* is about an entity, so it still links the entity's timeline. Different message, different right target.

Both stay gated on `TARES_PUBLIC_URL`, because a link to `127.0.0.1` is worse than no link.

⚠️ **That variable has never been set on any cloud cell**, so every prod alert so far has silently had no link at all. Fixed by the matching cloud PR — this one alone changes nothing for cloud users.

## Timestamps

The footer was `Tares · 2026-08-06T17:11:01.882211+00:00` — microsecond precision and a UTC offset, in a chat client. Now Slack's `<!date^…>` token, which renders in each **reader's** timezone.

Event ages become `[29m ago]` instead of `[T-1734s]` — **in the Slack copy only**. The payload is the agent-facing contract and goes out over MCP verbatim, so it keeps its exact seconds. The ticket left this open ("decide whether this changes everywhere or only in the Slack rendering"); changing it everywhere would change what agents receive.

## Markdown that `/tares ask` actually emits

`to_mrkdwn` handled `**bold**`, `[a](b)` and `## heading`. It did not handle the two things wrecking real answers:

- **pipe tables** → raw pipes plus a `|---|---|` separator row. On a "how many sources are running" answer that was the entire content.
- **`---` rules** → three literal dashes.

Tables are not an edge case: the assistant is explicitly told to *"use small tables or lists where they help"*. Slack renders no tables at all, so a table becomes an **aligned monospace block** — the only place Slack keeps columns lined up.

Before / after on a real answer:

```
| # | Name | Connector | Type | Status |          #  Name            Connector  Type
|---|------|-----------|------|--------|    →     -  --------------  ---------  ---------------
| 1 | `docs-github` | GitHub | event_stream |     1  docs-github     GitHub     event_stream
```

Extraction runs **before** the emphasis and link substitutions, so those never rewrite a cell's contents — inside a code block their output would be literal asterisks and angle brackets. Cell backticks are stripped for the same reason. A lone pipe in prose (`use a | b to split`) is still prose; a table needs a separator row.

## Verified

`tests/test_slack.py` at 78 assertions, all 13 suites green, `tsc --noEmit` clean. The conversions were checked against the two answers that actually rendered badly, not invented examples.

**One existing assertion changed rather than being made to pass**: it pinned the alert's link to `/explore?key=`, which is now the *finding's* target, not the alert's. The link moving is the point of the change, so the test had to move with it.