### PR TITLE
Agents: external MCP server registry with per-agent selection and run-loop integration

### DIFF
--- a/tares/builtin_agents.py
+++ b/tares/builtin_agents.py
@@ -225,16 +225,17 @@ class AgentRunner:
             self.store.finish_agent_run(run_id, "capped", error=msg)
             return "capped", msg
 
-        finding, rounds, tool_calls = await self._loop(agent, trigger_name, key, payload, api_key)
+        finding, rounds, tool_calls, external_used = await self._loop(
+            agent, trigger_name, key, payload, api_key)
         if not finding:
             msg = "the model returned no conclusion"
             self.store.finish_agent_run(run_id, "empty", rounds=rounds, tool_calls=tool_calls,
-                                        error=msg)
+                                        error=msg, external_tools=external_used)
             return "empty", msg
 
         await self._record(agent, trigger_name, key, finding)
         self.store.finish_agent_run(run_id, "ok", rounds=rounds, tool_calls=tool_calls,
-                                    finding=finding)
+                                    finding=finding, external_tools=external_used)
         if (agent.get("webhook_url") or "").strip():
             await self._webhook(agent, {
                 "event": "finding",
@@ -251,7 +252,22 @@ class AgentRunner:
 
     # ── the bounded model loop ────────────────────────────────────────────────
     async def _loop(self, agent: dict, trigger_name: str, key: str, payload: str,
-                    api_key: str) -> tuple[str, int, int]:
+                    api_key: str) -> tuple[str, int, int, list[str]]:
+        # External tools: the agent's selected MCP servers, connected for the duration of this
+        # run. A server that fails to connect is skipped (recorded below) — losing a tool server
+        # must not lose the run.
+        from .mcp_client import RemoteToolbox
+        selected = set(agent.get("mcp_servers") or [])
+        servers = [m for m in self.store.list_mcp_servers() if m["name"] in selected]
+        async with RemoteToolbox(servers) as toolbox:
+            for failure in toolbox.failures:
+                print(f"[agent {agent['name']}] mcp connect failed — {failure}")
+            return await self._loop_with(agent, trigger_name, key, payload, api_key, toolbox)
+
+    async def _loop_with(self, agent: dict, trigger_name: str, key: str, payload: str,
+                         api_key: str, toolbox) -> tuple[str, int, int, list[str]]:
+        tools = TOOL_DEFS + toolbox.tool_defs
+        external_used: list[str] = []
         messages = [{
             "role": "user",
             "content": (
@@ -268,7 +284,7 @@ class AgentRunner:
                     headers={"x-api-key": api_key, "anthropic-version": "2023-06-01"},
                     json={"model": agent.get("model") or MODEL,
                           "max_tokens": MAX_TOKENS, "system": agent["prompt"],
-                          "tools": TOOL_DEFS, "messages": messages})
+                          "tools": tools, "messages": messages})
                 if r.status_code >= 400:
                     raise RuntimeError(f"anthropic {r.status_code}: {r.text[:300]}")
                 msg = r.json()
@@ -278,19 +294,24 @@ class AgentRunner:
                 if not uses:
                     text = "\n".join(b.get("text", "") for b in msg["content"]
                                      if b.get("type") == "text")
-                    return text.strip(), rounds, tool_calls
+                    return text.strip(), rounds, tool_calls, external_used
 
                 results = []
                 for u in uses:
                     tool_calls += 1
+                    name = str(u["name"])
                     try:
-                        out = self._tool(agent["name"], str(u["name"]), u.get("input") or {})
+                        if toolbox.owns(name):
+                            external_used.append(name)
+                            out = await toolbox.call(name, u.get("input") or {})
+                        else:
+                            out = self._tool(agent["name"], name, u.get("input") or {})
                     except Exception as e:   # a tool error is evidence, not a crash
                         out = f"tool error: {type(e).__name__}: {e}"
                     results.append({"type": "tool_result", "tool_use_id": u["id"], "content": out})
                 messages.append({"role": "user", "content": results})
 
-        return "", rounds, tool_calls   # round budget exhausted without a conclusion
+        return "", rounds, tool_calls, external_used   # round budget exhausted without a conclusion
 
     def _tool(self, agent_name: str, name: str, args: dict) -> str:
         """The two reads, in-process. No HTTP hop and no credential: a Tares agent IS Tares, so

--- a/tares/config.py
+++ b/tares/config.py
@@ -128,6 +128,7 @@ class AgentCfg:
     slack_channel: str = ""   # workspace-bot channel id; wins over slack_webhook when both set
     webhook_url: str = ""     # write-back: findings + run metadata POSTed here
     webhook_token: str = ""   # optional bearer token for the write-back (a secret)
+    mcp_servers: list = dc_field(default_factory=list)   # registry names this agent may use
     enabled: bool = False
 
 
@@ -232,6 +233,7 @@ def _agent_from_dict(a: dict, enabled: bool = False) -> AgentCfg:
         slack_channel=a.get("slack_channel") or "",
         webhook_url=a.get("webhook_url") or "",
         webhook_token=a.get("webhook_token") or "",
+        mcp_servers=list(a.get("mcp_servers") or []),
         enabled=bool(a.get("enabled", enabled)),
     )
 
@@ -274,6 +276,21 @@ def catalog_from_db(store) -> Catalog:
     return Catalog(sources=sources, views=views, triggers=triggers, agents=agents)
 
 
+def validate_mcp_server_dict(m: dict) -> None:
+    for field in ("name", "url"):
+        if not str(m.get(field) or "").strip():
+            raise CatalogError(f"mcp_server is missing required field {field!r}")
+    if not _AGENT_NAME_RE.match(str(m["name"])):
+        raise CatalogError(f"mcp_server name {m['name']!r} must be alphanumeric/_/-")
+    url = str(m["url"]).strip()
+    if not url.startswith("https://") and not url.startswith("http://"):
+        raise CatalogError(f"mcp_server {m['name']!r}: url must be an http(s) URL "
+                           "(stdio servers are not supported)")
+    header = str(m.get("auth_header") or "").strip()
+    if header and not re.fullmatch(r"[A-Za-z0-9-]+", header):
+        raise CatalogError(f"mcp_server {m['name']!r}: auth_header must be a header name")
+
+
 def import_yaml_to_db(store, text: str) -> dict:
     """Validate and write a YAML catalog into the store. Returns counts."""
     raw = yaml.safe_load(text) or {}
@@ -281,6 +298,9 @@ def import_yaml_to_db(store, text: str) -> dict:
     views = raw.get("views", []) or []
     triggers = raw.get("triggers", []) or []
     agents = raw.get("agents", []) or []
+    mcp_servers = raw.get("mcp_servers", []) or []
+    for m in mcp_servers:
+        validate_mcp_server_dict(m)
 
     # validate the whole document before writing anything
     names = {s["name"] for s in sources}
@@ -296,8 +316,10 @@ def import_yaml_to_db(store, text: str) -> dict:
     all_views.update({v["name"]: v for v in views})
     all_triggers = {t["name"]: t for t in store.list_catalog_triggers()}
     all_triggers.update({t["name"]: t for t in triggers})
+    server_names = ({m["name"] for m in mcp_servers}
+                    | {m["name"] for m in store.list_mcp_servers()})
     for a in agents:
-        validate_agent_dict(a, trigger_names, all_triggers, all_views)
+        validate_agent_dict(a, trigger_names, all_triggers, all_views, server_names)
 
     from .connectors import normalize_config, source_type_for
     for s in sources:
@@ -319,7 +341,8 @@ def import_yaml_to_db(store, text: str) -> dict:
     for a in agents:
         store.upsert_catalog_agent(a["name"], a["trigger"], a["prompt"], a.get("slack_webhook"),
                                    a.get("model"), a.get("slack_channel"),
-                                   a.get("webhook_url"), a.get("webhook_token"))
+                                   a.get("webhook_url"), a.get("webhook_token"),
+                                   a.get("mcp_servers"))
         # enabled ⟺ a subscription to the trigger. Reflect the document's state so an enabled agent
         # round-trips: add the internal subscription if enabled, remove it if not.
         url = agent_url(a["name"])
@@ -330,8 +353,12 @@ def import_yaml_to_db(store, text: str) -> dict:
         else:
             store.remove_subscription_by_url(url)
 
+    for m in mcp_servers:
+        store.upsert_mcp_server(m["name"], str(m["url"]).strip(),
+                                m.get("auth_header"), m.get("auth_value"))
+
     return {"sources": len(sources), "views": len(views), "triggers": len(triggers),
-            "agents": len(agents)}
+            "agents": len(agents), "mcp_servers": len(mcp_servers)}
 
 
 def export_db_to_yaml(store, sources: list | None = None, include_secrets: bool = False) -> str:
@@ -384,11 +411,22 @@ def export_db_to_yaml(store, sources: list | None = None, include_secrets: bool 
     # as connector secrets above; the operator re-enters it on the target. enabled is derived from
     # the presence of the agent's internal subscription.
     enabled_urls = {s["url"] for s in store.all_subscriptions()}
+    # MCP connections: the URL and header name are configuration, the value is a credential —
+    # same rule as every other secret here.
+    mcp_out = [
+        {"name": m["name"], "url": m["url"],
+         **({"auth_header": m["auth_header"]} if m.get("auth_header") else {}),
+         **({"auth_value": m["auth_value"]}
+            if include_secrets and m.get("auth_value") else {})}
+        for m in store.list_mcp_servers()
+    ]
+
     agent_out = [
         {"name": a["name"], "trigger": a["trigger"], "prompt": a["prompt"],
          **({"model": a["model"]} if a.get("model") else {}),
          **({"slack_channel": a["slack_channel"]} if a.get("slack_channel") else {}),
          **({"webhook_url": a["webhook_url"]} if a.get("webhook_url") else {}),
+         **({"mcp_servers": a["mcp_servers"]} if a.get("mcp_servers") else {}),
          **({"slack_webhook": a["slack_webhook"]}
             if include_secrets and a.get("slack_webhook") else {}),
          **({"webhook_token": a["webhook_token"]}
@@ -401,6 +439,8 @@ def export_db_to_yaml(store, sources: list | None = None, include_secrets: bool 
     doc = {"sources": src_out, "views": view_out, "triggers": trig_out}
     if agent_out:
         doc["agents"] = agent_out
+    if mcp_out:
+        doc["mcp_servers"] = mcp_out
     return yaml.safe_dump(doc, sort_keys=False, default_flow_style=False)
 
 
@@ -620,7 +660,8 @@ MAX_PROMPT_CHARS = 8000
 
 
 def validate_agent_dict(a: dict, trigger_names: set, triggers: dict | None = None,
-                        views: dict | None = None) -> None:
+                        views: dict | None = None,
+                        mcp_server_names: set | None = None) -> None:
     for field in ("name", "trigger", "prompt"):
         if not str(a.get(field) or "").strip():
             raise CatalogError(f"agent is missing required field {field!r}")
@@ -647,6 +688,14 @@ def validate_agent_dict(a: dict, trigger_names: set, triggers: dict | None = Non
     wurl = str(a.get("webhook_url") or "").strip()
     if wurl and not wurl.startswith("https://") and not wurl.startswith("http://"):
         raise CatalogError(f"agent {a['name']!r}: webhook_url must be an http(s) URL")
+    servers = a.get("mcp_servers") or []
+    if not isinstance(servers, list) or not all(isinstance(x, str) for x in servers):
+        raise CatalogError(f"agent {a['name']!r}: mcp_servers must be a list of server names")
+    if mcp_server_names is not None:
+        for x in servers:
+            if x not in mcp_server_names:
+                raise CatalogError(f"agent {a['name']!r}: unknown mcp server {x!r} "
+                                   "(add it to the MCP servers registry first)")
 
     # Loop guard: a Tares agent writes a finding into the `findings` source. If its trigger
     # watches a view containing that source, the finding re-fires the trigger, which runs the agent

--- a/tares/daemon.py
+++ b/tares/daemon.py
@@ -27,6 +27,7 @@ from fastapi.responses import FileResponse, JSONResponse, PlainTextResponse, Str
 from pydantic import BaseModel
 
 from .config import (SLACK_URL_PREFIX, CatalogError, agent_url, export_db_to_yaml,
+                     validate_mcp_server_dict,
                      import_yaml_to_db, slack_channel_from_url, slack_url,
                      validate_agent_dict, validate_slack_channel, validate_source_dict,
                      validate_trigger_dict, validate_view_dict, _source_from_dict)
@@ -266,11 +267,19 @@ class AgentIn(BaseModel):
     webhook_url: str = ""        # write-back: findings + run metadata POSTed here
     webhook_token: str = ""      # optional bearer for the write-back (secret; blank-to-keep)
     slack_webhook_clear: bool = False   # blank means keep (it is a secret), so clearing is explicit
+    mcp_servers: list[str] = []  # registry names this agent may use
 
 
 class ImportReq(BaseModel):
     yaml: str
     mode: str = "merge"    # merge (upsert) | replace (clear catalog first)
+
+
+class McpServerIn(BaseModel):
+    name: str
+    url: str
+    auth_header: str = ""        # header name; empty means Authorization when a value is set
+    auth_value: str = ""         # the credential (secret; blank-to-keep on update)
 
 
 class AskSessionIn(BaseModel):
@@ -1113,6 +1122,66 @@ def make_app() -> FastAPI:
                       model=body.get("model"), self_headers=self_headers),
             media_type="text/event-stream")
 
+    # ── MCP connections — external tool servers a Tares agent can opt into ─────
+    # The registry: URL + optional auth header. The auth value is a secret: never returned,
+    # blank-to-keep on update, exported only with secrets included.
+    def _mcp_row(m: dict) -> dict:
+        return {"name": m["name"], "url": m["url"], "auth_header": m["auth_header"],
+                "auth_value_configured": bool(m["auth_value"]), "updated_at": m["updated_at"]}
+
+    @app.get("/api/mcp-servers")
+    async def list_mcp_servers():
+        return {"servers": [_mcp_row(m) for m in store.list_mcp_servers()]}
+
+    @app.post("/api/mcp-servers", status_code=201)
+    async def create_mcp_server(body: McpServerIn):
+        if store.get_mcp_server(body.name) is not None:
+            _err(ValueError(f"mcp server {body.name!r} already exists"), 409)
+        try:
+            validate_mcp_server_dict(body.model_dump())
+        except CatalogError as e:
+            _err(e)
+        store.upsert_mcp_server(body.name, body.url.strip(), body.auth_header.strip(),
+                                body.auth_value)
+        return {"ok": True}
+
+    @app.put("/api/mcp-servers/{name}")
+    async def update_mcp_server(name: str, body: McpServerIn):
+        existing = store.get_mcp_server(name)
+        if existing is None:
+            _err(KeyError(f"unknown mcp server {name!r}"), 404)
+        if body.name != name:
+            _err(ValueError("renaming a server is not supported; delete and recreate"), 400)
+        try:
+            validate_mcp_server_dict(body.model_dump())
+        except CatalogError as e:
+            _err(e)
+        value = body.auth_value or existing.get("auth_value", "")   # blank-to-keep
+        store.upsert_mcp_server(name, body.url.strip(), body.auth_header.strip(), value)
+        return {"ok": True}
+
+    @app.delete("/api/mcp-servers/{name}")
+    async def delete_mcp_server(name: str):
+        if store.get_mcp_server(name) is None:
+            _err(KeyError(f"unknown mcp server {name!r}"), 404)
+        store.delete_mcp_server(name)
+        return {"ok": True}
+
+    @app.post("/api/mcp-servers/{name}/test")
+    async def test_mcp_server(name: str):
+        """Connect with the stored config and list the server's tools — the proof a connection
+        works, and the tool list the agent form will offer."""
+        server = store.get_mcp_server(name)
+        if server is None:
+            _err(KeyError(f"unknown mcp server {name!r}"), 404)
+        from .mcp_client import list_remote_tools
+        try:
+            tools = await asyncio.wait_for(list_remote_tools(server), timeout=20)
+        except Exception as e:
+            detail = f"{type(e).__name__}: {str(e)[:200]}" if str(e).strip() else type(e).__name__
+            return {"ok": False, "error": detail, "tools": []}
+        return {"ok": True, "tools": tools}
+
     # ── Ask sessions — server-side chat history, so a conversation survives navigation and a
     # console reopened tomorrow can pick up where it left off. The console PUTs the whole session
     # after each exchange; the store keeps the newest 50.
@@ -1265,7 +1334,8 @@ def make_app() -> FastAPI:
         views = {v["name"]: v for v in store.list_catalog_views()}
         raw = body.model_dump()
         try:
-            validate_agent_dict(raw, set(triggers), triggers, views)
+            validate_agent_dict(raw, set(triggers), triggers, views,
+                                {m["name"] for m in store.list_mcp_servers()})
         except CatalogError as e:
             _err(e)
         return raw
@@ -1285,6 +1355,7 @@ def make_app() -> FastAPI:
                          "slack_channel": a.get("slack_channel") or "",
                          "webhook_url": a.get("webhook_url") or "",
                          "webhook_token_configured": bool(a.get("webhook_token")),
+                         "mcp_servers": a.get("mcp_servers") or [],
                          "enabled": _agent_enabled(a["name"]), "updated_at": a.get("updated_at"),
                          "last_run": runs[0] if runs else None})
         return {"agents": rows, "key_configured": bool(key), "key_source": origin,
@@ -1299,7 +1370,7 @@ def make_app() -> FastAPI:
         _agent_payload(body)
         store.upsert_catalog_agent(body.name, body.trigger, body.prompt, body.slack_webhook,
                                    body.model, body.slack_channel,
-                                   body.webhook_url, body.webhook_token)
+                                   body.webhook_url, body.webhook_token, body.mcp_servers)
         runtime.reload_catalog()
         return {"ok": True, "enabled": False,
                 "note": "agents start disabled — enable it to run on the next firing"}
@@ -1322,7 +1393,7 @@ def make_app() -> FastAPI:
         # so what the body says is what the user wants — including blank (removed).
         store.upsert_catalog_agent(name, body.trigger, body.prompt, hook,
                                    body.model, body.slack_channel,
-                                   body.webhook_url, wtoken)
+                                   body.webhook_url, wtoken, body.mcp_servers)
         # if the trigger changed while enabled, re-point the subscription so the agent fires on the
         # new trigger (the subscription, not the definition, is what the dispatcher reads).
         if body.trigger != existing["trigger"] and _agent_enabled(name):

--- a/tares/mcp_client.py
+++ b/tares/mcp_client.py
@@ -7,10 +7,15 @@ daemon spawning arbitrary commands, which is unacceptable on a hosted cell and a
 """
 from __future__ import annotations
 
+import json
+
 from mcp import ClientSession
 from mcp.client.streamable_http import streamablehttp_client
 
 CONNECT_TIMEOUT = 15.0
+# One tool result may not eat the run's context: the loop answers in 2048 tokens and the model
+# still has to hold the timeline, so a verbose server gets truncated, not obeyed.
+RESULT_CAP = 8_000
 
 
 def _headers(server: dict) -> dict:
@@ -29,3 +34,116 @@ async def list_remote_tools(server: dict) -> list[dict]:
             res = await session.list_tools()
             return [{"name": t.name, "description": (t.description or "").strip()}
                     for t in res.tools]
+
+
+def _flatten(result) -> str:
+    """One string from a call_tool result: text blocks joined, anything else JSON-dumped."""
+    parts = []
+    for c in result.content or []:
+        text = getattr(c, "text", None)
+        if text is not None:
+            parts.append(text)
+        else:
+            try:
+                parts.append(json.dumps(c.model_dump(), default=str))
+            except Exception:
+                parts.append(repr(c))
+    out = "\n".join(parts).strip()
+    if len(out) > RESULT_CAP:
+        out = out[:RESULT_CAP] + f"\n… truncated at {RESULT_CAP} characters"
+    if getattr(result, "isError", False):
+        out = f"tool error from server: {out or 'no detail'}"
+    return out or "(empty result)"
+
+
+class RemoteToolbox:
+    """The external tools an agent's selected MCP servers offer, held open for one run.
+
+    Tool names are prefixed `server__tool` so they can never collide with the built-in reads (or
+    with each other across servers). A server that fails to connect is skipped and remembered in
+    `failures` — the run continues on what remains, because a down tool server is evidence, not a
+    reason to lose the finding.
+
+    Each connection lives inside its OWN task (`_worker`): the mcp client stacks anyio cancel
+    scopes that must be entered and exited by the same task, so sharing sessions across tasks (or
+    holding them in one exit stack) detonates on unwind. Calls are passed to the owning worker
+    over a queue and answered on a future.
+    """
+
+    def __init__(self, servers: list[dict]):
+        self._servers = servers
+        self._tasks: list = []
+        self._queues: dict[str, object] = {}      # server name -> request queue
+        self._route: dict[str, tuple[str, str]] = {}   # prefixed -> (server, tool)
+        self.tool_defs: list[dict] = []
+        self.failures: list[str] = []   # "name: reason", for the run log
+
+    async def _worker(self, server: dict, ready, requests) -> None:
+        """Owns the connection end to end. Resolves `ready` with the tool list (or the connect
+        error), then serves call requests until it is handed None."""
+        try:
+            async with streamablehttp_client(server["url"], headers=_headers(server),
+                                             timeout=CONNECT_TIMEOUT) as (read, write, _):
+                async with ClientSession(read, write) as session:
+                    await session.initialize()
+                    res = await session.list_tools()
+                    ready.set_result(res.tools)
+                    while True:
+                        item = await requests.get()
+                        if item is None:
+                            return
+                        tool, args, fut = item
+                        try:
+                            fut.set_result(await session.call_tool(tool, args or {}))
+                        except Exception as e:
+                            fut.set_exception(e)
+        except Exception as e:
+            if not ready.done():
+                ready.set_exception(e)
+
+    async def __aenter__(self) -> "RemoteToolbox":
+        import asyncio
+        pending = []
+        for server in self._servers:
+            ready: asyncio.Future = asyncio.get_running_loop().create_future()
+            requests: asyncio.Queue = asyncio.Queue()
+            self._tasks.append(asyncio.create_task(self._worker(server, ready, requests)))
+            self._queues[server["name"]] = requests
+            pending.append((server, ready))
+        for server, ready in pending:
+            try:
+                tools = await asyncio.wait_for(ready, timeout=CONNECT_TIMEOUT + 5)
+            except Exception as e:
+                detail = f"{type(e).__name__}: {str(e)[:120]}" if str(e).strip() else type(e).__name__
+                self.failures.append(f"{server['name']}: {detail}")
+                continue
+            for t in tools:
+                prefixed = f"{server['name']}__{t.name}"
+                self._route[prefixed] = (server["name"], t.name)
+                self.tool_defs.append({
+                    "name": prefixed,
+                    "description": f"[{server['name']}] {(t.description or '').strip()}"[:1024],
+                    "input_schema": t.inputSchema or {"type": "object", "properties": {}},
+                })
+        return self
+
+    async def __aexit__(self, *exc) -> None:
+        import asyncio
+        for q in self._queues.values():
+            q.put_nowait(None)
+        for task in self._tasks:
+            try:
+                await asyncio.wait_for(task, timeout=5)
+            except Exception:
+                task.cancel()
+
+    def owns(self, name: str) -> bool:
+        return name in self._route
+
+    async def call(self, name: str, args: dict, timeout: float = 60.0) -> str:
+        import asyncio
+        server, tool = self._route[name]
+        fut: asyncio.Future = asyncio.get_running_loop().create_future()
+        self._queues[server].put_nowait((tool, args, fut))
+        result = await asyncio.wait_for(fut, timeout=timeout)
+        return _flatten(result)

--- a/tares/mcp_client.py
+++ b/tares/mcp_client.py
@@ -1,0 +1,31 @@
+"""Client side of MCP — the daemon reaching OUT to external tool servers.
+
+Not to be confused with tares/mcp_server.py (Tares serving its own surface). This module is what
+Tares agents use to reach the customer's other tools: connect over streamable HTTP, present the
+stored auth header, list tools, call one. stdio is deliberately unsupported: it would mean the
+daemon spawning arbitrary commands, which is unacceptable on a hosted cell and a footgun anywhere.
+"""
+from __future__ import annotations
+
+from mcp import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
+
+CONNECT_TIMEOUT = 15.0
+
+
+def _headers(server: dict) -> dict:
+    header = (server.get("auth_header") or "").strip() or "Authorization"
+    value = (server.get("auth_value") or "").strip()
+    return {header: value} if value else {}
+
+
+async def list_remote_tools(server: dict) -> list[dict]:
+    """Connect, initialize, and list the server's tools. Raises on failure — the caller decides
+    whether that is a 502 (a test button) or evidence (an agent run)."""
+    async with streamablehttp_client(server["url"], headers=_headers(server),
+                                     timeout=CONNECT_TIMEOUT) as (read, write, _):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            res = await session.list_tools()
+            return [{"name": t.name, "description": (t.description or "").strip()}
+                    for t in res.tools]

--- a/tares/store.py
+++ b/tares/store.py
@@ -199,6 +199,7 @@ _MIGRATIONS = [
     "ALTER TABLE catalog_agents ADD COLUMN IF NOT EXISTS webhook_url TEXT",
     "ALTER TABLE catalog_agents ADD COLUMN IF NOT EXISTS webhook_token TEXT",
     "ALTER TABLE catalog_agents ADD COLUMN IF NOT EXISTS mcp_servers JSON",
+    "ALTER TABLE agent_runs ADD COLUMN IF NOT EXISTS external_tools JSON",
     # `reviews` were renamed to Tares agents before release; drop the old-named tables if a dev
     # DB still carries them (the definitions are re-created under the new names).
     "DROP TABLE IF EXISTS catalog_reviews",
@@ -854,19 +855,21 @@ class Store:
             )
 
     def finish_agent_run(self, run_id: str, status: str, rounds: int = 0, tool_calls: int = 0,
-                         finding: str | None = None, error: str | None = None) -> None:
+                         finding: str | None = None, error: str | None = None,
+                         external_tools: list[str] | None = None) -> None:
         with self._lock:
             self.con.execute(
                 "UPDATE agent_runs SET status = ?, rounds = ?, tool_calls = ?, finding = ?, "
-                "error = ?, finished_at = ?, "
+                "error = ?, external_tools = ?, finished_at = ?, "
                 "duration_ms = CAST(date_diff('millisecond', started_at, ?) AS INTEGER) "
                 "WHERE id = ?",
-                [status, rounds, tool_calls, finding, error, now_utc(), now_utc(), run_id],
+                [status, rounds, tool_calls, finding, error,
+                 json.dumps(external_tools or []), now_utc(), now_utc(), run_id],
             )
 
     def list_agent_runs(self, agent: str | None = None, limit: int = 50) -> list[dict]:
         sql = ("SELECT id, agent, trigger, dispatch_id, key_value, status, rounds, tool_calls, "
-               "started_at, duration_ms, finding, error FROM agent_runs ")
+               "started_at, duration_ms, finding, error, external_tools FROM agent_runs ")
         params: list = []
         if agent:
             sql += "WHERE agent = ? "
@@ -878,7 +881,8 @@ class Store:
         return [
             {"id": r[0], "agent": r[1], "trigger": r[2], "dispatch_id": r[3], "key": r[4],
              "status": r[5], "rounds": r[6], "tool_calls": r[7], "started_at": r[8],
-             "duration_ms": r[9], "finding": r[10], "error": r[11]}
+             "duration_ms": r[9], "finding": r[10], "error": r[11],
+             "external_tools": json.loads(r[12]) if r[12] else []}
             for r in rows
         ]
 

--- a/tares/store.py
+++ b/tares/store.py
@@ -146,6 +146,14 @@ CREATE TABLE IF NOT EXISTS settings (
   value      TEXT,
   updated_at TIMESTAMPTZ
 );
+CREATE TABLE IF NOT EXISTS mcp_servers (
+  name        TEXT PRIMARY KEY,
+  url         TEXT,
+  auth_header TEXT,
+  auth_value  TEXT,
+  created_at  TIMESTAMPTZ,
+  updated_at  TIMESTAMPTZ
+);
 CREATE TABLE IF NOT EXISTS ask_sessions (
   id         TEXT PRIMARY KEY,
   title      TEXT,
@@ -190,6 +198,7 @@ _MIGRATIONS = [
     "ALTER TABLE catalog_agents ADD COLUMN IF NOT EXISTS slack_channel TEXT",
     "ALTER TABLE catalog_agents ADD COLUMN IF NOT EXISTS webhook_url TEXT",
     "ALTER TABLE catalog_agents ADD COLUMN IF NOT EXISTS webhook_token TEXT",
+    "ALTER TABLE catalog_agents ADD COLUMN IF NOT EXISTS mcp_servers JSON",
     # `reviews` were renamed to Tares agents before release; drop the old-named tables if a dev
     # DB still carries them (the definitions are re-created under the new names).
     "DROP TABLE IF EXISTS catalog_reviews",
@@ -785,39 +794,43 @@ class Store:
             self.con.execute("DELETE FROM catalog_views")
             self.con.execute("DELETE FROM catalog_triggers")
             self.con.execute("DELETE FROM catalog_agents")
+            self.con.execute("DELETE FROM mcp_servers")
 
     # ── Tares agents (a prompt attached to a trigger; enabled ⟺ subscribed) ──
     def upsert_catalog_agent(self, name: str, trigger: str, prompt: str,
                              slack_webhook: str | None = None, model: str | None = None,
                              slack_channel: str | None = None, webhook_url: str | None = None,
-                             webhook_token: str | None = None) -> None:
+                             webhook_token: str | None = None,
+                             mcp_servers: list[str] | None = None) -> None:
         ts = now_utc()
         with self._lock:
             self.con.execute(
                 "INSERT INTO catalog_agents "
                 "(name, trigger, prompt, slack_webhook, model, slack_channel, "
-                "webhook_url, webhook_token, created_at, updated_at) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
+                "webhook_url, webhook_token, mcp_servers, created_at, updated_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
                 "ON CONFLICT (name) DO UPDATE SET trigger = excluded.trigger, "
                 "prompt = excluded.prompt, slack_webhook = excluded.slack_webhook, "
                 "model = excluded.model, slack_channel = excluded.slack_channel, "
                 "webhook_url = excluded.webhook_url, webhook_token = excluded.webhook_token, "
-                "updated_at = excluded.updated_at",
+                "mcp_servers = excluded.mcp_servers, updated_at = excluded.updated_at",
                 [name, trigger, prompt, slack_webhook or "", model or "",
-                 slack_channel or "", webhook_url or "", webhook_token or "", ts, ts],
+                 slack_channel or "", webhook_url or "", webhook_token or "",
+                 json.dumps(mcp_servers or []), ts, ts],
             )
 
     def list_catalog_agents(self) -> list[dict]:
         with self._lock:
             rows = self.con.execute(
                 "SELECT name, trigger, prompt, slack_webhook, model, slack_channel, "
-                "webhook_url, webhook_token, updated_at "
+                "webhook_url, webhook_token, mcp_servers, updated_at "
                 "FROM catalog_agents ORDER BY name"
             ).fetchall()
         return [
             {"name": r[0], "trigger": r[1], "prompt": r[2], "slack_webhook": r[3] or "",
              "model": r[4] or "", "slack_channel": r[5] or "",
-             "webhook_url": r[6] or "", "webhook_token": r[7] or "", "updated_at": r[8]}
+             "webhook_url": r[6] or "", "webhook_token": r[7] or "",
+             "mcp_servers": json.loads(r[8]) if r[8] else [], "updated_at": r[9]}
             for r in rows
         ]
 
@@ -930,6 +943,36 @@ class Store:
                     "INSERT INTO settings (key, value, updated_at) VALUES (?, ?, ?) "
                     "ON CONFLICT (key) DO UPDATE SET value = excluded.value, "
                     "updated_at = excluded.updated_at", [key, value, now_utc()])
+
+    # ── MCP connections (external tool servers a Tares agent may opt into) ─────
+    # `auth_value` is a secret (an API key or full header value); redaction is the API layer's
+    # job, the store holds it verbatim like connector secrets.
+    def list_mcp_servers(self) -> list[dict]:
+        with self._lock:
+            rows = self.con.execute(
+                "SELECT name, url, auth_header, auth_value, updated_at "
+                "FROM mcp_servers ORDER BY name").fetchall()
+        return [{"name": r[0], "url": r[1], "auth_header": r[2] or "",
+                 "auth_value": r[3] or "", "updated_at": r[4]} for r in rows]
+
+    def get_mcp_server(self, name: str) -> dict | None:
+        return next((m for m in self.list_mcp_servers() if m["name"] == name), None)
+
+    def upsert_mcp_server(self, name: str, url: str, auth_header: str | None = None,
+                          auth_value: str | None = None) -> None:
+        ts = now_utc()
+        with self._lock:
+            self.con.execute(
+                "INSERT INTO mcp_servers (name, url, auth_header, auth_value, "
+                "created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?) "
+                "ON CONFLICT (name) DO UPDATE SET url = excluded.url, "
+                "auth_header = excluded.auth_header, auth_value = excluded.auth_value, "
+                "updated_at = excluded.updated_at",
+                [name, url, auth_header or "", auth_value or "", ts, ts])
+
+    def delete_mcp_server(self, name: str) -> None:
+        with self._lock:
+            self.con.execute("DELETE FROM mcp_servers WHERE name = ?", [name])
 
     # ── ask sessions (the in-app agent's chat history) ────────────────────────
     # `state` is an opaque JSON blob owned by the console (messages, tool calls, proposal

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -53,6 +53,7 @@ const SECTION_LABEL: Record<string, string> = {
   connect: "Connect",
   activity: "Activity",
   catalog: "Catalog",
+  "mcp-servers": "MCP servers",
   ask: "Ask",
   security: "Security",
   settings: "Settings",

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -152,10 +152,10 @@ export const api = {
     request<{ agents: BuiltinAgent[]; key_configured: boolean; key_source: string;
               models: string[]; default_model: string; slack_workspace: boolean;
               presets: AgentPreset[] }>("/api/agents/builtin"),
-  createBuiltinAgent: (body: { name: string; trigger: string; prompt: string; slack_webhook?: string; slack_webhook_clear?: boolean; model?: string; slack_channel?: string; webhook_url?: string; webhook_token?: string }) =>
+  createBuiltinAgent: (body: { name: string; trigger: string; prompt: string; slack_webhook?: string; slack_webhook_clear?: boolean; model?: string; slack_channel?: string; webhook_url?: string; webhook_token?: string; mcp_servers?: string[] }) =>
     request<{ ok: boolean; enabled: boolean }>("/api/agents/builtin",
       { method: "POST", body: JSON.stringify(body) }),
-  updateBuiltinAgent: (name: string, body: { name: string; trigger: string; prompt: string; slack_webhook?: string; slack_webhook_clear?: boolean; model?: string; slack_channel?: string; webhook_url?: string; webhook_token?: string }) =>
+  updateBuiltinAgent: (name: string, body: { name: string; trigger: string; prompt: string; slack_webhook?: string; slack_webhook_clear?: boolean; model?: string; slack_channel?: string; webhook_url?: string; webhook_token?: string; mcp_servers?: string[] }) =>
     request(`/api/agents/builtin/${name}`, { method: "PUT", body: JSON.stringify(body) }),
   deleteBuiltinAgent: (name: string) => request(`/api/agents/builtin/${name}`, { method: "DELETE" }),
   enableBuiltinAgent: (name: string) => request(`/api/agents/builtin/${name}/enable`, { method: "POST" }),
@@ -210,6 +210,21 @@ export const api = {
   subscribe: (trigger: string, url: string) =>
     request<{ subscription_id: string }>("/subscribe",
       { method: "POST", body: JSON.stringify({ trigger, url }) }),
+
+  // ── MCP connections: external tool servers agents can opt into ──
+  mcpServers: () =>
+    request<{ servers: { name: string; url: string; auth_header: string;
+                         auth_value_configured: boolean; updated_at: string }[] }>("/api/mcp-servers"),
+  createMcpServer: (body: { name: string; url: string; auth_header?: string; auth_value?: string }) =>
+    request<{ ok: boolean }>("/api/mcp-servers", { method: "POST", body: JSON.stringify(body) }),
+  updateMcpServer: (name: string, body: { name: string; url: string; auth_header?: string; auth_value?: string }) =>
+    request<{ ok: boolean }>(`/api/mcp-servers/${encodeURIComponent(name)}`,
+      { method: "PUT", body: JSON.stringify(body) }),
+  deleteMcpServer: (name: string) =>
+    request<{ ok: boolean }>(`/api/mcp-servers/${encodeURIComponent(name)}`, { method: "DELETE" }),
+  testMcpServer: (name: string) =>
+    request<{ ok: boolean; error?: string; tools: { name: string; description: string }[] }>(
+      `/api/mcp-servers/${encodeURIComponent(name)}/test`, { method: "POST" }),
 
   // ── Ask sessions: server-side chat history (state is the console's own JSON blob) ──
   askSessions: () =>

--- a/ui/src/components/AgentForm.tsx
+++ b/ui/src/components/AgentForm.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from "react";
 
+import { Link } from "react-router-dom";
+
 import { api } from "../api";
 import type { SlackChannels } from "../api";
 import { Combo, Picker } from "./bits";
@@ -77,6 +79,7 @@ export default function AgentForm({ initial, presetTrigger, triggers, presets, m
   const [writebackOn, setWritebackOn] = useState(!!initial?.webhook_url);
   const [webhookUrl, setWebhookUrl] = useState(initial?.webhook_url ?? "");
   const [webhookToken, setWebhookToken] = useState("");
+  const [mcpSel, setMcpSel] = useState<string[]>(initial?.mcp_servers ?? []);
 
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string>();
@@ -96,6 +99,17 @@ export default function AgentForm({ initial, presetTrigger, triggers, presets, m
       .catch(() => { if (live) setChannels({ channels: [], reason: "error" }); });
     return () => { live = false; };
   }, [slackWorkspace]);
+  // The MCP registry: which servers exist is managed on its own page; here the agent only picks
+  // from them.
+  const [mcpAvail, setMcpAvail] = useState<{ name: string; url: string }[]>();
+  useEffect(() => {
+    let live = true;
+    api.mcpServers().then((r) => { if (live) setMcpAvail(r.servers); }).catch(() => { if (live) setMcpAvail([]); });
+    return () => { live = false; };
+  }, []);
+  const toggleMcp = (name: string, on: boolean) =>
+    setMcpSel((cur) => (on ? [...cur, name] : cur.filter((n) => n !== name)));
+
   const chanList = channels?.reason === null ? channels.channels : [];
   const chanLabels: Record<string, string> = { "": "pick a channel…" };
   for (const c of chanList) chanLabels[c.id] = (c.is_private ? "🔒 " : "#") + c.name;
@@ -109,6 +123,7 @@ export default function AgentForm({ initial, presetTrigger, triggers, presets, m
       slack_webhook_clear: !hookOn,
       webhook_url: writebackOn ? webhookUrl.trim() : "",
       webhook_token: writebackOn ? webhookToken.trim() : "",
+      mcp_servers: mcpSel,
     };
     try {
       if (isNew) await api.createBuiltinAgent(body);
@@ -168,6 +183,44 @@ export default function AgentForm({ initial, presetTrigger, triggers, presets, m
         <span className="lbl">model</span>
         <Picker value={model} onChange={setModel} options={modelOptions} labels={modelLabels}
                 ariaLabel="model" />
+      </div>
+
+      <div className="field">
+        <h3 style={{ margin: "10px 0 2px", fontSize: 16 }}>External tools</h3>
+        <span className="help" style={{ display: "block", margin: "0 0 10px" }}>
+          MCP servers this agent may call, alongside its built-in reads. Tools from these servers
+          can act on your systems; enable only what this agent should touch.
+        </span>
+        {mcpAvail === undefined ? <span className="dim">loading…</span>
+          : mcpAvail.length === 0 ? (
+            <span className="help">
+              none connected yet. Add one under <Link to="/mcp-servers">MCP servers</Link>, then
+              pick it here.
+            </span>
+          ) : (
+            <>
+              {mcpSel.length > 0 && (
+                <div className="btnrow" style={{ marginBottom: 8, flexWrap: "wrap" }}>
+                  {mcpSel.map((name) => (
+                    <span key={name} className="chip mono" title={mcpAvail.find((m) => m.name === name)?.url}>
+                      {name}
+                      <button type="button" className="chip-x" aria-label={`remove ${name}`}
+                              onClick={() => toggleMcp(name, false)}>×</button>
+                    </span>
+                  ))}
+                </div>
+              )}
+              {mcpAvail.some((m) => !mcpSel.includes(m.name)) && (
+                <Picker value="" ariaLabel="add an MCP server"
+                        options={mcpAvail.filter((m) => !mcpSel.includes(m.name)).map((m) => m.name)}
+                        labels={{ "": "add a server…" }}
+                        onChange={(name) => { if (name) toggleMcp(name, true); }} />
+              )}
+              <span className="help">
+                manage connections under <Link to="/mcp-servers">MCP servers</Link>
+              </span>
+            </>
+          )}
       </div>
 
       <div className="field">

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -23,6 +23,7 @@ import SourceDiscover from "./pages/SourceDiscover";
 import SourceNew from "./pages/SourceNew";
 import Security from "./pages/Security";
 import Home from "./pages/Home";
+import McpServers from "./pages/McpServers";
 import Sources from "./pages/Sources";
 import { TriggersPage, ViewsPage } from "./pages/ViewsTriggers";
 import "./styles.css";
@@ -54,6 +55,7 @@ const router = createBrowserRouter([
       { path: "activity", element: <AgentActivity /> },
       { path: "dispatches/:id", element: <DispatchDetail /> },
       { path: "agents", element: <Agents /> },
+      { path: "mcp-servers", element: <McpServers /> },
       { path: "agents/new", element: <AgentNew /> },
       { path: "agents/:name", element: <AgentDetail /> },
       { path: "ask", element: <Ask /> },

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -147,6 +147,14 @@ export default function AgentDetail() {
                   {r.rounds ? ` · ${r.rounds} round${r.rounds === 1 ? "" : "s"}` : ""}
                   {r.duration_ms != null ? ` · ${(r.duration_ms / 1000).toFixed(1)}s` : ""}
                 </span>
+                {(r.external_tools ?? []).length > 0 && (
+                  <span style={{ marginLeft: 8 }}>
+                    {[...new Set(r.external_tools)].map((t) => (
+                      <span key={t} className="chip mono" title="external MCP tool this run called"
+                            style={{ marginRight: 4 }}>{t}</span>
+                    ))}
+                  </span>
+                )}
               </>
             );
             const body = r.finding

--- a/ui/src/pages/Agents.tsx
+++ b/ui/src/pages/Agents.tsx
@@ -33,7 +33,10 @@ export default function Agents() {
             and <strong>connected agents</strong> reached over a webhook
           </p>
         </div>
-        <button className="primary" onClick={() => nav("/agents/new")}>Create Tares agent</button>
+        <div className="btnrow">
+          <button onClick={() => nav("/mcp-servers")}>MCP servers</button>
+          <button className="primary" onClick={() => nav("/agents/new")}>Create Tares agent</button>
+        </div>
       </div>
 
       {data && !data.key_configured && (

--- a/ui/src/pages/McpServers.tsx
+++ b/ui/src/pages/McpServers.tsx
@@ -1,0 +1,191 @@
+import { useMemo, useState } from "react";
+
+import { api } from "../api";
+import { TimeAgo, usePolling } from "../components/bits";
+
+// The MCP connections registry: external tool servers a Tares agent can opt into. This page owns
+// the connection (URL + credential, entered once); which agent uses which server is chosen on the
+// agent's own form. HTTP transport only — stdio would mean the daemon spawning arbitrary
+// commands, which is off the table on a hosted cell and a footgun anywhere.
+
+type Server = { name: string; url: string; auth_header: string;
+                auth_value_configured: boolean; updated_at: string };
+type Tool = { name: string; description: string };
+
+function ServerForm({ initial, onSaved, onCancel }: {
+  initial?: Server; onSaved: () => void; onCancel: () => void;
+}) {
+  const isNew = !initial;
+  const [name, setName] = useState(initial?.name ?? "");
+  const [url, setUrl] = useState(initial?.url ?? "");
+  const [header, setHeader] = useState(initial?.auth_header ?? "");
+  const [value, setValue] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string>();
+
+  const save = async () => {
+    setBusy(true); setErr(undefined);
+    const body = { name: name.trim(), url: url.trim(),
+                   auth_header: header.trim(), auth_value: value };
+    try {
+      if (isNew) await api.createMcpServer(body);
+      else await api.updateMcpServer(initial!.name, body);
+      onSaved();
+    } catch (e) { setErr(String((e as Error).message ?? e)); }
+    setBusy(false);
+  };
+
+  return (
+    <div className="panel">
+      {err && <div className="alert error">{err}</div>}
+      <div className="row2">
+        <label className="field">
+          <span className="lbl">name</span>
+          <input type="text" value={name} placeholder="e.g. github" disabled={!isNew}
+                 onChange={(e) => setName(e.target.value)} />
+          {!isNew && <span className="help">fixed; delete and recreate to rename</span>}
+        </label>
+        <label className="field">
+          <span className="lbl">url</span>
+          <input type="text" className="mono" value={url}
+                 placeholder="https://mcp.example.com/mcp"
+                 onChange={(e) => setUrl(e.target.value)} />
+          <span className="help">streamable HTTP endpoint; stdio servers are not supported</span>
+        </label>
+      </div>
+      <div className="field">
+        <span className="lbl">authentication <span className="help">(optional)</span></span>
+        <div className="hook-group">
+          <input type="text" className="mono" placeholder="header name (default: Authorization)"
+                 value={header} onChange={(e) => setHeader(e.target.value)} />
+          <input type="password" className="mono" autoComplete="new-password" placeholder={
+            initial?.auth_value_configured
+              ? "•••• configured, leave blank to keep"
+              : "header value, e.g. Bearer sk-…"}
+                 value={value} onChange={(e) => setValue(e.target.value)} />
+        </div>
+        <span className="help">
+          sent on every request to this server; the value is stored as a secret and never shown again
+        </span>
+      </div>
+      <div className="btnrow">
+        <button className="primary" onClick={save}
+                disabled={busy || !name.trim() || !url.trim()}>
+          {isNew ? "Add server" : "Save changes"}
+        </button>
+        <button onClick={onCancel}>Cancel</button>
+      </div>
+    </div>
+  );
+}
+
+export default function McpServers() {
+  const { data, error, reload } = usePolling(() => api.mcpServers(), 30000);
+  const [editing, setEditing] = useState<Server | "new">();
+  const [tests, setTests] = useState<Record<string, { busy?: boolean; ok?: boolean;
+                                                     error?: string; tools?: Tool[] }>>({});
+  const [open, setOpen] = useState<string>();
+
+  const servers = useMemo(() => data?.servers ?? [], [data]);
+
+  const test = async (name: string) => {
+    setTests((t) => ({ ...t, [name]: { busy: true } }));
+    setOpen(name);
+    try {
+      const r = await api.testMcpServer(name);
+      setTests((t) => ({ ...t, [name]: { ok: r.ok, error: r.error, tools: r.tools } }));
+    } catch (e) {
+      setTests((t) => ({ ...t, [name]: { ok: false, error: String((e as Error).message ?? e) } }));
+    }
+  };
+
+  const remove = async (name: string) => {
+    try { await api.deleteMcpServer(name); reload(); }
+    catch { /* the next poll shows the truth */ }
+  };
+
+  return (
+    <>
+      <h1>MCP servers</h1>
+      <p className="subtitle">
+        external tool servers your <em>Tares agents</em> can use, connected once with their credential
+      </p>
+
+      {error && <div className="alert error">{error}</div>}
+
+      {editing !== undefined ? (
+        <ServerForm initial={editing === "new" ? undefined : editing}
+                    onSaved={() => { setEditing(undefined); reload(); }}
+                    onCancel={() => setEditing(undefined)} />
+      ) : (
+        <div className="btnrow" style={{ marginBottom: 12 }}>
+          <button className="primary" onClick={() => setEditing("new")}>Add server</button>
+        </div>
+      )}
+
+      {!data ? <div className="dim">loading…</div>
+        : servers.length === 0 ? (
+          <div className="empty">
+            no servers yet. Add one, then pick it on an agent's form to give that agent its tools.
+          </div>
+        ) : (
+          <table>
+            <thead><tr><th>name</th><th>url</th><th>auth</th><th>updated</th><th aria-label="actions" /></tr></thead>
+            <tbody>
+              {servers.map((s) => {
+                const t = tests[s.name];
+                return (
+                  <>
+                    <tr key={s.name}>
+                      <td className="mono"><strong>{s.name}</strong></td>
+                      <td className="mono">{s.url}</td>
+                      <td>{s.auth_value_configured
+                        ? <span className="badge ok">{s.auth_header || "Authorization"}</span>
+                        : <span className="dim">none</span>}</td>
+                      <td style={{ whiteSpace: "nowrap" }}><TimeAgo ts={s.updated_at} /></td>
+                      <td>
+                        <div className="btnrow" style={{ justifyContent: "flex-end" }}>
+                          <button onClick={() => test(s.name)} disabled={t?.busy}>
+                            {t?.busy ? "testing…" : "Test"}
+                          </button>
+                          <button onClick={() => setEditing(s)}>Edit</button>
+                          <button className="danger" onClick={() => remove(s.name)}>Delete</button>
+                        </div>
+                      </td>
+                    </tr>
+                    {open === s.name && t && !t.busy && (
+                      <tr key={s.name + "-test"}>
+                        <td colSpan={5} style={{ background: "var(--wash)" }}>
+                          {t.ok ? (
+                            <div style={{ padding: "6px 4px" }}>
+                              <span className="badge ok">connected</span>{" "}
+                              <span className="help">{t.tools?.length ?? 0} tools</span>
+                              <ul style={{ margin: "6px 0 2px", paddingLeft: 22 }}>
+                                {(t.tools ?? []).map((tool) => (
+                                  <li key={tool.name}>
+                                    <span className="mono">{tool.name}</span>
+                                    {tool.description && (
+                                      <span className="help"> {tool.description.slice(0, 140)}</span>
+                                    )}
+                                  </li>
+                                ))}
+                              </ul>
+                            </div>
+                          ) : (
+                            <div style={{ padding: "6px 4px" }}>
+                              <span className="badge error">failed</span>{" "}
+                              <span className="help mono">{t.error}</span>
+                            </div>
+                          )}
+                        </td>
+                      </tr>
+                    )}
+                  </>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
+    </>
+  );
+}

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -1200,3 +1200,10 @@ pre.payload {
 .hook-group input { border: none; border-radius: 0; width: 100%; }
 .hook-group input + input { border-top: 1px solid var(--line); }
 .hook-group:focus-within { border-color: var(--accent); }
+
+/* Removable chip: the x rides inside the chip, appearing as part of the same tag. */
+.chip .chip-x {
+  background: none; border: none; cursor: pointer; padding: 0 0 0 6px;
+  color: var(--ink-faint); font-size: 13px; line-height: 1;
+}
+.chip .chip-x:hover { color: var(--err); }

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -237,6 +237,7 @@ export interface BuiltinAgent {
   slack_channel: string;       // workspace-bot channel id, "" = none
   webhook_url: string;         // write-back target, "" = none
   webhook_token_configured: boolean;   // the token itself is never sent to the client
+  mcp_servers: string[];       // registry names this agent may use
   updated_at?: string;
   last_run?: AgentRun | null;
 }

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -251,6 +251,7 @@ export interface AgentRun {
   status: "running" | "ok" | "empty" | "failed" | "capped";
   rounds: number;
   tool_calls: number;
+  external_tools?: string[];   // prefixed server__tool names this run called
   started_at: string;
   duration_ms: number | null;
   finding: string | null;


### PR DESCRIPTION
Replaces #68 (auto-closed when its stacked base merged). Same two commits, rebased onto main. See #68 for the full description and verification notes.