### PR TITLE
Ask: server-side chat history

### DIFF
--- a/tares/daemon.py
+++ b/tares/daemon.py
@@ -267,6 +267,11 @@ class ImportReq(BaseModel):
     mode: str = "merge"    # merge (upsert) | replace (clear catalog first)
 
 
+class AskSessionIn(BaseModel):
+    title: str = ""
+    state: str             # opaque JSON blob owned by the console (messages + decisions)
+
+
 class AnthropicKeyIn(BaseModel):
     key: str    # blank-to-keep is not offered here: the only edits are "set a new one" or DELETE
 
@@ -1101,6 +1106,36 @@ def make_app() -> FastAPI:
             run_agent(key, body.get("messages") or [],
                       model=body.get("model"), self_headers=self_headers),
             media_type="text/event-stream")
+
+    # ── Ask sessions — server-side chat history, so a conversation survives navigation and a
+    # console reopened tomorrow can pick up where it left off. The console PUTs the whole session
+    # after each exchange; the store keeps the newest 50.
+    @app.get("/api/ask/sessions")
+    async def ask_sessions():
+        return {"sessions": store.list_ask_sessions()}
+
+    @app.get("/api/ask/sessions/{sid}")
+    async def ask_session(sid: str):
+        row = store.get_ask_session(sid)
+        if row is None:
+            _err(KeyError(f"unknown session {sid!r}"), 404)
+        return row
+
+    @app.put("/api/ask/sessions/{sid}")
+    async def save_ask_session(sid: str, body: AskSessionIn):
+        if not re.fullmatch(r"[0-9a-f]{16,64}", sid):
+            _err(ValueError("session id must be a hex id"), 400)
+        # a runaway transcript should degrade the one session, not the instance
+        if len(body.state) > 2_000_000:
+            _err(ValueError("session too large to save (2 MB cap)"), 413)
+        store.upsert_ask_session(sid, body.title[:120], body.state)
+        return {"ok": True}
+
+    @app.delete("/api/ask/sessions/{sid}")
+    async def remove_ask_session(sid: str):
+        if not store.delete_ask_session(sid):
+            _err(KeyError(f"unknown session {sid!r}"), 404)
+        return {"ok": True}
 
     @app.get("/api/mcp/tools")
     async def mcp_tool_list():

--- a/tares/store.py
+++ b/tares/store.py
@@ -146,6 +146,13 @@ CREATE TABLE IF NOT EXISTS settings (
   value      TEXT,
   updated_at TIMESTAMPTZ
 );
+CREATE TABLE IF NOT EXISTS ask_sessions (
+  id         TEXT PRIMARY KEY,
+  title      TEXT,
+  state      TEXT,
+  created_at TIMESTAMPTZ,
+  updated_at TIMESTAMPTZ
+);
 CREATE TABLE IF NOT EXISTS query_log (
   id            TEXT PRIMARY KEY,
   view          TEXT,
@@ -911,6 +918,49 @@ class Store:
                     "INSERT INTO settings (key, value, updated_at) VALUES (?, ?, ?) "
                     "ON CONFLICT (key) DO UPDATE SET value = excluded.value, "
                     "updated_at = excluded.updated_at", [key, value, now_utc()])
+
+    # ── ask sessions (the in-app agent's chat history) ────────────────────────
+    # `state` is an opaque JSON blob owned by the console (messages, tool calls, proposal
+    # decisions). The daemon stores and returns it; it never interprets it — parsing it here
+    # would couple the store's schema to the UI's message shape for no reader's benefit.
+    ASK_SESSIONS_KEEP = 50   # bounded history: enough to scroll back, never a growth vector
+
+    def list_ask_sessions(self) -> list[dict]:
+        with self._lock:
+            rows = self.con.execute(
+                "SELECT id, title, created_at, updated_at FROM ask_sessions "
+                "ORDER BY updated_at DESC").fetchall()
+        return [{"id": r[0], "title": r[1], "created_at": r[2], "updated_at": r[3]} for r in rows]
+
+    def get_ask_session(self, sid: str) -> dict | None:
+        with self._lock:
+            row = self.con.execute(
+                "SELECT id, title, state, created_at, updated_at FROM ask_sessions WHERE id = ?",
+                [sid]).fetchone()
+        if row is None:
+            return None
+        return {"id": row[0], "title": row[1], "state": row[2],
+                "created_at": row[3], "updated_at": row[4]}
+
+    def upsert_ask_session(self, sid: str, title: str, state: str) -> None:
+        ts = now_utc()
+        with self._lock:
+            self.con.execute(
+                "INSERT INTO ask_sessions (id, title, state, created_at, updated_at) "
+                "VALUES (?, ?, ?, ?, ?) "
+                "ON CONFLICT (id) DO UPDATE SET title = excluded.title, "
+                "state = excluded.state, updated_at = excluded.updated_at",
+                [sid, title, state, ts, ts])
+            self.con.execute(
+                "DELETE FROM ask_sessions WHERE id NOT IN "
+                "(SELECT id FROM ask_sessions ORDER BY updated_at DESC LIMIT ?)",
+                [self.ASK_SESSIONS_KEEP])
+
+    def delete_ask_session(self, sid: str) -> bool:
+        with self._lock:
+            n = self.con.execute("DELETE FROM ask_sessions WHERE id = ?", [sid]).fetchone()
+            # DuckDB returns the deleted-row count as a result row
+        return bool(n and n[0])
 
     # ── activity logs (agent-facing observability) ────────────────────────────
     def log_query(self, qid: str, view: str, key: str, window: str,

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -210,6 +210,18 @@ export const api = {
     request<{ subscription_id: string }>("/subscribe",
       { method: "POST", body: JSON.stringify({ trigger, url }) }),
 
+  // ── Ask sessions: server-side chat history (state is the console's own JSON blob) ──
+  askSessions: () =>
+    request<{ sessions: { id: string; title: string; created_at: string; updated_at: string }[] }>(
+      "/api/ask/sessions"),
+  askSession: (id: string) =>
+    request<{ id: string; title: string; state: string }>(`/api/ask/sessions/${id}`),
+  saveAskSession: (id: string, title: string, state: string) =>
+    request<{ ok: boolean }>(`/api/ask/sessions/${id}`,
+      { method: "PUT", body: JSON.stringify({ title, state }) }),
+  deleteAskSession: (id: string) =>
+    request<{ ok: boolean }>(`/api/ask/sessions/${id}`, { method: "DELETE" }),
+
   queries: (limit = 100) => request<QueryLogEntry[]>(`/api/activity/queries?limit=${limit}`),
   dispatches: (limit = 100) =>
     request<DispatchLogEntry[]>(`/api/activity/dispatches?limit=${limit}`),

--- a/ui/src/components/AskChat.tsx
+++ b/ui/src/components/AskChat.tsx
@@ -3,8 +3,11 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
 import { api, authHeader } from "../api";
+import { TimeAgo } from "./bits";
 import { applyProposal, ProposalCard } from "./proposals";
 import type { DecisionMap, Proposal } from "./proposals";
+
+type SessionMeta = { id: string; title: string; created_at: string; updated_at: string };
 
 // The Ask assistant. Backs both the /ask page and the global ⌘K palette — the page for long
 // sessions, the overlay to ask from anywhere without losing your place.
@@ -88,7 +91,7 @@ const scrollToEnd = () => {
   el.scrollTop = el.scrollHeight;
 };
 
-export default function AskChat() {
+export default function AskChat({ history = false }: { history?: boolean }) {
   const [ready, setReady] = useState<boolean>();      // is a key configured on the server?
   const [msgs, setMsgs] = useState<Msg[]>([]);
   const [input, setInput] = useState("");
@@ -109,6 +112,76 @@ export default function AskChat() {
   const refreshKey = () => api.capabilities()
     .then((c) => setReady(!!c.agent_key_configured)).catch(() => setReady(false));
   useEffect(() => { refreshKey(); }, []);
+
+  // ── server-side chat history ──────────────────────────────────────────────
+  // The conversation is saved to the daemon after every exchange, so navigating away (or closing
+  // the browser) loses nothing: on mount the latest session is resumed, and older ones are
+  // offered on the empty screen. The id is a ref, not state — nothing renders it, and a state
+  // update here would re-render the transcript for no reason.
+  const sessionId = useRef("");
+  const dirty = useRef(false);   // set by a sent message or a proposal decision, never by opening
+  const [sessions, setSessions] = useState<SessionMeta[]>([]);
+  const refreshSessions = () =>
+    api.askSessions().then((r) => setSessions(r.sessions)).catch(() => {});
+
+  const restore = (id: string, state: string) => {
+    try {
+      const st = JSON.parse(state || "{}");
+      sessionId.current = id;
+      dirty.current = false;
+      setMsgs(st.msgs ?? []);
+      setDecisions(st.decisions ?? {});
+      stick.current = true;
+      setShowJump(false);
+    } catch { /* an unreadable blob is a fresh start, not an error screen */ }
+  };
+
+  const booted = useRef(false);
+  useEffect(() => {
+    if (booted.current) return;   // resume once per mount, never after the user pressed New
+    booted.current = true;
+    api.askSessions().then(async (r) => {
+      setSessions(r.sessions);
+      if (!r.sessions.length) return;
+      const full = await api.askSession(r.sessions[0].id);
+      restore(full.id, full.state);
+    }).catch(() => {});
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Save when a turn settles (stream finished, or a proposal decided) — never per token. The
+  // debounce coalesces the decision clicks that land in a burst.
+  const saveTimer = useRef<number>();
+  useEffect(() => {
+    if (busy || msgs.length === 0 || !dirty.current) return;
+    if (!sessionId.current) sessionId.current = crypto.randomUUID().replace(/-/g, "");
+    window.clearTimeout(saveTimer.current);
+    saveTimer.current = window.setTimeout(() => {
+      const first = msgs.find((m) => m.role === "user");
+      const title = (first ? textOf(first).trim() : "conversation").slice(0, 80);
+      api.saveAskSession(sessionId.current, title, JSON.stringify({ msgs, decisions }))
+        .then(() => { dirty.current = false; refreshSessions(); })
+        .catch(() => {});   // a failed save must not disturb the conversation
+    }, 600);
+    return () => window.clearTimeout(saveTimer.current);
+  }, [busy, msgs, decisions]);
+
+  const openSession = async (id: string) => {
+    try {
+      const full = await api.askSession(id);
+      restore(full.id, full.state);
+    } catch { refreshSessions(); }   // deleted meanwhile — drop it from the list
+  };
+  const newConversation = () => {
+    sessionId.current = "";
+    dirty.current = false;
+    setMsgs([]); setDecisions({});
+    stick.current = true; setShowJump(false);
+  };
+  const removeSession = async (id: string) => {
+    try { await api.deleteAskSession(id); } catch { /* already gone */ }
+    if (sessionId.current === id) { sessionId.current = ""; setMsgs([]); setDecisions({}); }
+    refreshSessions();
+  };
 
   // One layout read per animation frame, never per scroll event, and no React state unless the
   // button's visibility actually changes.
@@ -173,6 +246,7 @@ export default function AskChat() {
 
   async function send(text: string) {
     if (!text.trim() || busy) return;
+    dirty.current = true;
     setInput("");
     if (taRef.current) { taRef.current.style.height = "auto"; }
     stick.current = true;
@@ -225,15 +299,38 @@ export default function AskChat() {
     }
   }
 
-  const decide = (id: string, status: "applied" | "skipped" | "error", detail?: string) =>
+  const decide = (id: string, status: "applied" | "skipped" | "error", detail?: string) => {
+    dirty.current = true;
     setDecisions((d) => ({ ...d, [id]: { status, detail } }));
+  };
   const apply = async (p: Proposal) => {
     try { await applyProposal(p); decide(p.id, "applied"); }
     catch (e) { decide(p.id, "error", String((e as Error).message ?? e)); }
   };
 
   return (
-    <div className="askchat">
+    <div className={"askchat" + (history ? " with-rail" : "")}>
+      {history && (
+        <aside className="ask-side">
+          <button type="button" className="primary ask-rail-new" onClick={newConversation}
+                  disabled={busy}>+ New conversation</button>
+          <div className="help" style={{ margin: "14px 0 4px" }}>Recents</div>
+          <div className="ask-rail-list">
+            {sessions.map((sess) => (
+              <div key={sess.id}
+                   className={"ask-rail-item" + (sess.id === sessionId.current ? " active" : "")}
+                   onClick={() => { if (!busy) openSession(sess.id); }}>
+                <span className="t" title={sess.title}>{sess.title || "conversation"}</span>
+                <span className="help when"><TimeAgo ts={sess.updated_at} /></span>
+                <button type="button" className="x" title="delete this conversation"
+                        onClick={(e) => { e.stopPropagation(); removeSession(sess.id); }}>×</button>
+              </div>
+            ))}
+            {sessions.length === 0 && <div className="help">no conversations yet</div>}
+          </div>
+        </aside>
+      )}
+      <div className="ask-main">
       <div className="chat">
         {msgs.length === 0 && (
           <div className="starters">
@@ -276,11 +373,12 @@ export default function AskChat() {
         {busy
           ? <button type="button" className="danger" onClick={() => abortRef.current?.abort()}>Stop</button>
           : <button className="primary" disabled={!input.trim()}>Send</button>}
-        {msgs.length > 0 && !busy && (
+        {!history && msgs.length > 0 && !busy && (
           <button type="button" className="dim" title="start a new conversation"
-                  onClick={() => { setMsgs([]); setDecisions({}); stick.current = true; setShowJump(false); }}>New</button>
+                  onClick={newConversation}>New</button>
         )}
       </form>
+      </div>
     </div>
   );
 }

--- a/ui/src/pages/Ask.tsx
+++ b/ui/src/pages/Ask.tsx
@@ -4,11 +4,9 @@ import AskChat from "../components/AskChat";
 // its own 200-line chat — but it POSTed the same tools to the same endpoint and differed only by a
 // system prompt. That prompt's judgement now applies to every proposal (tares/agent.py), and its
 // full-source sweep is a starter prompt here, so the split bought nothing but a choice to make.
+//
+// No h1: the page is the familiar two-column AI-chat shell — conversations in a second sidebar
+// flush against the nav, the active chat beside it — and the breadcrumb already names the page.
 export default function Ask() {
-  return (
-    <>
-      <h1>Ask</h1>
-      <AskChat />
-    </>
-  );
+  return <AskChat history />;
 }

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -1134,3 +1134,42 @@ pre.payload {
 .codeblock-head { display: flex; justify-content: space-between; align-items: center; padding: 6px 12px; background: var(--th-bg); font-family: var(--pixel); font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase; font-variant-ligatures: none; color: var(--ink-soft); }
 .codeblock pre { margin: 0; border: 0; border-radius: 0; }
 .copybtn { font-size: 12px; padding: 2px 10px; }
+
+/* Ask as the familiar AI-chat shell: a second, full-height sidebar of conversations flush
+   against the app nav, the active chat beside it. Only /ask gets this; the page container drops
+   its padding for it (the :has() below) and the ⌘K overlay stays a single column. */
+.main:has(> .askchat.with-rail) { padding: 0; max-width: none; display: flex; }
+.askchat.with-rail { flex: 1; display: flex; flex-direction: row; align-items: stretch; min-width: 0; }
+.askchat.with-rail .ask-main {
+  flex: 1; min-width: 0;
+  padding: 24px 36px 64px;
+  max-width: 980px; margin: 0 auto;
+}
+.ask-side {
+  width: 240px; flex-shrink: 0;
+  border-right: 1px solid var(--line);
+  background: var(--bg);
+  padding: 16px 12px;
+  position: sticky; top: 46px;                 /* below the breadcrumb bar */
+  height: calc(100vh - 46px);
+  overflow-y: auto;
+}
+.ask-rail-new { width: 100%; }
+.ask-rail-list { display: flex; flex-direction: column; gap: 2px; }
+.ask-rail-item {
+  display: flex; align-items: center; gap: 6px;
+  padding: 7px 9px; border-radius: 6px; cursor: pointer;
+  border: 1px solid transparent; font-size: 13.5px;
+}
+.ask-rail-item:hover { background: var(--wash); }
+.ask-rail-item.active { background: var(--accent-soft); }
+.ask-rail-item .t { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ask-rail-item .when { font-size: 11.5px; white-space: nowrap; }
+.ask-rail-item .x { visibility: hidden; background: none; border: none; cursor: pointer; color: var(--ink-faint); padding: 0 2px; }
+.ask-rail-item:hover .x { visibility: visible; }
+/* On a narrow window the second sidebar would crush the chat: stack it above instead. */
+@media (max-width: 900px) {
+  .askchat.with-rail { flex-direction: column; }
+  .ask-side { position: static; width: 100%; height: auto; max-height: 220px; border-right: none; border-bottom: 1px solid var(--line); }
+}
+


### PR DESCRIPTION
A conversation with Ask now survives navigation, refreshes, and browser restarts.

**Server**: new `ask_sessions` table (id, title, opaque state blob) with list/get/save/delete under `/api/ask/sessions`, behind the normal auth middleware. The daemon never parses the blob — it is the console's message shape stored as-is. Hex-id validation, a 2 MB per-session cap, and only the newest 50 sessions are kept.

**Console**: the Ask page becomes the familiar AI-chat shell — a second full-height sidebar of conversations flush against the nav ("+ New conversation" on top, recents below, active highlighted, delete on hover), the chat beside it. The latest conversation resumes automatically on open (page and ⌘K palette both). Saves happen when a turn settles (debounced, never per streamed token) and only when something actually changed — opening an old conversation does not bump its position. Resumed conversations feed their full transcript back to the agent, same serialization as within a live chat. The palette keeps its single-column layout.

Tested: store round-trip, endpoint edge cases (bad ids, double delete, size cap), full test-script suite (two pre-existing failures unrelated to this change: test_agent.py expects a create_view tool that no longer exists; test_include_payload.py flakes on empty rows), and manual UI runs on a local instance.