### PR TITLE
Agents: per-agent model, Slack channel delivery, authenticated write-back webhook

### DIFF
--- a/tares/builtin_agents.py
+++ b/tares/builtin_agents.py
@@ -32,6 +32,11 @@ from .slack import deep_link as _slack_deep_link
 from .views import resolve_query_full, resolve_read
 
 MODEL = os.getenv("TARES_AGENT_MODEL", "claude-sonnet-4-6")
+# The model choices the console offers per agent. The instance default (TARES_AGENT_MODEL) is
+# always first; an agent stores "" to mean "follow the instance default", so changing the
+# instance default moves every agent that never chose one.
+AGENT_MODELS = list(dict.fromkeys(
+    [MODEL, "claude-opus-5", "claude-sonnet-5", "claude-haiku-4-5-20251001"]))
 # Overridable so the end-to-end test can point at a stub instead of the real API.
 API_BASE = os.getenv("TARES_ANTHROPIC_BASE", "https://api.anthropic.com").rstrip("/")
 MAX_ROUNDS = 6            # model-call rounds per run
@@ -244,7 +249,8 @@ class AgentRunner:
                 r = await cx.post(
                     f"{API_BASE}/v1/messages",
                     headers={"x-api-key": api_key, "anthropic-version": "2023-06-01"},
-                    json={"model": MODEL, "max_tokens": MAX_TOKENS, "system": agent["prompt"],
+                    json={"model": agent.get("model") or MODEL,
+                          "max_tokens": MAX_TOKENS, "system": agent["prompt"],
                           "tools": TOOL_DEFS, "messages": messages})
                 if r.status_code >= 400:
                     raise RuntimeError(f"anthropic {r.status_code}: {r.text[:300]}")
@@ -329,9 +335,45 @@ class AgentRunner:
             "prompt_hash": prompt_hash(agent["prompt"]),
             "labels": {label: key} if label else {},
         })
+        # Notification: the workspace bot posting to a channel is the primary path (one token,
+        # picked from a list, no credential per agent); the per-agent incoming webhook stays as
+        # the secondary/legacy path. An agent uses one — channel wins when both are set.
+        channel = (agent.get("slack_channel") or "").strip()
         hook = agent.get("slack_webhook")
-        if hook:
+        if channel:
+            await self._slack_channel(agent["name"], channel, trigger_name, key, finding)
+        elif hook:
             await self._slack(agent["name"], hook, trigger_name, key, finding)
+
+    async def _slack_channel(self, agent_name: str, channel: str, trigger_name: str,
+                             key: str, finding: str) -> None:
+        """Post the finding through the workspace bot (`chat.postMessage`). Same message shape as
+        the webhook path — the full finding, standing alone — but the credential is the one bot
+        token the instance already holds, and the target is a channel picked from a list.
+
+        One attempt, verdict from `slack.classify` (Slack answers HTTP 200 with ok:false), failure
+        printed — a notification failing must never lose the finding, which is already stored."""
+        from . import slack as _slack_mod
+        token, _origin = _slack_mod.resolve_token(self.store)
+        if not token:
+            print(f"[agent {agent_name}] slack: no bot token configured, channel post skipped")
+            return
+        link = _slack_deep_link(key)
+        text = f"*{agent_name}* · `{trigger_name}` fired for *{key}*\n\n{finding}{link}"
+        try:
+            async with httpx.AsyncClient(timeout=15) as cx:
+                r = await cx.post(f"{_slack_mod.API_BASE}/chat.postMessage",
+                                  json={"channel": channel, "text": text},
+                                  headers={"authorization": f"Bearer {token}"})
+                try:
+                    data = r.json()
+                except Exception:
+                    data = None
+                ok, error, _retry = _slack_mod.classify(r.status_code, data)
+                if not ok:
+                    print(f"[agent {agent_name}] slack: {error}")
+        except Exception as e:   # notification failing must never lose the finding
+            print(f"[agent {agent_name}] slack: {type(e).__name__}: {e}")
 
     async def _slack(self, agent_name: str, hook: str, trigger_name: str, key: str,
                      finding: str) -> None:

--- a/tares/builtin_agents.py
+++ b/tares/builtin_agents.py
@@ -23,11 +23,13 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import os
+import time
 import uuid
 
 import httpx
 
 from .config import FINDINGS_SOURCE, agent_url
+from .envelope import now_utc
 from .slack import deep_link as _slack_deep_link
 from .views import resolve_query_full, resolve_read
 
@@ -192,7 +194,8 @@ class AgentRunner:
         self.store.start_agent_run(run_id, agent["name"], trigger_name, dispatch_id, key,
                                    prompt_hash(agent["prompt"]))
         try:
-            status, error = await self._run(agent, trigger_name, key, payload, run_id)
+            status, error = await self._run(agent, trigger_name, key, payload, run_id,
+                                            dispatch_id)
         except Exception as e:
             detail = f"{type(e).__name__}: {str(e) or repr(e)}"
             self.store.finish_agent_run(run_id, "failed", error=detail[:500])
@@ -207,7 +210,9 @@ class AgentRunner:
                                    None if status == "ok" else error)
 
     async def _run(self, agent: dict, trigger_name: str, key: str, payload: str,
-                   run_id: str) -> tuple[str, str | None]:
+                   run_id: str, dispatch_id: str | None = None) -> tuple[str, str | None]:
+        started_at = now_utc()
+        t0 = time.monotonic()
         api_key, _ = resolve_key(self.store)
         if not api_key:
             msg = "no Anthropic key: set ANTHROPIC_API_KEY or add one in the console"
@@ -230,6 +235,18 @@ class AgentRunner:
         await self._record(agent, trigger_name, key, finding)
         self.store.finish_agent_run(run_id, "ok", rounds=rounds, tool_calls=tool_calls,
                                     finding=finding)
+        if (agent.get("webhook_url") or "").strip():
+            await self._webhook(agent, {
+                "event": "finding",
+                "agent": agent["name"], "trigger": trigger_name, "key": key,
+                "finding": finding,
+                "run_id": run_id, "dispatch_id": dispatch_id,
+                "model": agent.get("model") or MODEL,
+                "rounds": rounds, "tool_calls": tool_calls,
+                "started_at": started_at.isoformat(), "finished_at": now_utc().isoformat(),
+                "duration_s": round(time.monotonic() - t0, 2),
+                "prompt_hash": prompt_hash(agent["prompt"]),
+            })
         return "ok", None
 
     # ── the bounded model loop ────────────────────────────────────────────────
@@ -344,6 +361,37 @@ class AgentRunner:
             await self._slack_channel(agent["name"], channel, trigger_name, key, finding)
         elif hook:
             await self._slack(agent["name"], hook, trigger_name, key, finding)
+
+    async def _webhook(self, agent: dict, body: dict, attempts: int = 3) -> None:
+        """POST the finding plus its run metadata to the agent's write-back webhook — the machine
+        counterpart of the Slack post, for feeding findings into the customer's own automation.
+
+        The body carries only what the customer may already read via the API: the finding, the
+        run's shape (rounds, tool calls, duration), the model name and a hash of the prompt —
+        never a key or token. Auth is an optional bearer token sent as a header; it is never
+        logged, and a delivery failing must never lose the finding (already stored)."""
+        url = agent["webhook_url"].strip()
+        headers = {"content-type": "application/json"}
+        token = (agent.get("webhook_token") or "").strip()
+        if token:
+            headers["authorization"] = f"Bearer {token}"
+        delay = 1.0
+        async with httpx.AsyncClient(timeout=15) as cx:
+            for attempt in range(attempts):
+                try:
+                    r = await cx.post(url, json=body, headers=headers)
+                    if 200 <= r.status_code < 300:
+                        return
+                    if r.status_code < 500:   # client error — won't self-heal, don't retry
+                        print(f"[agent {agent['name']}] webhook: HTTP {r.status_code}")
+                        return
+                    err = f"HTTP {r.status_code}"
+                except Exception as e:        # transport failure — unreachable / timeout / DNS
+                    err = f"{type(e).__name__}: {str(e)[:120]}"
+                if attempt < attempts - 1:
+                    await asyncio.sleep(delay)
+                    delay = min(delay * 2, 10)
+        print(f"[agent {agent['name']}] webhook: giving up after {attempts} attempts ({err})")
 
     async def _slack_channel(self, agent_name: str, channel: str, trigger_name: str,
                              key: str, finding: str) -> None:

--- a/tares/config.py
+++ b/tares/config.py
@@ -126,6 +126,8 @@ class AgentCfg:
     slack_webhook: str = ""
     model: str = ""           # "" = follow the instance default (TARES_AGENT_MODEL)
     slack_channel: str = ""   # workspace-bot channel id; wins over slack_webhook when both set
+    webhook_url: str = ""     # write-back: findings + run metadata POSTed here
+    webhook_token: str = ""   # optional bearer token for the write-back (a secret)
     enabled: bool = False
 
 
@@ -228,6 +230,8 @@ def _agent_from_dict(a: dict, enabled: bool = False) -> AgentCfg:
         slack_webhook=a.get("slack_webhook") or "",
         model=a.get("model") or "",
         slack_channel=a.get("slack_channel") or "",
+        webhook_url=a.get("webhook_url") or "",
+        webhook_token=a.get("webhook_token") or "",
         enabled=bool(a.get("enabled", enabled)),
     )
 
@@ -314,7 +318,8 @@ def import_yaml_to_db(store, text: str) -> dict:
         store.set_trigger_paused(t["name"], bool(t.get("paused", False)))
     for a in agents:
         store.upsert_catalog_agent(a["name"], a["trigger"], a["prompt"], a.get("slack_webhook"),
-                                   a.get("model"), a.get("slack_channel"))
+                                   a.get("model"), a.get("slack_channel"),
+                                   a.get("webhook_url"), a.get("webhook_token"))
         # enabled ⟺ a subscription to the trigger. Reflect the document's state so an enabled agent
         # round-trips: add the internal subscription if enabled, remove it if not.
         url = agent_url(a["name"])
@@ -383,8 +388,11 @@ def export_db_to_yaml(store, sources: list | None = None, include_secrets: bool 
         {"name": a["name"], "trigger": a["trigger"], "prompt": a["prompt"],
          **({"model": a["model"]} if a.get("model") else {}),
          **({"slack_channel": a["slack_channel"]} if a.get("slack_channel") else {}),
+         **({"webhook_url": a["webhook_url"]} if a.get("webhook_url") else {}),
          **({"slack_webhook": a["slack_webhook"]}
             if include_secrets and a.get("slack_webhook") else {}),
+         **({"webhook_token": a["webhook_token"]}
+            if include_secrets and a.get("webhook_token") else {}),
          **({"enabled": True} if agent_url(a["name"]) in enabled_urls else {})}
         for a in store.list_catalog_agents()
         if a["trigger"] in kept_triggers
@@ -636,6 +644,9 @@ def validate_agent_dict(a: dict, trigger_names: set, triggers: dict | None = Non
     if channel and not re.fullmatch(r"[A-Z][A-Z0-9]{4,}", channel):
         raise CatalogError(f"agent {a['name']!r}: slack_channel must be a Slack channel ID "
                            "(e.g. C0123456789), not a name")
+    wurl = str(a.get("webhook_url") or "").strip()
+    if wurl and not wurl.startswith("https://") and not wurl.startswith("http://"):
+        raise CatalogError(f"agent {a['name']!r}: webhook_url must be an http(s) URL")
 
     # Loop guard: a Tares agent writes a finding into the `findings` source. If its trigger
     # watches a view containing that source, the finding re-fires the trigger, which runs the agent

--- a/tares/config.py
+++ b/tares/config.py
@@ -124,6 +124,8 @@ class AgentCfg:
     trigger: str
     prompt: str
     slack_webhook: str = ""
+    model: str = ""           # "" = follow the instance default (TARES_AGENT_MODEL)
+    slack_channel: str = ""   # workspace-bot channel id; wins over slack_webhook when both set
     enabled: bool = False
 
 
@@ -224,6 +226,8 @@ def _agent_from_dict(a: dict, enabled: bool = False) -> AgentCfg:
     return AgentCfg(
         name=a["name"], trigger=a["trigger"], prompt=a["prompt"],
         slack_webhook=a.get("slack_webhook") or "",
+        model=a.get("model") or "",
+        slack_channel=a.get("slack_channel") or "",
         enabled=bool(a.get("enabled", enabled)),
     )
 
@@ -309,7 +313,8 @@ def import_yaml_to_db(store, text: str) -> dict:
         # paused trigger round-trips. Sources carry paused through upsert_catalog_source already.
         store.set_trigger_paused(t["name"], bool(t.get("paused", False)))
     for a in agents:
-        store.upsert_catalog_agent(a["name"], a["trigger"], a["prompt"], a.get("slack_webhook"))
+        store.upsert_catalog_agent(a["name"], a["trigger"], a["prompt"], a.get("slack_webhook"),
+                                   a.get("model"), a.get("slack_channel"))
         # enabled ⟺ a subscription to the trigger. Reflect the document's state so an enabled agent
         # round-trips: add the internal subscription if enabled, remove it if not.
         url = agent_url(a["name"])
@@ -376,6 +381,8 @@ def export_db_to_yaml(store, sources: list | None = None, include_secrets: bool 
     enabled_urls = {s["url"] for s in store.all_subscriptions()}
     agent_out = [
         {"name": a["name"], "trigger": a["trigger"], "prompt": a["prompt"],
+         **({"model": a["model"]} if a.get("model") else {}),
+         **({"slack_channel": a["slack_channel"]} if a.get("slack_channel") else {}),
          **({"slack_webhook": a["slack_webhook"]}
             if include_secrets and a.get("slack_webhook") else {}),
          **({"enabled": True} if agent_url(a["name"]) in enabled_urls else {})}
@@ -619,6 +626,16 @@ def validate_agent_dict(a: dict, trigger_names: set, triggers: dict | None = Non
     hook = str(a.get("slack_webhook") or "").strip()
     if hook and not hook.startswith("https://"):
         raise CatalogError(f"agent {a['name']!r}: slack_webhook must be an https URL")
+    model = str(a.get("model") or "").strip()
+    # Loose on purpose: the console offers a curated list, but YAML/API users may name a model
+    # newer than this build knows. The API rejects a wrong name at run time either way.
+    if model and not re.fullmatch(r"claude-[a-z0-9.\-]+", model):
+        raise CatalogError(f"agent {a['name']!r}: model must be a claude model id (or empty "
+                           "for the instance default)")
+    channel = str(a.get("slack_channel") or "").strip()
+    if channel and not re.fullmatch(r"[A-Z][A-Z0-9]{4,}", channel):
+        raise CatalogError(f"agent {a['name']!r}: slack_channel must be a Slack channel ID "
+                           "(e.g. C0123456789), not a name")
 
     # Loop guard: a Tares agent writes a finding into the `findings` source. If its trigger
     # watches a view containing that source, the finding re-fires the trigger, which runs the agent

--- a/tares/daemon.py
+++ b/tares/daemon.py
@@ -34,7 +34,8 @@ from .connectors import (SPECS, normalize_config, redact_config, restore_secrets
                          source_type_for)
 from .dispatch import Dispatcher
 from .envelope import now_utc
-from .builtin_agents import (PRESETS as AGENT_PRESETS, AgentRunner,
+from .builtin_agents import (AGENT_MODELS, MODEL as AGENT_DEFAULT_MODEL,
+                             PRESETS as AGENT_PRESETS, AgentRunner,
                              resolve_key as resolve_anthropic_key)
 from .runtime import Runtime
 from . import slack as slack_mod
@@ -258,8 +259,10 @@ class TriggerIn(BaseModel):
 class AgentIn(BaseModel):
     name: str
     trigger: str
-    prompt: str                  # the only field a user edits — see docs/design/navflow-agents.md
-    slack_webhook: str = ""
+    prompt: str
+    slack_webhook: str = ""      # legacy per-agent notification path (blank-to-keep on update)
+    model: str = ""              # "" = the instance default (TARES_AGENT_MODEL)
+    slack_channel: str = ""      # workspace-bot channel; the primary notification path
 
 
 class ImportReq(BaseModel):
@@ -1275,9 +1278,13 @@ def make_app() -> FastAPI:
             runs = store.list_agent_runs(a["name"], limit=1)
             rows.append({"name": a["name"], "trigger": a["trigger"], "prompt": a["prompt"],
                          "slack_configured": bool(a.get("slack_webhook")),
+                         "model": a.get("model") or "",
+                         "slack_channel": a.get("slack_channel") or "",
                          "enabled": _agent_enabled(a["name"]), "updated_at": a.get("updated_at"),
                          "last_run": runs[0] if runs else None})
         return {"agents": rows, "key_configured": bool(key), "key_source": origin,
+                "models": AGENT_MODELS, "default_model": AGENT_DEFAULT_MODEL,
+                "slack_workspace": bool(resolve_slack_token(store)[0]),
                 "presets": [{"id": k, **v} for k, v in AGENT_PRESETS.items()]}
 
     @app.post("/api/agents/builtin", status_code=201)
@@ -1285,7 +1292,8 @@ def make_app() -> FastAPI:
         if store.get_catalog_agent(body.name) is not None:
             _err(ValueError(f"agent {body.name!r} already exists"), 409)
         _agent_payload(body)
-        store.upsert_catalog_agent(body.name, body.trigger, body.prompt, body.slack_webhook)
+        store.upsert_catalog_agent(body.name, body.trigger, body.prompt, body.slack_webhook,
+                                   body.model, body.slack_channel)
         runtime.reload_catalog()
         return {"ok": True, "enabled": False,
                 "note": "agents start disabled — enable it to run on the next firing"}
@@ -1301,7 +1309,10 @@ def make_app() -> FastAPI:
         # blank-to-keep for the webhook, matching the connector-secret convention: the UI never
         # receives the stored URL back, so an unedited form must not wipe it.
         hook = body.slack_webhook or existing.get("slack_webhook", "")
-        store.upsert_catalog_agent(name, body.trigger, body.prompt, hook)
+        # model and channel are not secrets: the form always shows the stored value, so what the
+        # body says is what the user wants — including blank (default model / channel removed).
+        store.upsert_catalog_agent(name, body.trigger, body.prompt, hook,
+                                   body.model, body.slack_channel)
         # if the trigger changed while enabled, re-point the subscription so the agent fires on the
         # new trigger (the subscription, not the definition, is what the dispatcher reads).
         if body.trigger != existing["trigger"] and _agent_enabled(name):

--- a/tares/daemon.py
+++ b/tares/daemon.py
@@ -263,6 +263,9 @@ class AgentIn(BaseModel):
     slack_webhook: str = ""      # legacy per-agent notification path (blank-to-keep on update)
     model: str = ""              # "" = the instance default (TARES_AGENT_MODEL)
     slack_channel: str = ""      # workspace-bot channel; the primary notification path
+    webhook_url: str = ""        # write-back: findings + run metadata POSTed here
+    webhook_token: str = ""      # optional bearer for the write-back (secret; blank-to-keep)
+    slack_webhook_clear: bool = False   # blank means keep (it is a secret), so clearing is explicit
 
 
 class ImportReq(BaseModel):
@@ -1280,6 +1283,8 @@ def make_app() -> FastAPI:
                          "slack_configured": bool(a.get("slack_webhook")),
                          "model": a.get("model") or "",
                          "slack_channel": a.get("slack_channel") or "",
+                         "webhook_url": a.get("webhook_url") or "",
+                         "webhook_token_configured": bool(a.get("webhook_token")),
                          "enabled": _agent_enabled(a["name"]), "updated_at": a.get("updated_at"),
                          "last_run": runs[0] if runs else None})
         return {"agents": rows, "key_configured": bool(key), "key_source": origin,
@@ -1293,7 +1298,8 @@ def make_app() -> FastAPI:
             _err(ValueError(f"agent {body.name!r} already exists"), 409)
         _agent_payload(body)
         store.upsert_catalog_agent(body.name, body.trigger, body.prompt, body.slack_webhook,
-                                   body.model, body.slack_channel)
+                                   body.model, body.slack_channel,
+                                   body.webhook_url, body.webhook_token)
         runtime.reload_catalog()
         return {"ok": True, "enabled": False,
                 "note": "agents start disabled — enable it to run on the next firing"}
@@ -1308,11 +1314,15 @@ def make_app() -> FastAPI:
         _agent_payload(body)
         # blank-to-keep for the webhook, matching the connector-secret convention: the UI never
         # receives the stored URL back, so an unedited form must not wipe it.
-        hook = body.slack_webhook or existing.get("slack_webhook", "")
-        # model and channel are not secrets: the form always shows the stored value, so what the
-        # body says is what the user wants — including blank (default model / channel removed).
+        hook = "" if body.slack_webhook_clear else (body.slack_webhook or existing.get("slack_webhook", ""))
+        # blank-to-keep for the write-back token too (a secret the UI never gets back). Clearing
+        # it means clearing the URL: a webhook without its token is a delivery that 401s forever.
+        wtoken = body.webhook_token or (existing.get("webhook_token", "") if body.webhook_url else "")
+        # model, channel and webhook URL are not secrets: the form always shows the stored value,
+        # so what the body says is what the user wants — including blank (removed).
         store.upsert_catalog_agent(name, body.trigger, body.prompt, hook,
-                                   body.model, body.slack_channel)
+                                   body.model, body.slack_channel,
+                                   body.webhook_url, wtoken)
         # if the trigger changed while enabled, re-point the subscription so the agent fires on the
         # new trigger (the subscription, not the definition, is what the dispatcher reads).
         if body.trigger != existing["trigger"] and _agent_enabled(name):

--- a/tares/store.py
+++ b/tares/store.py
@@ -186,6 +186,8 @@ _MIGRATIONS = [
     # rows get NULL (read as False); the upsert always writes an explicit value going forward.
     "ALTER TABLE catalog_triggers ADD COLUMN IF NOT EXISTS paused BOOLEAN",
     "ALTER TABLE dispatch_deliveries ADD COLUMN IF NOT EXISTS error TEXT",
+    "ALTER TABLE catalog_agents ADD COLUMN IF NOT EXISTS model TEXT",
+    "ALTER TABLE catalog_agents ADD COLUMN IF NOT EXISTS slack_channel TEXT",
     # `reviews` were renamed to Tares agents before release; drop the old-named tables if a dev
     # DB still carries them (the definitions are re-created under the new names).
     "DROP TABLE IF EXISTS catalog_reviews",
@@ -784,28 +786,32 @@ class Store:
 
     # ── Tares agents (a prompt attached to a trigger; enabled ⟺ subscribed) ──
     def upsert_catalog_agent(self, name: str, trigger: str, prompt: str,
-                             slack_webhook: str | None = None) -> None:
+                             slack_webhook: str | None = None, model: str | None = None,
+                             slack_channel: str | None = None) -> None:
         ts = now_utc()
         with self._lock:
             self.con.execute(
                 "INSERT INTO catalog_agents "
-                "(name, trigger, prompt, slack_webhook, created_at, updated_at) "
-                "VALUES (?, ?, ?, ?, ?, ?) "
+                "(name, trigger, prompt, slack_webhook, model, slack_channel, "
+                "created_at, updated_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?) "
                 "ON CONFLICT (name) DO UPDATE SET trigger = excluded.trigger, "
                 "prompt = excluded.prompt, slack_webhook = excluded.slack_webhook, "
+                "model = excluded.model, slack_channel = excluded.slack_channel, "
                 "updated_at = excluded.updated_at",
-                [name, trigger, prompt, slack_webhook or "", ts, ts],
+                [name, trigger, prompt, slack_webhook or "", model or "",
+                 slack_channel or "", ts, ts],
             )
 
     def list_catalog_agents(self) -> list[dict]:
         with self._lock:
             rows = self.con.execute(
-                "SELECT name, trigger, prompt, slack_webhook, updated_at "
+                "SELECT name, trigger, prompt, slack_webhook, model, slack_channel, updated_at "
                 "FROM catalog_agents ORDER BY name"
             ).fetchall()
         return [
             {"name": r[0], "trigger": r[1], "prompt": r[2], "slack_webhook": r[3] or "",
-             "updated_at": r[4]}
+             "model": r[4] or "", "slack_channel": r[5] or "", "updated_at": r[6]}
             for r in rows
         ]
 

--- a/tares/store.py
+++ b/tares/store.py
@@ -188,6 +188,8 @@ _MIGRATIONS = [
     "ALTER TABLE dispatch_deliveries ADD COLUMN IF NOT EXISTS error TEXT",
     "ALTER TABLE catalog_agents ADD COLUMN IF NOT EXISTS model TEXT",
     "ALTER TABLE catalog_agents ADD COLUMN IF NOT EXISTS slack_channel TEXT",
+    "ALTER TABLE catalog_agents ADD COLUMN IF NOT EXISTS webhook_url TEXT",
+    "ALTER TABLE catalog_agents ADD COLUMN IF NOT EXISTS webhook_token TEXT",
     # `reviews` were renamed to Tares agents before release; drop the old-named tables if a dev
     # DB still carries them (the definitions are re-created under the new names).
     "DROP TABLE IF EXISTS catalog_reviews",
@@ -787,31 +789,35 @@ class Store:
     # ── Tares agents (a prompt attached to a trigger; enabled ⟺ subscribed) ──
     def upsert_catalog_agent(self, name: str, trigger: str, prompt: str,
                              slack_webhook: str | None = None, model: str | None = None,
-                             slack_channel: str | None = None) -> None:
+                             slack_channel: str | None = None, webhook_url: str | None = None,
+                             webhook_token: str | None = None) -> None:
         ts = now_utc()
         with self._lock:
             self.con.execute(
                 "INSERT INTO catalog_agents "
                 "(name, trigger, prompt, slack_webhook, model, slack_channel, "
-                "created_at, updated_at) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?) "
+                "webhook_url, webhook_token, created_at, updated_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
                 "ON CONFLICT (name) DO UPDATE SET trigger = excluded.trigger, "
                 "prompt = excluded.prompt, slack_webhook = excluded.slack_webhook, "
                 "model = excluded.model, slack_channel = excluded.slack_channel, "
+                "webhook_url = excluded.webhook_url, webhook_token = excluded.webhook_token, "
                 "updated_at = excluded.updated_at",
                 [name, trigger, prompt, slack_webhook or "", model or "",
-                 slack_channel or "", ts, ts],
+                 slack_channel or "", webhook_url or "", webhook_token or "", ts, ts],
             )
 
     def list_catalog_agents(self) -> list[dict]:
         with self._lock:
             rows = self.con.execute(
-                "SELECT name, trigger, prompt, slack_webhook, model, slack_channel, updated_at "
+                "SELECT name, trigger, prompt, slack_webhook, model, slack_channel, "
+                "webhook_url, webhook_token, updated_at "
                 "FROM catalog_agents ORDER BY name"
             ).fetchall()
         return [
             {"name": r[0], "trigger": r[1], "prompt": r[2], "slack_webhook": r[3] or "",
-             "model": r[4] or "", "slack_channel": r[5] or "", "updated_at": r[6]}
+             "model": r[4] or "", "slack_channel": r[5] or "",
+             "webhook_url": r[6] or "", "webhook_token": r[7] or "", "updated_at": r[8]}
             for r in rows
         ]
 

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -150,11 +150,12 @@ export const api = {
   // ── Tares agents: a first look when a trigger fires (managed under /builtin) ──
   builtinAgents: () =>
     request<{ agents: BuiltinAgent[]; key_configured: boolean; key_source: string;
+              models: string[]; default_model: string; slack_workspace: boolean;
               presets: AgentPreset[] }>("/api/agents/builtin"),
-  createBuiltinAgent: (body: { name: string; trigger: string; prompt: string; slack_webhook?: string }) =>
+  createBuiltinAgent: (body: { name: string; trigger: string; prompt: string; slack_webhook?: string; model?: string; slack_channel?: string }) =>
     request<{ ok: boolean; enabled: boolean }>("/api/agents/builtin",
       { method: "POST", body: JSON.stringify(body) }),
-  updateBuiltinAgent: (name: string, body: { name: string; trigger: string; prompt: string; slack_webhook?: string }) =>
+  updateBuiltinAgent: (name: string, body: { name: string; trigger: string; prompt: string; slack_webhook?: string; model?: string; slack_channel?: string }) =>
     request(`/api/agents/builtin/${name}`, { method: "PUT", body: JSON.stringify(body) }),
   deleteBuiltinAgent: (name: string) => request(`/api/agents/builtin/${name}`, { method: "DELETE" }),
   enableBuiltinAgent: (name: string) => request(`/api/agents/builtin/${name}/enable`, { method: "POST" }),

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -152,10 +152,10 @@ export const api = {
     request<{ agents: BuiltinAgent[]; key_configured: boolean; key_source: string;
               models: string[]; default_model: string; slack_workspace: boolean;
               presets: AgentPreset[] }>("/api/agents/builtin"),
-  createBuiltinAgent: (body: { name: string; trigger: string; prompt: string; slack_webhook?: string; model?: string; slack_channel?: string }) =>
+  createBuiltinAgent: (body: { name: string; trigger: string; prompt: string; slack_webhook?: string; slack_webhook_clear?: boolean; model?: string; slack_channel?: string; webhook_url?: string; webhook_token?: string }) =>
     request<{ ok: boolean; enabled: boolean }>("/api/agents/builtin",
       { method: "POST", body: JSON.stringify(body) }),
-  updateBuiltinAgent: (name: string, body: { name: string; trigger: string; prompt: string; slack_webhook?: string; model?: string; slack_channel?: string }) =>
+  updateBuiltinAgent: (name: string, body: { name: string; trigger: string; prompt: string; slack_webhook?: string; slack_webhook_clear?: boolean; model?: string; slack_channel?: string; webhook_url?: string; webhook_token?: string }) =>
     request(`/api/agents/builtin/${name}`, { method: "PUT", body: JSON.stringify(body) }),
   deleteBuiltinAgent: (name: string) => request(`/api/agents/builtin/${name}`, { method: "DELETE" }),
   enableBuiltinAgent: (name: string) => request(`/api/agents/builtin/${name}/enable`, { method: "POST" }),

--- a/ui/src/components/AgentForm.tsx
+++ b/ui/src/components/AgentForm.tsx
@@ -1,18 +1,23 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { api } from "../api";
-import { Combo } from "./bits";
+import type { SlackChannels } from "../api";
+import { Combo, Picker } from "./bits";
 import type { AgentPreset, BuiltinAgent } from "../types";
 
-// Create/edit a Tares agent. One editable substance field — the prompt — seeded by a preset.
-// Model/tools/budgets are Tares's decisions and never surfaced: a second knob turns a data-plane
-// feature into an agent builder (docs/design/tares-agents.md). The trigger is chosen at creation
-// and fixed thereafter (move an agent by deleting and recreating), so it's read-only when editing.
-export default function AgentForm({ initial, presetTrigger, triggers, presets, onSaved, onCancel }: {
+// Create/edit a Tares agent. The prompt is the substance; the model is the one runtime choice an
+// agent may pin (default: follow the instance). Tools and budgets stay Tares's decisions — more
+// knobs turn a data-plane feature into an agent builder (docs/design/tares-agents.md). The trigger
+// is chosen at creation and fixed thereafter (move an agent by deleting and recreating).
+export default function AgentForm({ initial, presetTrigger, triggers, presets, models,
+                                    defaultModel, slackWorkspace, onSaved, onCancel }: {
   initial?: BuiltinAgent;              // absent = create
   presetTrigger?: string;              // create: trigger preselected (came from a trigger page)
   triggers: string[];
   presets: AgentPreset[];
+  models: string[];                    // curated choices; [0] is the instance default
+  defaultModel: string;
+  slackWorkspace: boolean;             // a workspace bot token is configured
   onSaved: (name: string) => void;
   onCancel: () => void;
 }) {
@@ -20,13 +25,35 @@ export default function AgentForm({ initial, presetTrigger, triggers, presets, o
   const [name, setName] = useState(initial?.name ?? "");
   const [trigger, setTrigger] = useState(initial?.trigger ?? presetTrigger ?? "");
   const [prompt, setPrompt] = useState(initial?.prompt ?? "");
+  const [model, setModel] = useState(initial?.model ?? "");
+  const [channel, setChannel] = useState(initial?.slack_channel ?? "");
   const [slack, setSlack] = useState("");
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string>();
 
+  // "" is a real option — follow the instance default — so the picker always has one more entry
+  // than the curated list, and the default reads as what it is rather than as a copy of a model.
+  const modelOptions = ["", ...models.filter((m) => m !== defaultModel)];
+  const modelLabels: Record<string, string> = { "": `${defaultModel} · instance default` };
+
+  // The channel list comes from the workspace bot, exactly like the trigger page's picker: only
+  // channels the bot is in are offered, because anything else fails at the first post.
+  const [channels, setChannels] = useState<SlackChannels>();
+  useEffect(() => {
+    if (!slackWorkspace) return;
+    let live = true;
+    api.slackChannels().then((c) => { if (live) setChannels(c); })
+      .catch(() => { if (live) setChannels({ channels: [], reason: "error" }); });
+    return () => { live = false; };
+  }, [slackWorkspace]);
+  const chanList = channels?.reason === null ? channels.channels : [];
+  const chanLabels: Record<string, string> = { "": "no channel — don't post" };
+  for (const c of chanList) chanLabels[c.id] = (c.is_private ? "🔒 " : "#") + c.name;
+
   const save = async () => {
     setBusy(true); setErr(undefined);
-    const body = { name: name.trim(), trigger, prompt: prompt.trim(), slack_webhook: slack.trim() };
+    const body = { name: name.trim(), trigger, prompt: prompt.trim(), model,
+                   slack_channel: channel, slack_webhook: slack.trim() };
     try {
       if (isNew) await api.createBuiltinAgent(body);
       else await api.updateBuiltinAgent(initial!.name, body);
@@ -81,13 +108,44 @@ export default function AgentForm({ initial, presetTrigger, triggers, presets, o
           ))}
         </div>
       )}
-      <label className="field">
-        <span className="lbl">Slack webhook <span className="help">(optional)</span></span>
-        <input type="text" className="mono" placeholder={
-          initial?.slack_configured ? "•••• configured — leave blank to keep" : "https://hooks.slack.com/services/…"}
-               value={slack} onChange={(e) => setSlack(e.target.value)} />
-        <span className="help">the full finding is posted there, not a link</span>
-      </label>
+      <div className="field">
+        <span className="lbl">model</span>
+        <Picker value={model} onChange={setModel} options={modelOptions} labels={modelLabels}
+                ariaLabel="model" />
+        <span className="help">the model this agent runs on; leave on the default to follow the instance</span>
+      </div>
+      {slackWorkspace ? (
+        <>
+          <div className="field">
+            <span className="lbl">post findings to Slack <span className="help">(optional)</span></span>
+            <Picker value={channel} onChange={setChannel}
+                    options={["", ...chanList.map((c) => c.id)]} labels={chanLabels}
+                    ariaLabel="Slack channel" />
+            <span className="help">
+              posted by the workspace bot; the full finding, not a link.
+              {channels?.reason === "missing_scope" && " (reconnect Slack to list channels)"}
+              {channels?.reason === null && chanList.length === 0 && " Add the bot to a channel in Slack first."}
+            </span>
+          </div>
+          <label className="field">
+            <span className="lbl">Slack webhook <span className="help">(legacy — used only when no channel is set)</span></span>
+            <input type="text" className="mono" placeholder={
+              initial?.slack_configured ? "•••• configured — leave blank to keep" : "https://hooks.slack.com/services/…"}
+                   value={slack} onChange={(e) => setSlack(e.target.value)} />
+          </label>
+        </>
+      ) : (
+        <label className="field">
+          <span className="lbl">Slack webhook <span className="help">(optional)</span></span>
+          <input type="text" className="mono" placeholder={
+            initial?.slack_configured ? "•••• configured — leave blank to keep" : "https://hooks.slack.com/services/…"}
+                 value={slack} onChange={(e) => setSlack(e.target.value)} />
+          <span className="help">
+            the full finding is posted there, not a link. Connect a workspace bot under Security to
+            pick a channel instead.
+          </span>
+        </label>
+      )}
       <div className="btnrow">
         <button className="primary" onClick={save}
                 disabled={busy || !name.trim() || !trigger.trim() || !prompt.trim()}>

--- a/ui/src/components/AgentForm.tsx
+++ b/ui/src/components/AgentForm.tsx
@@ -5,10 +5,51 @@ import type { SlackChannels } from "../api";
 import { Combo, Picker } from "./bits";
 import type { AgentPreset, BuiltinAgent } from "../types";
 
+/** One delivery option: a collapsed row whose title and description read before it is opened.
+ *  Opening the row shows an explicit on/off toggle; the fields appear only when it is on. */
+function OptionRow({ title, desc, on, disabled, disabledHint, onToggle, children }: {
+  title: string; desc: string; on: boolean;
+  disabled?: boolean; disabledHint?: string;
+  onToggle: (on: boolean) => void;
+  children?: React.ReactNode;
+}) {
+  const [open, setOpen] = useState(on);
+  return (
+    <div className="opt-row">
+      <button type="button" className="opt-head" onClick={() => setOpen((o) => !o)}>
+        <span className="opt-caret">{open ? "▾" : "▸"}</span>
+        <span>
+          <span className="opt-title">{title}</span>
+          <span className="opt-desc help">{desc}</span>
+        </span>
+        <span className={"badge" + (on ? " ok" : "")}>{on ? "on" : "off"}</span>
+      </button>
+      {open && (
+        <div className="opt-body">
+          {disabled
+            ? <span className="help">{disabledHint}</span>
+            : (
+              <label className="opt-toggle">
+                <input type="checkbox" checked={on} onChange={(e) => onToggle(e.target.checked)} />
+                <span>{on ? "enabled" : "enable"}</span>
+              </label>
+            )}
+          {on && !disabled && children}
+        </div>
+      )}
+    </div>
+  );
+}
+
 // Create/edit a Tares agent. The prompt is the substance; the model is the one runtime choice an
-// agent may pin (default: follow the instance). Tools and budgets stay Tares's decisions — more
+// agent may pin (default: follow the instance). Tools and budgets stay Tares's decisions: more
 // knobs turn a data-plane feature into an agent builder (docs/design/tares-agents.md). The trigger
 // is chosen at creation and fixed thereafter (move an agent by deleting and recreating).
+//
+// Delivery is a list of collapsed option rows, each with an explicit toggle: the finding always
+// lands on the entity's timeline; these rows only deliver it elsewhere too. The write-back URL and
+// its bearer token render as one connected control (.hook-group): they are one credential pair,
+// not two settings.
 export default function AgentForm({ initial, presetTrigger, triggers, presets, models,
                                     defaultModel, slackWorkspace, onSaved, onCancel }: {
   initial?: BuiltinAgent;              // absent = create
@@ -26,12 +67,21 @@ export default function AgentForm({ initial, presetTrigger, triggers, presets, m
   const [trigger, setTrigger] = useState(initial?.trigger ?? presetTrigger ?? "");
   const [prompt, setPrompt] = useState(initial?.prompt ?? "");
   const [model, setModel] = useState(initial?.model ?? "");
+
+  // Delivery options: each is a toggle plus its fields. Off at save time means off, even if the
+  // fields still hold text.
+  const [channelOn, setChannelOn] = useState(!!initial?.slack_channel);
   const [channel, setChannel] = useState(initial?.slack_channel ?? "");
+  const [hookOn, setHookOn] = useState(!!initial?.slack_configured);
   const [slack, setSlack] = useState("");
+  const [writebackOn, setWritebackOn] = useState(!!initial?.webhook_url);
+  const [webhookUrl, setWebhookUrl] = useState(initial?.webhook_url ?? "");
+  const [webhookToken, setWebhookToken] = useState("");
+
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string>();
 
-  // "" is a real option — follow the instance default — so the picker always has one more entry
+  // "" is a real option (follow the instance default), so the picker always has one more entry
   // than the curated list, and the default reads as what it is rather than as a copy of a model.
   const modelOptions = ["", ...models.filter((m) => m !== defaultModel)];
   const modelLabels: Record<string, string> = { "": `${defaultModel} · instance default` };
@@ -47,13 +97,19 @@ export default function AgentForm({ initial, presetTrigger, triggers, presets, m
     return () => { live = false; };
   }, [slackWorkspace]);
   const chanList = channels?.reason === null ? channels.channels : [];
-  const chanLabels: Record<string, string> = { "": "no channel — don't post" };
+  const chanLabels: Record<string, string> = { "": "pick a channel…" };
   for (const c of chanList) chanLabels[c.id] = (c.is_private ? "🔒 " : "#") + c.name;
 
   const save = async () => {
     setBusy(true); setErr(undefined);
-    const body = { name: name.trim(), trigger, prompt: prompt.trim(), model,
-                   slack_channel: channel, slack_webhook: slack.trim() };
+    const body = {
+      name: name.trim(), trigger, prompt: prompt.trim(), model,
+      slack_channel: channelOn ? channel : "",
+      slack_webhook: hookOn ? slack.trim() : "",
+      slack_webhook_clear: !hookOn,
+      webhook_url: writebackOn ? webhookUrl.trim() : "",
+      webhook_token: writebackOn ? webhookToken.trim() : "",
+    };
     try {
       if (isNew) await api.createBuiltinAgent(body);
       else await api.updateBuiltinAgent(initial!.name, body);
@@ -80,14 +136,14 @@ export default function AgentForm({ initial, presetTrigger, triggers, presets, m
           </div>
         </div>
       ) : (
-        // Name and trigger are fixed after creation — shown as read-only facts, not fields, so it's
+        // Name and trigger are fixed after creation: shown as read-only facts, not fields, so it's
         // clear they can't be edited here (to move the agent, delete and recreate).
         <table style={{ marginBottom: 12 }}>
           <tbody>
             <tr><td className="help" style={{ width: 120 }}>name</td>
-                <td className="mono">{name} <span className="help">— fixed</span></td></tr>
+                <td className="mono">{name} <span className="help">fixed</span></td></tr>
             <tr><td className="help">trigger</td>
-                <td className="mono">{trigger} <span className="help">— fixed; delete and recreate to move</span></td></tr>
+                <td className="mono">{trigger} <span className="help">fixed; delete and recreate to move</span></td></tr>
           </tbody>
         </table>
       )}
@@ -112,43 +168,55 @@ export default function AgentForm({ initial, presetTrigger, triggers, presets, m
         <span className="lbl">model</span>
         <Picker value={model} onChange={setModel} options={modelOptions} labels={modelLabels}
                 ariaLabel="model" />
-        <span className="help">the model this agent runs on; leave on the default to follow the instance</span>
       </div>
-      {slackWorkspace ? (
-        <>
-          <div className="field">
-            <span className="lbl">post findings to Slack <span className="help">(optional)</span></span>
-            <Picker value={channel} onChange={setChannel}
-                    options={["", ...chanList.map((c) => c.id)]} labels={chanLabels}
-                    ariaLabel="Slack channel" />
-            <span className="help">
-              posted by the workspace bot; the full finding, not a link.
-              {channels?.reason === "missing_scope" && " (reconnect Slack to list channels)"}
-              {channels?.reason === null && chanList.length === 0 && " Add the bot to a channel in Slack first."}
-            </span>
-          </div>
-          <label className="field">
-            <span className="lbl">Slack webhook <span className="help">(legacy — used only when no channel is set)</span></span>
-            <input type="text" className="mono" placeholder={
-              initial?.slack_configured ? "•••• configured — leave blank to keep" : "https://hooks.slack.com/services/…"}
-                   value={slack} onChange={(e) => setSlack(e.target.value)} />
-          </label>
-        </>
-      ) : (
-        <label className="field">
-          <span className="lbl">Slack webhook <span className="help">(optional)</span></span>
-          <input type="text" className="mono" placeholder={
-            initial?.slack_configured ? "•••• configured — leave blank to keep" : "https://hooks.slack.com/services/…"}
-                 value={slack} onChange={(e) => setSlack(e.target.value)} />
+
+      <div className="field">
+        <h3 style={{ margin: "10px 0 2px", fontSize: 16 }}>Deliver findings</h3>
+        <span className="help" style={{ display: "block", margin: "0 0 10px" }}>
+          every finding lands on the entity's timeline; these options also deliver it elsewhere
+        </span>
+        <OptionRow title="Slack channel"
+                   desc="the workspace bot posts the full finding to a channel"
+                   on={channelOn} disabled={!slackWorkspace}
+                   disabledHint="connect a workspace bot under Security to enable this"
+                   onToggle={setChannelOn}>
+          <Picker value={channel} onChange={setChannel}
+                  options={["", ...chanList.map((c) => c.id)]} labels={chanLabels}
+                  ariaLabel="Slack channel" />
           <span className="help">
-            the full finding is posted there, not a link. Connect a workspace bot under Security to
-            pick a channel instead.
+            {channels?.reason === "missing_scope" && "reconnect Slack to list channels"}
+            {channels?.reason === null && chanList.length === 0 && "add the bot to a channel in Slack first"}
           </span>
-        </label>
-      )}
+        </OptionRow>
+        <OptionRow title="Slack incoming webhook"
+                   desc="legacy per-agent webhook; used only when no channel is set"
+                   on={hookOn} onToggle={setHookOn}>
+          <input type="text" className="mono" placeholder={
+            initial?.slack_configured ? "•••• configured, leave blank to keep" : "https://hooks.slack.com/services/…"}
+                 value={slack} onChange={(e) => setSlack(e.target.value)} />
+        </OptionRow>
+        <OptionRow title="Write-back webhook"
+                   desc="POST each finding as JSON with its run metadata to your own automation"
+                   on={writebackOn} onToggle={setWritebackOn}>
+          <div className="hook-group">
+            <input type="text" className="mono" placeholder="https://your-automation.example.com/findings"
+                   value={webhookUrl} onChange={(e) => setWebhookUrl(e.target.value)} />
+            <input type="password" className="mono" autoComplete="new-password" placeholder={
+              initial?.webhook_token_configured ? "bearer token: •••• configured, leave blank to keep" : "bearer token (optional)"}
+                   value={webhookToken} onChange={(e) => setWebhookToken(e.target.value)} />
+          </div>
+          <span className="help">
+            the payload carries the finding plus trigger, entity, model, rounds, tool calls and
+            timing; the token is sent as an Authorization header and never shown again
+          </span>
+        </OptionRow>
+      </div>
+
       <div className="btnrow">
         <button className="primary" onClick={save}
-                disabled={busy || !name.trim() || !trigger.trim() || !prompt.trim()}>
+                disabled={busy || !name.trim() || !trigger.trim() || !prompt.trim()
+                          || (writebackOn && !webhookUrl.trim())
+                          || (channelOn && !channel)}>
           {isNew ? "Create agent" : "Save changes"}
         </button>
         <button onClick={onCancel}>Cancel</button>

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -80,6 +80,9 @@ export default function AgentDetail() {
           initial={agent}
           triggers={(triggers ?? []).map((t) => t.name)}
           presets={data.presets}
+          models={data.models}
+          defaultModel={data.default_model}
+          slackWorkspace={data.slack_workspace}
           onSaved={() => { setEditing(false); reload(); }}
           onCancel={() => setEditing(false)}
         />
@@ -108,8 +111,15 @@ export default function AgentDetail() {
                       ? <><TimeAgo ts={lastRun.started_at} /> for <span className="mono">{lastRun.key}</span>
                           {lastRun.dispatch_id && <> · <Link to={`/dispatches/${encodeURIComponent(lastRun.dispatch_id)}`}>the firing</Link></>}</>
                       : <span className="dim">never</span>}</td></tr>
+                <tr><td className="help">model</td>
+                    <td><span className="mono">{agent.model || data.default_model}</span>
+                        {!agent.model && <span className="help"> — instance default</span>}</td></tr>
                 <tr><td className="help">Slack</td>
-                    <td>{agent.slack_configured ? <span className="badge ok">configured</span> : <span className="dim">—</span>}</td></tr>
+                    <td>{agent.slack_channel
+                      ? <><span className="badge ok">channel</span> <span className="help">posted by the workspace bot</span></>
+                      : agent.slack_configured
+                        ? <><span className="badge ok">webhook</span> <span className="help">legacy per-agent webhook</span></>
+                        : <span className="dim">—</span>}</td></tr>
                 <tr><td className="help">prompt</td>
                     <td><pre className="mono" style={{ whiteSpace: "pre-wrap", margin: 0 }}>{agent.prompt}</pre></td></tr>
               </tbody>

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -120,6 +120,13 @@ export default function AgentDetail() {
                       : agent.slack_configured
                         ? <><span className="badge ok">webhook</span> <span className="help">legacy per-agent webhook</span></>
                         : <span className="dim">—</span>}</td></tr>
+                <tr><td className="help">write-back</td>
+                    <td>{agent.webhook_url
+                      ? <><span className="mono">{agent.webhook_url}</span>
+                          {agent.webhook_token_configured
+                            ? <span className="badge ok" style={{ marginLeft: 8 }}>bearer auth</span>
+                            : <span className="help"> — no auth</span>}</>
+                      : <span className="dim">—</span>}</td></tr>
                 <tr><td className="help">prompt</td>
                     <td><pre className="mono" style={{ whiteSpace: "pre-wrap", margin: 0 }}>{agent.prompt}</pre></td></tr>
               </tbody>

--- a/ui/src/pages/AgentNew.tsx
+++ b/ui/src/pages/AgentNew.tsx
@@ -14,14 +14,20 @@ export default function AgentNew() {
 
   const [triggers, setTriggers] = useState<string[]>();
   const [presets, setPresets] = useState<AgentPreset[]>([]);
+  const [models, setModels] = useState<string[]>([]);
+  const [defaultModel, setDefaultModel] = useState("");
+  const [slackWorkspace, setSlackWorkspace] = useState(false);
   const [keyOk, setKeyOk] = useState(true);
   const [err, setErr] = useState<string>();
 
   useEffect(() => {
     api.triggers().then((ts) => setTriggers(ts.map((t) => t.name)))
       .catch((e) => setErr(String((e as Error).message ?? e)));
-    api.builtinAgents().then((d) => { setPresets(d.presets); setKeyOk(d.key_configured); })
-      .catch(() => {});
+    api.builtinAgents().then((d) => {
+      setPresets(d.presets); setKeyOk(d.key_configured);
+      setModels(d.models); setDefaultModel(d.default_model);
+      setSlackWorkspace(d.slack_workspace);
+    }).catch(() => {});
   }, []);
 
   return (
@@ -51,6 +57,9 @@ export default function AgentNew() {
             presetTrigger={presetTrigger}
             triggers={triggers}
             presets={presets}
+            models={models}
+            defaultModel={defaultModel}
+            slackWorkspace={slackWorkspace}
             onSaved={(name) => nav(`/agents/${encodeURIComponent(name)}`)}
             onCancel={() => nav(presetTrigger ? `/triggers/${encodeURIComponent(presetTrigger)}` : "/agents")}
           />

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -449,12 +449,15 @@ button.linklike:hover { border: none; opacity: 0.8; }
 .menu-pop .menu-item:hover { background: var(--hover); }
 
 label.field { display: block; margin-bottom: 14px; }
-label.field .lbl { display: block; font-size: 12px; font-weight: 600; margin-bottom: 4px; }
+/* div.field is the same thing for fields that hold interactive children (a Picker, option rows)
+   where nesting them in a <label> would misdirect clicks — the LOOK must not differ. */
+div.field { display: block; margin-bottom: 14px; }
+label.field .lbl, div.field > .lbl { display: block; font-size: 12px; font-weight: 600; margin-bottom: 4px; }
 label.field .lbl .req { color: var(--accent-deep); }
 label.field.invalid input, label.field.invalid textarea, label.field.invalid select { border-color: var(--err); background: var(--err-soft); }
 label.field.invalid input:focus, label.field.invalid textarea:focus { box-shadow: 0 0 0 3px var(--err-soft); }
 label.field.invalid .help { color: var(--err); }
-label.field .help { display: block; font-size: 12px; color: var(--ink-soft); margin-top: 3px; }
+label.field .help, div.field > .help { display: block; font-size: 12px; color: var(--ink-soft); margin-top: 3px; }
 .help { color: var(--ink-soft); }
 
 /* two-column connector field rows */
@@ -1173,3 +1176,27 @@ pre.payload {
   .ask-side { position: static; width: 100%; height: auto; max-height: 220px; border-right: none; border-bottom: 1px solid var(--line); }
 }
 
+
+/* Delivery option rows on the agent form: collapsed rows that read before they open, an explicit
+   toggle inside, fields only when on. */
+.opt-row { border: 1px solid var(--line); border-radius: 8px; margin-bottom: 6px; }
+.opt-head {
+  display: flex; align-items: center; gap: 10px; width: 100%;
+  padding: 10px 12px; background: none; border: none; cursor: pointer;
+  font: inherit; text-align: left;
+}
+.opt-head:hover { background: var(--wash); border-radius: 8px; }
+.opt-caret { color: var(--ink-faint); width: 12px; flex-shrink: 0; }
+.opt-title { font-weight: 600; margin-right: 10px; }
+.opt-desc { display: inline; }
+.opt-head .badge { margin-left: auto; flex-shrink: 0; }
+.opt-body { padding: 0 12px 12px 34px; display: flex; flex-direction: column; gap: 8px; }
+.opt-toggle { display: flex; align-items: center; gap: 8px; cursor: pointer; font-size: 13.5px; }
+.opt-toggle input { accent-color: var(--accent); }
+
+/* URL + bearer token as ONE control: a shared border, an inner divider, no gap — they are a
+   credential pair, not two independent settings. */
+.hook-group { border: 1px solid var(--line); border-radius: 8px; overflow: hidden; }
+.hook-group input { border: none; border-radius: 0; width: 100%; }
+.hook-group input + input { border-top: 1px solid var(--line); }
+.hook-group:focus-within { border-color: var(--accent); }

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -235,6 +235,8 @@ export interface BuiltinAgent {
   slack_configured: boolean;   // the webhook URL itself is never sent to the client
   model: string;               // "" = the instance default
   slack_channel: string;       // workspace-bot channel id, "" = none
+  webhook_url: string;         // write-back target, "" = none
+  webhook_token_configured: boolean;   // the token itself is never sent to the client
   updated_at?: string;
   last_run?: AgentRun | null;
 }

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -233,6 +233,8 @@ export interface BuiltinAgent {
   prompt: string;
   enabled: boolean;
   slack_configured: boolean;   // the webhook URL itself is never sent to the client
+  model: string;               // "" = the instance default
+  slack_channel: string;       // workspace-bot channel id, "" = none
   updated_at?: string;
   last_run?: AgentRun | null;
 }


### PR DESCRIPTION
Three additions to Tares agents, plus a redesign of how delivery is configured.

**Per-agent model.** A dropdown (the product's Picker) with a curated list served by the daemon; the instance default (TARES_AGENT_MODEL) is always first and stored as empty, so unpinned agents follow the instance. YAML/API accept any claude-* id so newer models work without a release.

**Slack channel as the primary Slack output.** When the workspace bot is connected, the agent posts findings to a channel picked from the bot's own membership list (same rule and rendering as trigger subscriptions); the per-agent incoming webhook demotes to a legacy option and can now actually be turned off (new explicit clear flag; blank still means keep).

**Authenticated write-back webhook.** Findings POST as JSON to the customer's automation with run metadata: trigger, entity key, model, rounds, tool calls, started/finished timestamps, duration, run and dispatch ids, and the prompt hash. Never a key or token. Optional bearer token sent as an Authorization header, stored like the other agent secret (never returned by the API, blank-to-keep, exported only with include_secrets; clearing the URL clears the token). Delivery retries transient failures and never loses the finding, which is already stored.

**Form redesign.** Delivery options are collapsed rows under a "Deliver findings" section: title and description readable before expanding, an explicit enable toggle inside, fields only when on. The write-back URL and token render as one connected control. Field label styling unified across label/div fields (model's label was unstyled).

Tested: agent/catalog/Slack test scripts pass; webhook delivery verified against a local receiver (bearer header, 5xx retry, clean payload); API round-trip confirms the token never appears in responses and blank-to-keep works; DB migration via the existing ALTER TABLE pattern.