### PR TITLE
Add-source redesign: paste-a-catalog-snippet, connector cards; UI copy pass

### DIFF
--- a/tares/config.py
+++ b/tares/config.py
@@ -358,7 +358,12 @@ def import_yaml_to_db(store, text: str) -> dict:
                                 m.get("auth_header"), m.get("auth_value"))
 
     return {"sources": len(sources), "views": len(views), "triggers": len(triggers),
-            "agents": len(agents), "mcp_servers": len(mcp_servers)}
+            "agents": len(agents), "mcp_servers": len(mcp_servers),
+            "names": {"sources": [s["name"] for s in sources],
+                      "views": [v["name"] for v in views],
+                      "triggers": [t["name"] for t in triggers],
+                      "agents": [a["name"] for a in agents],
+                      "mcp_servers": [m["name"] for m in mcp_servers]}}
 
 
 def export_db_to_yaml(store, sources: list | None = None, include_secrets: bool = False) -> str:

--- a/tares/daemon.py
+++ b/tares/daemon.py
@@ -1698,10 +1698,14 @@ def make_app() -> FastAPI:
         d = store.get_dispatch(dispatch_id)
         if d is None:
             _err(KeyError(f"unknown dispatch {dispatch_id!r}"), 404)
+        from .config import agent_name_from_url
         deliveries = []
         for dv in store.deliveries_for(dispatch_id):
-            name, masked = _agent_identity(dv["url"].rstrip("/"))
-            deliveries.append({"agent": name, "endpoint": masked, "ok": dv["ok"],
+            url = dv["url"].rstrip("/")
+            name, masked = _agent_identity(url)
+            kind = ("tares" if agent_name_from_url(url) is not None
+                    else "slack" if slack_channel_from_url(url) is not None else "webhook")
+            deliveries.append({"agent": name, "endpoint": masked, "kind": kind, "ok": dv["ok"],
                                "error": dv["error"], "delivered_at": dv["delivered_at"]})
         return {**d, "deliveries": deliveries}
 

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -290,7 +290,10 @@ export const api = {
     return res.text();
   },
   importYaml: (yaml: string, mode: "merge" | "replace") =>
-    request<{ sources: number; views: number; triggers: number }>("/api/catalog/import", {
+    request<{ sources: number; views: number; triggers: number; agents: number;
+              mcp_servers: number;
+              names: { sources: string[]; views: string[]; triggers: string[];
+                       agents: string[]; mcp_servers: string[] } }>("/api/catalog/import", {
       method: "POST",
       body: JSON.stringify({ yaml, mode }),
     }),

--- a/ui/src/components/AgentForm.tsx
+++ b/ui/src/components/AgentForm.tsx
@@ -147,7 +147,6 @@ export default function AgentForm({ initial, presetTrigger, triggers, presets, m
             <span className="lbl">trigger</span>
             <Combo value={trigger} options={triggers}
                    placeholder="the trigger that wakes this agent" onChange={setTrigger} />
-            <span className="help">the agent runs when this trigger fires</span>
           </div>
         </div>
       ) : (
@@ -167,8 +166,7 @@ export default function AgentForm({ initial, presetTrigger, triggers, presets, m
         <textarea rows={12} className="mono" value={prompt}
                   onChange={(e) => setPrompt(e.target.value)} />
         <span className="help">
-          what to look for and what to write. The correlated timeline at firing time is supplied
-          automatically; the agent's final message becomes the finding.
+          the correlated timeline is supplied at firing time; the final message becomes the finding
         </span>
       </label>
       {isNew && presets.length > 0 && (
@@ -259,8 +257,7 @@ export default function AgentForm({ initial, presetTrigger, triggers, presets, m
                    value={webhookToken} onChange={(e) => setWebhookToken(e.target.value)} />
           </div>
           <span className="help">
-            the payload carries the finding plus trigger, entity, model, rounds, tool calls and
-            timing; the token is sent as an Authorization header and never shown again
+            finding + run metadata as JSON; the token is sent as a bearer header
           </span>
         </OptionRow>
       </div>

--- a/ui/src/components/AskChat.tsx
+++ b/ui/src/components/AskChat.tsx
@@ -61,7 +61,7 @@ const textOf = (m: Msg, decisions?: DecisionMap) =>
       const what = p.proposal.kind === "labels"
         ? `labels for source ${p.proposal.source}`
         : p.proposal.kind === "view" ? `view ${p.proposal.name}` : `trigger ${p.proposal.name}`;
-      return `\n[proposal: ${what} — ${st}]\n`;
+      return `\n[proposal: ${what}; ${st}]\n`;
     }
     return "";
   }).join("");
@@ -169,7 +169,7 @@ export default function AskChat({ history = false }: { history?: boolean }) {
     try {
       const full = await api.askSession(id);
       restore(full.id, full.state);
-    } catch { refreshSessions(); }   // deleted meanwhile — drop it from the list
+    } catch { refreshSessions(); }   // deleted meanwhile; drop it from the list
   };
   const newConversation = () => {
     sessionId.current = "";

--- a/ui/src/components/AuthGate.tsx
+++ b/ui/src/components/AuthGate.tsx
@@ -50,7 +50,7 @@ export default function AuthGate({ children }: { children: React.ReactNode }) {
       if (!alive) return;
 
       if (!h) {
-        setBanner("Can’t reach the Tares daemon — it may be starting, stopped, or blocked "
+        setBanner("Can’t reach the Tares daemon; it may be starting, stopped, or blocked "
                   + "between this browser and the server. Pages will keep retrying.");
       } else if (h.status && h.status !== "ok") {
         setBanner(h.detail

--- a/ui/src/components/IngestSetup.tsx
+++ b/ui/src/components/IngestSetup.tsx
@@ -40,7 +40,7 @@ export default function IngestSetup({ connector, url, authKey }: {
     );
   }
 
-  if (!authRequired) return null;   // open instance — the URL alone accepts events
+  if (!authRequired) return null;   // open instance; the URL alone accepts events
 
   const snippet = connector === "otlp"
     ? [
@@ -60,7 +60,7 @@ export default function IngestSetup({ connector, url, authKey }: {
       <KeyNote authKey={authKey} />
       <p className="muted" style={{ marginTop: 12 }}>
         {connector === "otlp"
-          ? <>Exporter setup — Tares accepts OTLP/HTTP <strong>JSON</strong> (not protobuf); use a
+          ? <>Exporter setup; Tares accepts OTLP/HTTP <strong>JSON</strong> (not protobuf); use a
               JSON-capable exporter, e.g. the OTel Collector's <span className="mono">otlphttp</span>{" "}
               exporter with <span className="mono">encoding: json</span>:</>
           : <>Test it right away:</>}
@@ -78,13 +78,13 @@ export default function IngestSetup({ connector, url, authKey }: {
 function KeyNote({ authKey }: { authKey?: string }) {
   return authKey ? (
     <p className="muted">
-      This instance requires auth — send this source's <strong>ingest key</strong> as{" "}
+      This instance requires auth; send this source's <strong>ingest key</strong> as{" "}
       <span className="mono">Authorization: Bearer …</span>. Copy it now; it's shown once and listed
       under <Link to="/security">Security</Link>.
     </p>
   ) : (
     <p className="muted">
-      This instance requires auth — the producer needs this source's <strong>ingest key</strong> in{" "}
+      This instance requires auth; the producer needs this source's <strong>ingest key</strong> in{" "}
       <span className="mono">Authorization: Bearer …</span>. Use the key shown when you created the
       source, or mint one under <Link to="/security">Security</Link> (scope <span className="mono">ingest</span>).
     </p>

--- a/ui/src/components/SourceForm.tsx
+++ b/ui/src/components/SourceForm.tsx
@@ -22,9 +22,9 @@ const NAME_PLACEHOLDER: Record<string, string> = {
 const DISCOVER_HINT: Record<string, string> = {
   docker_logs: "list the containers taresd can see, then pick one to fill this form",
   github: "enter the repo above, then Discover its default branch + author labels",
-  postgres: "enter the DSN above, then Discover — it lists the tables it can see; pick one and it proposes the cursor, entity key and labels from the columns",
-  prometheus: "enter the URL (+ any auth) above, then Discover — it lists the metrics and labels so you can pick what to ingest (by name or by label). No PromQL to write.",
-  prometheus_alerts: "enter the URL (+ any auth) above, then Discover — it lists the alerting rules Prometheus already has, and you ingest them as they fire (optionally filtered by severity).",
+  postgres: "enter the DSN above, then Discover; it lists the tables it can see; pick one and it proposes the cursor, entity key and labels from the columns",
+  prometheus: "enter the URL (+ any auth) above, then Discover; it lists the metrics and labels so you can pick what to ingest (by name or by label). No PromQL to write.",
+  prometheus_alerts: "enter the URL (+ any auth) above, then Discover; it lists the alerting rules Prometheus already has, and you ingest them as they fire (optionally filtered by severity).",
 };
 
 // Postgres form: plain-language field labels + grouping (main poll settings vs collapsed advanced),
@@ -373,7 +373,7 @@ export default function SourceForm({ connector, spec, initial, lockName, submitL
         ? pgColumns : [values[f.name], ...pgColumns];   // keep a stale value selectable
       return (
         <select value={values[f.name] ?? ""} onChange={(e) => setValues({ ...values, [f.name]: e.target.value })}>
-          <option value="">{f.required ? "— select —" : "— none —"}</option>
+          <option value="">{f.required ? "select…" : "none"}</option>
           {opts.map((c) => <option key={c} value={c}>{c}</option>)}
         </select>
       );
@@ -396,9 +396,9 @@ export default function SourceForm({ connector, spec, initial, lockName, submitL
     secretSet(f) ? (
       <span className="help">
         {cleared[f.name]
-          ? <>will be removed on save — <button type="button" className="linklike"
+          ? <>will be removed on save; <button type="button" className="linklike"
                 onClick={() => setCleared({ ...cleared, [f.name]: false })}>undo</button></>
-          : <>a value is set — type to replace, or leave blank to keep ·{" "}
+          : <>a value is set; type to replace, or leave blank to keep ·{" "}
               <button type="button" className="linklike"
                 onClick={() => { setCleared({ ...cleared, [f.name]: true }); setValues({ ...values, [f.name]: "" }); }}>remove</button></>}
       </span>
@@ -465,7 +465,7 @@ export default function SourceForm({ connector, spec, initial, lockName, submitL
           <div className="fld-group-head">
             <h3>{found ? <>What we read from <code>{values.table || "the table"}</code></> : "How to poll the table"}</h3>
             <p className="help">{found
-              ? "Discover picked these from the columns — adjust any that aren't right."
+              ? "Discover picked these from the columns; adjust any that aren't right."
               : "Run Discover above to fill these from the table, or set them by hand."}</p>
           </div>
           {main.map(renderField)}
@@ -486,7 +486,7 @@ export default function SourceForm({ connector, spec, initial, lockName, submitL
       {test && (
         <div className={`alert ${test.ok ? "ok" : "error"}`}>
           {test.ok
-            ? <>connection ok — {test.note ?? `${test.events} event(s) on a test poll`}
+            ? <>connection ok; {test.note ?? `${test.events} event(s) on a test poll`}
                 {test.sample?.length ? <pre className="payload">{test.sample.join("\n")}</pre> : null}</>
             : <>test failed: {test.error}</>}
         </div>
@@ -497,7 +497,6 @@ export default function SourceForm({ connector, spec, initial, lockName, submitL
         <input type="text" value={name} disabled={lockName}
                placeholder={NAME_PLACEHOLDER[connector] ?? "e.g. metrics"}
                onChange={(e) => setName(e.target.value)} />
-        <span className="help">logical source name; events carry it forever</span>
       </label>
 
       {spec.mode === "poll" && (() => {
@@ -517,7 +516,6 @@ export default function SourceForm({ connector, spec, initial, lockName, submitL
                       options={["s", "m", "h"]}
                       labels={{ s: "seconds", m: "minutes", h: "hours" }} />
             </div>
-            <span className="help">how often to poll the source</span>
           </div>
         );
       })()}
@@ -555,7 +553,7 @@ export default function SourceForm({ connector, spec, initial, lockName, submitL
               </button>
               <span className="help" style={{ margin: 0 }}>
                 {DISCOVER_HINT[connector]
-                  ?? "fill the URL above, then let Tares introspect the source and propose what to ingest — no PromQL to write by hand"}
+                  ?? "fill the URL above, then let Tares introspect the source and propose what to ingest; no PromQL to write by hand"}
               </span>
             </div>
           )}
@@ -752,7 +750,7 @@ function LabelsEditor({ rows, onChange, fields = [], fieldHints, sourceName }:
           `from` column and the `entity key` picker now say on their own. */}
       <span className="lbl">labels &amp; key</span>
       {/* The key is ONE decision about the source, so it gets ONE control. It used to be a radio
-          per row, which reads as "pick the row I'm editing" rather than "pick the key" — and its
+          per row, which reads as "pick the row I'm editing" rather than "pick the key"; and its
           consequence (the key's type is forced to string) then looked like a broken type select. */}
       {rows.length > 0 && (
         <div className="key-picker">
@@ -831,7 +829,7 @@ function LabelsEditor({ rows, onChange, fields = [], fieldHints, sourceName }:
         <>
           <div className="help" style={{ marginTop: 6 }}>
             this connector provides: {fields.map((f, i) => <span key={f}><code>{f}</code>{i < fields.length - 1 ? ", " : ""}</span>)}
-            {" "}— pick a <code>field</code> from these (the source's page shows each field's coverage once data flows).
+            {" "}· pick a <code>field</code> from these (the source's page shows each field's coverage once data flows).
           </div>
         </>
       )}
@@ -891,7 +889,7 @@ function NormalizeEditor({ row, onChange, sourceName }:
       <span className="help" style={{ display: "block", marginTop: 0, marginBottom: 8, whiteSpace: "normal" }}>
         {/* Kept, unlike the paragraphs removed elsewhere on this page: both sentences carry a fact
             the screen cannot show. The first is why merging matters at all; the second is what
-            makes someone willing to click. "Rename the variants onto one name here" went — the
+            makes someone willing to click. "Rename the variants onto one name here" went; the
             controls below say that. */}
         Variants of the same thing
         (<span className="mono">checkout</span>, <span className="mono">checkout-svc</span>)
@@ -916,7 +914,7 @@ function NormalizeEditor({ row, onChange, sourceName }:
                   <td className="mono">{r2.from}</td>
                   <td className="num">{r2.events}</td>
                   {/* An empty target used to render as a green arrow followed by nothing, which is
-                      indistinguishable from a missing value — and `ok` styling on it reads as
+                      indistinguishable from a missing value; and `ok` styling on it reads as
                       approval of the wrong thing. Blanking a value is a legitimate rule (a pattern
                       that keeps only what matches), so it needs to be stated, not flagged. */}
                   <td className="mono">
@@ -1040,7 +1038,7 @@ function ListFieldEditor({ field, rows, onChange }:
     <div className="field">
       <span className="lbl">{field.name} {field.required && <span className="req">*</span>}</span>
       <span className="help" style={{ marginTop: 0, marginBottom: 6 }}>{field.help}</span>
-      {rows.length === 0 && <div className="empty" style={{ padding: 10 }}>no rows yet — add one below</div>}
+      {rows.length === 0 && <div className="empty" style={{ padding: 10 }}>no rows yet; add one below</div>}
       {rows.map((row, i) => (
         <div key={i} className="panel" style={{ padding: 10, marginBottom: 8 }}>
           <div className="btnrow" style={{ justifyContent: "space-between", marginBottom: 4 }}>
@@ -1098,7 +1096,7 @@ function FamilyPicker({ groups, sel, q, setQ, onToggle, onSelect, onIntrospect, 
   return (
     <div style={{ marginTop: 10 }}>
       <p className="subtitle" style={{ marginTop: 0 }}>
-        {totalMetrics.toLocaleString()} metrics across {groups.length} systems — each is one exporter
+        {totalMetrics.toLocaleString()} metrics across {groups.length} systems; each is one exporter
         or app. Tick the ones you want to ingest.
       </p>
       <div className="btnrow" style={{ marginBottom: 6, alignItems: "center", gap: 8 }}>
@@ -1185,7 +1183,7 @@ function ReferenceForm({ attachments, setAttachments }: {
       <p className="help" style={{ marginTop: 2, marginBottom: 10 }}>
         Upload json / csv / md / txt files and tag each with the entity's labels (e.g.{" "}
         <span className="mono">service=tares</span>). Those labels become real Tares labels you
-        can correlate on — and the doc is always attached to that entity, no time window.
+        can correlate on; and the doc is always attached to that entity, no time window.
       </p>
 
       {attachments.length === 0 ? (
@@ -1258,7 +1256,7 @@ function AlertRulesCuration({ rules, severities, sev, onSevToggle, includePendin
   return (
     <div style={{ marginTop: 4 }}>
       <p className="subtitle" style={{ marginTop: 0 }}>
-        {summary} — you'll ingest these as they fire. Optionally narrow by severity.
+        {summary}; you'll ingest these as they fire. Optionally narrow by severity.
       </p>
       <div className="btnrow" style={{ marginBottom: 8, alignItems: "center", flexWrap: "wrap", gap: 6 }}>
         <span className="help" style={{ margin: 0 }}>severity:</span>
@@ -1341,7 +1339,7 @@ function MetricBasket({ catalog, basket, onAdd, onRemove, fetchLabelMetrics, onC
           add all {items.length}
         </button>
         <span className="help" style={{ margin: 0 }}>{items.length} match{items.length === 1 ? "" : "es"}
-          {items.length === 500 ? " (showing first 500 — narrow the pattern)" : ""}</span>
+          {items.length === 500 ? " (showing first 500; narrow the pattern)" : ""}</span>
       </div>
       <div className="fam-list" style={{ maxHeight: 240 }}>
         {items.map((m) => (
@@ -1359,7 +1357,7 @@ function MetricBasket({ catalog, basket, onAdd, onRemove, fetchLabelMetrics, onC
   return (
     <div style={{ marginTop: 4 }}>
       <p className="subtitle" style={{ marginTop: 0 }}>
-        Choose the metrics to ingest — by name, or by a label they carry. No PromQL to write.
+        Choose the metrics to ingest; by name, or by a label they carry. No PromQL to write.
       </p>
       <div className="btnrow" style={{ gap: 6, marginBottom: 8 }}>
         <button type="button" className={tab === "name" ? "primary" : ""} onClick={() => setTab("name")}>
@@ -1372,17 +1370,17 @@ function MetricBasket({ catalog, basket, onAdd, onRemove, fetchLabelMetrics, onC
 
       {tab === "name" && (
         <div>
-          <input type="text" placeholder="type a metric name or prefix — e.g. node_* or clickhouse"
+          <input type="text" placeholder="type a metric name or prefix; e.g. node_* or clickhouse"
                  value={nameQ} onChange={(e) => setNameQ(e.target.value)} />
           {nameQ.trim()
             ? <ResultList items={nameMatches} />
-            : <p className="help">{catalog.metrics.length.toLocaleString()} metrics available — start typing to filter (append <span className="mono">*</span> for a prefix match)</p>}
+            : <p className="help">{catalog.metrics.length.toLocaleString()} metrics available; start typing to filter (append <span className="mono">*</span> for a prefix match)</p>}
         </div>
       )}
 
       {tab === "label" && (
         <div>
-          <input type="text" placeholder="filter labels — e.g. namespace, service, clickhouse_org"
+          <input type="text" placeholder="filter labels; e.g. namespace, service, clickhouse_org"
                  value={labelQ} onChange={(e) => setLabelQ(e.target.value)} />
           <div className="fam-list" style={{ maxHeight: 150, marginTop: 6 }}>
             {labelMatches.map((l) => (
@@ -1459,7 +1457,7 @@ function PromQueriesView({ rows, onChange }:
         the metrics this source will ingest. Remove anything you don't want, or “change metrics” above.
       </span>
       {rows.length === 0 && (
-        <div className="empty" style={{ padding: 10 }}>none yet — run Discover above and pick metrics</div>
+        <div className="empty" style={{ padding: 10 }}>none yet; run Discover above and pick metrics</div>
       )}
       {rows.map((q, i) => {
         const s = summarize(q);
@@ -1506,7 +1504,7 @@ function ColumnPicker({ columns, value, mandatory, onChange }: {
         <button type="button" onClick={() => onChange("")}>All</button>
         <button type="button" onClick={() => emit(new Set())}>None</button>
         <span className="help">
-          {nChecked}/{columns.length} selected{nChecked >= columns.length ? " — pulls every column" : ""}
+          {nChecked}/{columns.length} selected{nChecked >= columns.length ? "; pulls every column" : ""}
         </span>
       </div>
       {columns.length > 8 && (
@@ -1520,7 +1518,7 @@ function ColumnPicker({ columns, value, mandatory, onChange }: {
             <input type="checkbox" checked={isChecked(c)} disabled={mandatory.has(c)}
                    onChange={() => toggle(c)} style={{ marginRight: 8 }} />
             <span className="mono">{c}</span>
-            {mandatory.has(c) && <span className="badge push" style={{ marginLeft: 8 }} title="cursor/key/time — always pulled">always</span>}
+            {mandatory.has(c) && <span className="badge push" style={{ marginLeft: 8 }} title="cursor/key/time; always pulled">always</span>}
           </label>
         ))}
       </div>
@@ -1556,7 +1554,7 @@ function ColumnsProposalView({ proposal, onApply }: { proposal: ColumnsProposal;
         Apply to form
       </button>
       <span className="help" style={{ marginLeft: 10 }}>
-        fills the fields below — review, Test connection, then Create
+        fills the fields below; review, Test connection, then Create
       </span>
     </div>
   );
@@ -1582,7 +1580,7 @@ function ProposalView({ proposal, onApply }: { proposal: DiscoverProposal; onApp
           <span className="help" style={{ marginLeft: 8 }}>
             {proposal.summary.total_metrics} metrics
             {families.length > 1 ? ` · ${families.length} families` : ""}
-            {" "}— each family is one query (histogram buckets excluded)
+            {" "}· each family is one query (histogram buckets excluded)
           </span>
         </div>
       </div>
@@ -1613,7 +1611,7 @@ function ProposalView({ proposal, onApply }: { proposal: DiscoverProposal; onApp
           {[...byFamily].map(([f, ms]) => (
             <details key={f} style={{ marginBottom: 4 }}>
               <summary className="help" style={{ cursor: "pointer", padding: "2px 0" }}>
-                <span className="mono">{f}_*</span> — {ms.length} sampled
+                <span className="mono">{f}_*</span> · {ms.length} sampled
               </summary>
               <div style={{ maxHeight: 220, overflowY: "auto", margin: "6px 0 6px 16px" }}>
                 <table>
@@ -1658,7 +1656,7 @@ function ProposalView({ proposal, onApply }: { proposal: DiscoverProposal; onApp
 
       <button type="button" className="primary" onClick={onApply}>Apply to form</button>
       <span className="help" style={{ marginLeft: 10 }}>
-        fills the fields below — review, Test connection, then Create
+        fills the fields below; review, Test connection, then Create
       </span>
     </div>
   );

--- a/ui/src/components/TriggerEditor.tsx
+++ b/ui/src/components/TriggerEditor.tsx
@@ -98,9 +98,9 @@ export default function TriggerEditor({ initial, presetView, onSaved, onCancel }
           <span className="help">
             {t.view
               ? fieldOpts.length
-                ? `${fieldOpts.length} numeric field${fieldOpts.length === 1 ? "" : "s"} in this view — click the box to pick. Leave empty to count events.`
-                : "no numeric fields found in this view's events yet — leave empty to count events"
-              : "pick a view first — its numeric fields will be suggested here"}
+                ? `${fieldOpts.length} numeric field${fieldOpts.length === 1 ? "" : "s"} in this view; click the box to pick. Leave empty to count events.`
+                : "no numeric fields found in this view's events yet; leave empty to count events"
+              : "pick a view first; its numeric fields will be suggested here"}
           </span>
         </div>
       </div>

--- a/ui/src/components/ViewEditor.tsx
+++ b/ui/src/components/ViewEditor.tsx
@@ -127,7 +127,7 @@ export default function ViewEditor({ initial, sourceNames, onSaved, onCancel }: 
                  hints={srcTypes} hintClass="chip"
                  onChange={(v) => (remaining.includes(v) ? addSource(v) : setPick(v))} />
         ) : sourceNames.length === 0 ? (
-          <span className="help">no sources yet — add one under Sources first</span>
+          <span className="help">no sources yet; add one under Sources first</span>
         ) : (
           <span className="help">all sources selected</span>
         )}
@@ -136,7 +136,7 @@ export default function ViewEditor({ initial, sourceNames, onSaved, onCancel }: 
       <div className="field" style={{ marginTop: 14 }}>
         <span className="lbl">key field</span>
         <span className="help" style={{ display: "block", marginTop: 0, marginBottom: 6 }}>
-          the label agents look an entity up by — pick one the selected sources share
+          the label agents look an entity up by; pick one the selected sources share
         </span>
         <Combo value={keyField} options={labelOpts} style={{ maxWidth: 340 }}
                placeholder={labelOpts.length ? `e.g. ${labelOpts[0]}` : "e.g. service"}
@@ -158,7 +158,7 @@ export default function ViewEditor({ initial, sourceNames, onSaved, onCancel }: 
       <div className="field">
         <span className="lbl">filters (optional)</span>
         <span className="help" style={{ display: "block", marginTop: 0, marginBottom: 6 }}>
-          narrow what the view returns — applied on reads and trigger evaluation
+          applied on reads and trigger evaluation
         </span>
         {fRows.map((r, i) => (
           <div key={i} className="btnrow" style={{ marginBottom: 6, alignItems: "center" }}>

--- a/ui/src/components/bits.tsx
+++ b/ui/src/components/bits.tsx
@@ -53,12 +53,12 @@ export function usePolling<T>(fn: () => Promise<T>, intervalMs = 5000): {
  *  `error` (which keeps the last good `data`, so this sits above stale rows). */
 export function ErrorState({ error, what, onRetry }: {
   error: string;
-  what?: string;          // what failed to load, e.g. "views" — omit for the generic wording
+  what?: string;          // what failed to load, e.g. "views"; omit for the generic wording
   onRetry?: () => void;   // usually usePolling's reload
 }) {
   return (
     <div className="alert error">
-      <strong>{what ? `Couldn’t load ${what}` : "Couldn’t load this page"}</strong> — {error}
+      <strong>{what ? `Couldn’t load ${what}` : "Couldn’t load this page"}</strong> · {error}
       {onRetry && (
         <button className="btn" style={{ marginLeft: 10 }} onClick={onRetry}>Retry</button>
       )}

--- a/ui/src/components/proposals.tsx
+++ b/ui/src/components/proposals.tsx
@@ -89,7 +89,7 @@ function NormPreview({ source, label }: { source: string; label: LabelSpec }) {
       <span className="help">
         <span className="mono">{label.name}</span>: {preview.distinct_before} value{preview.distinct_before === 1 ? "" : "s"} →{" "}
         <strong>{preview.distinct_after}</strong> after this merge ({preview.sampled} events sampled)
-        {merges.length === 0 && <> — <strong>no observed value actually changes</strong></>}
+        {merges.length === 0 && <> · <strong>no observed value actually changes</strong></>}
       </span>
       {merges.length > 0 && (
         <table style={{ marginTop: 6 }}>
@@ -163,7 +163,7 @@ export function ProposalCard({ proposal, decision, onApply, onSkip }: {
                 return (
                   <span key={i} className={"chip" + (ok ? "" : " invalid")}
                         title={ok ? undefined
-                                  : "not a valid filter — needs field, op and value, with op one of "
+                                  : "not a valid filter; needs field, op and value, with op one of "
                                     + FILTER_OPS.join(", ") + ". Apply will be rejected."}>
                     {text}
                   </span>

--- a/ui/src/pages/Activity.tsx
+++ b/ui/src/pages/Activity.tsx
@@ -31,7 +31,7 @@ export function ConnectPage() {
     <>
       <h1>Connect</h1>
       <p className="subtitle">
-        hook an agent up to this Tares — <em>it pulls (MCP), gets pushed (webhook), or calls
+        hook an agent up to this Tares; <em>it pulls (MCP), gets pushed (webhook), or calls
         plain REST</em>
       </p>
 
@@ -66,7 +66,7 @@ export default function AgentActivity() {
   return (
     <>
       <h1>Activity</h1>
-      <p className="subtitle">what's been happening — the reads agents made and every trigger dispatch</p>
+      <p className="subtitle">what's been happening; the reads agents made and every trigger dispatch</p>
 
       <div className="tabs">
         {(Object.keys(ACTIVITY_LABELS) as ActivityTab[]).map((t) => (
@@ -211,7 +211,7 @@ function Connect({ tab }: { tab: ConnectTab }) {
         <div className={`mcp-status ${status}`}>
           {status === "checking" && "checking the MCP endpoint…"}
           {status === "live" && <span>MCP endpoint is live at <span className="mono">{url}</span></span>}
-          {status === "absent" && <span>No MCP endpoint found — neither at <span className="mono">{origin}/mcp</span> (reverse-proxied) nor on the default port <span className="mono">:8788</span> (separate process). Run <span className="mono">tares mcp</span> alongside the daemon (the compose deployment includes it), or use the <strong>stdio</strong> proxy below.</span>}
+          {status === "absent" && <span>No MCP endpoint found; neither at <span className="mono">{origin}/mcp</span> (reverse-proxied) nor on the default port <span className="mono">:8788</span> (separate process). Run <span className="mono">tares mcp</span> alongside the daemon (the compose deployment includes it), or use the <strong>stdio</strong> proxy below.</span>}
         </div>
       )}
 
@@ -225,7 +225,7 @@ function Connect({ tab }: { tab: ConnectTab }) {
             </div>
           </div>
           <p className="help" style={{ marginTop: 6, whiteSpace: "normal" }}>
-            This is your console access token — it works in the snippets below, but it carries{" "}
+            This is your console access token; it works in the snippets below, but it carries{" "}
             <strong>full admin rights</strong>. For an agent, prefer a{" "}
             <span className="mono">read</span>-scoped API key from the{" "}
             <Link to="/security">Security page</Link> (add <span className="mono">ingest</span> if
@@ -272,7 +272,7 @@ function Connect({ tab }: { tab: ConnectTab }) {
             payload: "…the correlated timeline for this entity, ready to hand to the model…",
           }, null, 2)} />
           <p className="help" style={{ whiteSpace: "normal" }}>
-            Delivery is <strong>at-least-once</strong> — dedupe on{" "}
+            Delivery is <strong>at-least-once</strong> · dedupe on{" "}
             <span className="mono">dispatch_id</span>. Answer <strong>2xx</strong> to acknowledge;
             5xx and transport errors are retried with backoff, a 4xx is recorded as failed and not
             retried.
@@ -291,7 +291,7 @@ function Connect({ tab }: { tab: ConnectTab }) {
             </>
           ) : (
             <p className="help" style={{ whiteSpace: "normal" }}>
-              This instance has no triggers yet, so there is nothing to subscribe to — create one
+              This instance has no triggers yet, so there is nothing to subscribe to; create one
               under <Link to="/triggers">Triggers</Link> (a condition over a view), then come back
               here.
             </p>
@@ -310,7 +310,7 @@ function Connect({ tab }: { tab: ConnectTab }) {
       {tab === "rest" && (
         <>
           <p className="help" style={{ whiteSpace: "normal", marginTop: 14 }}>
-            No MCP client? The same read surface is plain HTTP — one call returns the correlated
+            No MCP client? The same read surface is plain HTTP; one call returns the correlated
             timeline. Agents can also write conclusions back with{" "}
             <span className="mono">POST /remember</span> (needs <span className="mono">ingest</span>),
             so the next timeline arrives with prior findings attached.
@@ -323,7 +323,7 @@ function Connect({ tab }: { tab: ConnectTab }) {
         <>
       <p className="help" style={{ whiteSpace: "normal", marginTop: 14 }}>
         The agent connects as an MCP client and reads on demand: <span className="mono">read</span>,{" "}
-        <span className="mono">query</span>, <span className="mono">catalog_*</span> — one correlated
+        <span className="mono">query</span>, <span className="mono">catalog_*</span> · one correlated
         timeline per call instead of fanning out across your systems. Needs a{" "}
         <span className="mono">read</span>-scoped key. Pick your client:
       </p>
@@ -393,7 +393,7 @@ function Connect({ tab }: { tab: ConnectTab }) {
         <>
       <h3 style={{ marginTop: 14 }}>Tools the agent gets {tools && <span className="dim">· {tools.length}</span>}</h3>
       <p className="help" style={{ whiteSpace: "normal" }}>
-        Exactly what a connected agent can call — read straight from this instance&rsquo;s MCP
+        Exactly what a connected agent can call; read straight from this instance&rsquo;s MCP
         surface, so it always matches what MCP (pull) serves. The same read/query operations back
         the REST endpoints.
       </p>
@@ -445,7 +445,7 @@ export function AgentsRoster({ only }: { only?: "connected" | "tares" }) {
   if (!agents.length) {
     return (
       <div className="empty">
-        no external agents connected — connect one, or a Slack channel, from a{" "}
+        no external agents connected; connect one, or a Slack channel, from a{" "}
         <Link to="/triggers">trigger's</Link> page
       </div>
     );
@@ -499,7 +499,7 @@ export function AgentsRoster({ only }: { only?: "connected" | "tares" }) {
                       ))}
                       {a.recent.length > 0 && (
                         <>
-                          <p className="help" style={{ margin: "10px 0 4px" }}>recent wakes — open one for the full dispatch</p>
+                          <p className="help" style={{ margin: "10px 0 4px" }}>recent wakes; open one for the full dispatch</p>
                           <table>
                             <thead><tr><th>when</th><th>trigger</th><th>entity</th><th>delivery</th></tr></thead>
                             <tbody>
@@ -531,7 +531,7 @@ export function AgentsRoster({ only }: { only?: "connected" | "tares" }) {
 function Queries() {
   const { data, error } = usePolling(() => api.queries(150));
   const [q, setQ] = useState("");
-  const [client, setClient] = useState("mcp");  // default to agent reads — the interesting traffic
+  const [client, setClient] = useState("mcp");  // default to agent reads; the interesting traffic
 
   // Filter options: "all" + mcp (always, the important one) + whatever else appears (ui, http).
   const clientOpts = useMemo(
@@ -548,7 +548,7 @@ function Queries() {
   }, [data, q, client]);
 
   if (error) return <div className="alert error">{error}</div>;
-  if (!data?.length) return <div className="empty">no reads yet — connect an agent in Connect and its reads show up here.</div>;
+  if (!data?.length) return <div className="empty">no reads yet; connect an agent in Connect and its reads show up here.</div>;
   return (
     <>
       <div className="toolbar">
@@ -568,7 +568,7 @@ function Queries() {
       {!shown.length ? (
         <div className="empty">
           no <span className="mono">{client}</span> reads{q && <> matching “{q}”</>} in the last {data.length}
-          {client === "mcp" && <> — connect an agent in Connect, or switch the client filter above.</>}
+          {client === "mcp" && <> · connect an agent in Connect, or switch the client filter above.</>}
         </div>
       ) : (
         <table>

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -96,16 +96,16 @@ export default function AgentDetail() {
                   <td>
                     {agent.enabled ? <span className="badge ok">enabled</span> : <span className="badge">disabled</span>}
                     {!data.key_configured
-                      ? <span className="help"> — no Anthropic key: set one under <Link to="/security">Security</Link> to run</span>
-                      : <span className="help"> — key from <span className="mono">{data.key_source}</span></span>}
+                      ? <span className="help"> · no Anthropic key: set one under <Link to="/security">Security</Link> to run</span>
+                      : <span className="help"> · key from <span className="mono">{data.key_source}</span></span>}
                   </td>
                 </tr>
                 <tr><td className="help">wakes on</td>
                     <td><Link to={`/triggers/${encodeURIComponent(agent.trigger)}`} className="mono">{agent.trigger}</Link>
-                        <span className="help"> — the trigger that runs this agent</span></td></tr>
+                        <span className="help"> · the trigger that runs this agent</span></td></tr>
                 <tr><td className="help">writes to</td>
                     <td><Link to="/sources/findings" className="mono">findings</Link>
-                        <span className="help"> — one finding per run, on the entity's timeline</span></td></tr>
+                        <span className="help"> · one finding per run, on the entity's timeline</span></td></tr>
                 <tr><td className="help">last woken</td>
                     <td>{lastRun
                       ? <><TimeAgo ts={lastRun.started_at} /> for <span className="mono">{lastRun.key}</span>
@@ -113,7 +113,7 @@ export default function AgentDetail() {
                       : <span className="dim">never</span>}</td></tr>
                 <tr><td className="help">model</td>
                     <td><span className="mono">{agent.model || data.default_model}</span>
-                        {!agent.model && <span className="help"> — instance default</span>}</td></tr>
+                        {!agent.model && <span className="help"> · instance default</span>}</td></tr>
                 <tr><td className="help">Slack</td>
                     <td>{agent.slack_channel
                       ? <><span className="badge ok">channel</span> <span className="help">posted by the workspace bot</span></>
@@ -125,7 +125,7 @@ export default function AgentDetail() {
                       ? <><span className="mono">{agent.webhook_url}</span>
                           {agent.webhook_token_configured
                             ? <span className="badge ok" style={{ marginLeft: 8 }}>bearer auth</span>
-                            : <span className="help"> — no auth</span>}</>
+                            : <span className="help"> · no auth</span>}</>
                       : <span className="dim">—</span>}</td></tr>
                 <tr><td className="help">prompt</td>
                     <td><pre className="mono" style={{ whiteSpace: "pre-wrap", margin: 0 }}>{agent.prompt}</pre></td></tr>
@@ -135,7 +135,7 @@ export default function AgentDetail() {
 
           <h2>Runs &amp; findings</h2>
           {runsError && <ErrorState error={runsError} what="this agent’s runs" />}
-          {!runsError && !runs?.length && <p className="help">none yet — this agent runs when <span className="mono">{agent.trigger}</span> fires</p>}
+          {!runsError && !runs?.length && <p className="help">none yet; this agent runs when <span className="mono">{agent.trigger}</span> fires</p>}
           {runs?.map((r, i) => {
             const header = (
               <>

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Link, useNavigate, useParams } from "react-router-dom";
+import { Link, useNavigate, useParams, useSearchParams } from "react-router-dom";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
@@ -22,7 +22,12 @@ function statusBadge(r: AgentRun) {
 }
 
 export default function AgentDetail() {
+  // A dispatch page links here as ?dispatch=<id>: that run opens, highlights, and scrolls into
+  // view, so "what did the agent do with this firing" is one click.
+
   const { name = "" } = useParams();
+  const [search] = useSearchParams();
+  const focusDispatch = search.get("dispatch") ?? undefined;
   const nav = useNavigate();
   const [editing, setEditing] = useState(false);
   const [confirmDel, setConfirmDel] = useState(false);
@@ -166,8 +171,11 @@ export default function AgentDetail() {
                 </p>;
             // Newest run expanded by default; older ones collapse so the page stays readable as
             // runs accumulate. <details> keeps it dependency-free and keyboard-accessible.
+            const focused = !!focusDispatch && r.dispatch_id === focusDispatch;
             return (
-              <details className="panel" key={r.id} open={i === 0}>
+              <details className="panel" key={r.id} open={i === 0 || focused}
+                       style={focused ? { outline: "2px solid var(--accent)" } : undefined}
+                       ref={(el) => { if (el && focused) el.scrollIntoView({ block: "center" }); }}>
                 <summary style={{ cursor: "pointer", listStyle: "revert" }}>{header}</summary>
                 {body}
               </details>

--- a/ui/src/pages/AgentNew.tsx
+++ b/ui/src/pages/AgentNew.tsx
@@ -34,14 +34,14 @@ export default function AgentNew() {
     <>
       <h1>Create Tares agent</h1>
       <p className="subtitle">
-        a prompt on a trigger — it reads the correlated timeline when the trigger fires and writes a
+        a prompt on a trigger; it reads the correlated timeline when the trigger fires and writes a
         finding back onto the entity's timeline
       </p>
 
       {err && <div className="alert error">{err}</div>}
       {!keyOk && (
         <div className="alert">
-          No Anthropic key configured — you can create the agent now, but it won't run until a key
+          No Anthropic key configured; you can create the agent now, but it won't run until a key
           is set under <Link to="/security">Security</Link>. It also starts disabled.
         </div>
       )}
@@ -49,7 +49,7 @@ export default function AgentNew() {
       {!triggers ? <div className="dim">loading…</div>
         : triggers.length === 0 ? (
           <div className="alert">
-            No triggers yet — an agent runs on a trigger. Create one under{" "}
+            No triggers yet; an agent runs on a trigger. Create one under{" "}
             <Link to="/triggers">Triggers</Link> first.
           </div>
         ) : (

--- a/ui/src/pages/Agents.tsx
+++ b/ui/src/pages/Agents.tsx
@@ -29,7 +29,7 @@ export default function Agents() {
         <div>
           <h1>Agents</h1>
           <p className="subtitle">
-            everything your triggers can wake — <strong>Tares agents</strong> that run in-process,
+            everything your triggers can wake; <strong>Tares agents</strong> that run in-process,
             and <strong>connected agents</strong> reached over a webhook
           </p>
         </div>
@@ -41,7 +41,7 @@ export default function Agents() {
 
       {data && !data.key_configured && (
         <div className="alert">
-          No Anthropic key configured — agents can be created but not enabled. Set one under{" "}
+          No Anthropic key configured; agents can be created but not enabled. Set one under{" "}
           <Link to="/security">Security</Link>.
         </div>
       )}
@@ -51,7 +51,7 @@ export default function Agents() {
         : data.agents.length === 0 ? (
           <div className="panel">
             <p className="help" style={{ whiteSpace: "normal", marginTop: 0 }}>
-              No Tares agents yet. Create one here, or from a trigger's page — it reads the same
+              No Tares agents yet. Create one here, or from a trigger's page; it reads the same
               correlated timeline your external agents receive and writes what it found back into
               Tares, so the next agent to read that entity already has the conclusion.
             </p>

--- a/ui/src/pages/CatalogExport.tsx
+++ b/ui/src/pages/CatalogExport.tsx
@@ -4,7 +4,7 @@ import { Link } from "react-router-dom";
 import { api } from "../api";
 import type { Source } from "../types";
 
-const REDACTED = "••••••••";   // matches connectors.REDACTED_SECRET — a set secret comes back as this
+const REDACTED = "••••••••";   // matches connectors.REDACTED_SECRET; a set secret comes back as this
 const hasSecret = (s: Source) => Object.values(s.config ?? {}).includes(REDACTED);
 
 // Export the catalog to portable YAML. Defaults mirror the API/agent call (all sources, no secrets);
@@ -58,7 +58,7 @@ export default function CatalogExport() {
         <div>
           <p className="subtitle" style={{ marginBottom: 4 }}><Link to="/sources">Sources</Link> ›</p>
           <h1>Export catalog</h1>
-          <p className="subtitle">the portable form of your catalog — sources, views and triggers as YAML</p>
+          <p className="subtitle">the portable form of your catalog; sources, views and triggers as YAML</p>
         </div>
       </div>
 
@@ -94,7 +94,7 @@ export default function CatalogExport() {
             </label>
             <p className="help" style={{ margin: "6px 0 0" }}>
               {includeSecrets
-                ? <span style={{ color: "var(--err)" }}>⚠️ The YAML will contain credentials in plaintext — don't commit or share it.</span>
+                ? <span style={{ color: "var(--err)" }}>⚠️ The YAML will contain credentials in plaintext; don't commit or share it.</span>
                 : <>Secrets are left out (empty); re-enter them on the target when importing. {anySecret && "Some selected sources carry a secret."}</>}
             </p>
           </div>

--- a/ui/src/pages/CatalogImport.tsx
+++ b/ui/src/pages/CatalogImport.tsx
@@ -14,7 +14,8 @@ export default function CatalogImport() {
     setBusy(true); setMsg(undefined);
     try {
       const r = await api.importYaml(text, mode);
-      setMsg({ ok: true, text: `imported ${r.sources} sources, ${r.views} views, ${r.triggers} triggers (${mode})` });
+      setMsg({ ok: true, text: `imported ${r.sources} sources, ${r.views} views, ${r.triggers} triggers, `
+        + `${r.agents} agents, ${r.mcp_servers} mcp servers (${mode})` });
       setText("");
     } catch (e) {
       setMsg({ ok: false, text: String((e as Error).message ?? e) });

--- a/ui/src/pages/CatalogImport.tsx
+++ b/ui/src/pages/CatalogImport.tsx
@@ -29,7 +29,7 @@ export default function CatalogImport() {
         <div>
           <p className="subtitle" style={{ marginBottom: 4 }}><Link to="/sources">Sources</Link> ›</p>
           <h1>Import catalog</h1>
-          <p className="subtitle">paste a catalog YAML — sources, views and triggers</p>
+          <p className="subtitle">paste a catalog YAML; sources, views and triggers</p>
         </div>
       </div>
 
@@ -41,10 +41,7 @@ export default function CatalogImport() {
           <textarea className="code" style={{ minHeight: 260 }} value={text}
                     placeholder={"sources:\n  - name: ...\nviews:\n  - name: ...\ntriggers:\n  - name: ..."}
                     onChange={(e) => setText(e.target.value)} />
-          <span className="help">
-            validated as a whole before anything is written · secrets left empty in an export must be
-            re-entered here (or set on the source afterwards)
-          </span>
+          <span className="help">secrets left empty in an export must be re-entered here</span>
         </label>
         <div className="btnrow">
           <label style={{ display: "inline-flex", gap: 6, alignItems: "center" }}>

--- a/ui/src/pages/DispatchDetail.tsx
+++ b/ui/src/pages/DispatchDetail.tsx
@@ -14,7 +14,7 @@ export default function DispatchDetail() {
     return (
       <div className="alert error">
         {/unknown dispatch/i.test(error) ? <>no dispatch <span className="mono">{id}</span></> : error}
-        {" "}— see <Link to="/activity?tab=dispatches">Trigger dispatches</Link>
+        {" "}· see <Link to="/activity?tab=dispatches">Trigger dispatches</Link>
       </div>
     );
   }
@@ -55,7 +55,7 @@ export default function DispatchDetail() {
       <h2>Deliveries</h2>
       {d.deliveries.length === 0 ? (
         <p className="help" style={{ whiteSpace: "normal" }}>
-          no subscribers were attached when this fired — nothing was delivered (the firing is still
+          no subscribers were attached when this fired; nothing was delivered (the firing is still
           logged; wire an agent on the <Link to={`/triggers/${encodeURIComponent(d.trigger)}`}>trigger</Link>).
         </p>
       ) : (
@@ -80,7 +80,7 @@ export default function DispatchDetail() {
 
       <h2>Payload</h2>
       <p className="help" style={{ margin: "0 0 6px", whiteSpace: "normal" }}>
-        the timeline POSTed to each subscriber — the agent boots holding this.
+        the timeline POSTed to each subscriber; the agent boots holding this.
       </p>
       <pre className="payload">{payload}</pre>
     </>

--- a/ui/src/pages/DispatchDetail.tsx
+++ b/ui/src/pages/DispatchDetail.tsx
@@ -62,9 +62,16 @@ export default function DispatchDetail() {
         <table style={{ marginBottom: 18 }}>
           <thead><tr><th>agent</th><th>endpoint</th><th>status</th><th>when</th></tr></thead>
           <tbody>
+            {/* Each kind links to where its story continues: a Tares agent to its run for THIS
+                firing, an external agent to its roster row. A Slack channel gets no link — the
+                message went to Slack; there is nothing more to show here. */}
             {d.deliveries.map((dv, i) => (
               <tr key={i}>
-                <td><Link to={`/activity?agent=${encodeURIComponent(dv.agent)}`}><strong>{dv.agent}</strong></Link></td>
+                <td>{dv.kind === "tares"
+                  ? <Link to={`/agents/${encodeURIComponent(dv.agent)}?dispatch=${encodeURIComponent(d.dispatch_id)}`}><strong>{dv.agent}</strong></Link>
+                  : dv.kind === "webhook"
+                  ? <Link to={`/agents?agent=${encodeURIComponent(dv.agent)}`}><strong>{dv.agent}</strong></Link>
+                  : <strong>{dv.agent}</strong>}</td>
                 <td className="mono">{dv.endpoint}</td>
                 <td>
                   {dv.ok

--- a/ui/src/pages/Explore.tsx
+++ b/ui/src/pages/Explore.tsx
@@ -12,7 +12,7 @@ import type { LabelFacet, TimelineEventRow, View } from "../types";
 // timeline or the exact payload an agent receives over MCP.
 
 const WINDOWS = ["1h", "24h", "7d", "30d"];
-const RAW = "";  // lens sentinel: "All sources (raw)" — the /read primitive, no view
+const RAW = "";  // lens sentinel: "All sources (raw)"; the /read primitive, no view
 
 // One label=value term of the conjunction. The first term carries display metadata (event count,
 // the axis's declared sources) so we can label the header and offer relevant view lenses.
@@ -136,7 +136,7 @@ export default function Explore() {
         <div className="cat-group-head">
           <span>{f.label}</span>
           {f.high_cardinality && (
-            <span className="badge starting" title="high-cardinality: too many distinct values to profile as an entity axis — showing a live sample">high-card</span>
+            <span className="badge starting" title="high-cardinality: too many distinct values to profile as an entity axis; showing a live sample">high-card</span>
           )}
           <span className="n">{vals.length}</span>
         </div>
@@ -158,18 +158,18 @@ export default function Explore() {
 
   const shownSources = effectiveLens === RAW ? readSources : (lensView?.sources ?? []);
   const emptyHint = effectiveLens === RAW
-    ? "no events match this selector in the last " + window_ + " — widen the window or remove a filter."
-    : "this view's sources don't carry this selector — switch to All sources (raw) to read every source.";
+    ? "no events match this selector in the last " + window_ + "; widen the window or remove a filter."
+    : "this view's sources don't carry this selector; switch to All sources (raw) to read every source.";
 
   return (
     <>
       <h1>Explore</h1>
-      <p className="subtitle">pick an entity, filter it if you like — read everything matching across every source, <em>one timeline</em></p>
+      <p className="subtitle">pick an entity, filter it if you like; read everything matching across every source, <em>one timeline</em></p>
 
       {error && <div className="alert error">{error}</div>}
       {!facets.length && !error && (
         <div className="empty">
-          no entities yet — add a source (each declares one or more labels; one is its key), then
+          no entities yet; add a source (each declares one or more labels; one is its key), then
           ingest some events.
         </div>
       )}

--- a/ui/src/pages/Home.tsx
+++ b/ui/src/pages/Home.tsx
@@ -47,7 +47,7 @@ export default function Home() {
         <div>
           <h1>Overview</h1>
           <p className="subtitle">
-            what this instance holds — <em>and how much room is left</em>
+            what this instance holds; <em>and how much room is left</em>
           </p>
         </div>
       </div>
@@ -96,7 +96,7 @@ export default function Home() {
 
       {sources && sources.length === 0 && !sourcesError && (
         <div className="empty">
-          Nothing is being ingested yet — <Link to="/sources/new">add a source</Link> to start
+          Nothing is being ingested yet; <Link to="/sources/new">add a source</Link> to start
           filling the timeline.
         </div>
       )}
@@ -126,7 +126,7 @@ function StoragePanel({ usage, error, reload, onDisk, pct }: {
     <div className="panel">
       <h2 style={{ marginTop: 0 }}>Storage</h2>
       <p className="help" style={{ marginTop: 0 }}>
-        What this instance is using on disk — the DuckDB file plus its write-ahead log. Nothing is
+        What this instance is using on disk; the DuckDB file plus its write-ahead log. Nothing is
         pruned today, so agent runs and dispatch deliveries grow with every firing.
       </p>
 
@@ -137,7 +137,7 @@ function StoragePanel({ usage, error, reload, onDisk, pct }: {
         <>
           {pct !== null && pct >= 80 && (
             <div className="alert warn">
-              <strong>Storage {pct}% full</strong> — {formatBytes(onDisk)} of the{" "}
+              <strong>Storage {pct}% full</strong> · {formatBytes(onDisk)} of the{" "}
               {formatBytes(u.max_bytes)} limit for this instance. Ingest keeps working until it
               runs out; free space or raise <code>TARES_MAX_DB_SIZE</code> before it does.
             </div>

--- a/ui/src/pages/McpServers.tsx
+++ b/ui/src/pages/McpServers.tsx
@@ -50,7 +50,7 @@ function ServerForm({ initial, onSaved, onCancel }: {
           <input type="text" className="mono" value={url}
                  placeholder="https://mcp.example.com/mcp"
                  onChange={(e) => setUrl(e.target.value)} />
-          <span className="help">streamable HTTP endpoint; stdio servers are not supported</span>
+          <span className="help">stdio servers are not supported</span>
         </label>
       </div>
       <div className="field">
@@ -64,9 +64,7 @@ function ServerForm({ initial, onSaved, onCancel }: {
               : "header value, e.g. Bearer sk-…"}
                  value={value} onChange={(e) => setValue(e.target.value)} />
         </div>
-        <span className="help">
-          sent on every request to this server; the value is stored as a secret and never shown again
-        </span>
+        <span className="help">stored as a secret, never shown again</span>
       </div>
       <div className="btnrow">
         <button className="primary" onClick={save}

--- a/ui/src/pages/Security.tsx
+++ b/ui/src/pages/Security.tsx
@@ -46,12 +46,12 @@ function AccessPanel() {
             <span className="help">
               the console and API require a login. You signed in with the root token printed by{" "}
               <code>tares up --auth</code>. Hand machines their own scoped <strong>API keys</strong>{" "}
-              below — never the root token.
+              below; never the root token.
             </span>
           </p>
         ) : (
           <div className="alert">
-            <span className="badge">auth off</span> — this instance is <strong>open</strong>: anyone
+            <span className="badge">auth off</span> · this instance is <strong>open</strong>: anyone
             who can reach it can read and write, and API keys are not enforced. Restart with{" "}
             <code>tares up --auth</code> to require a login.
           </div>
@@ -89,7 +89,7 @@ function AnthropicKeyPanel() {
     <div className="panel">
       <h2 style={{ marginTop: 0 }}>Anthropic key</h2>
       <p className="help" style={{ marginTop: 0 }}>
-        What <strong>Tares agents</strong> run on — their first look at an entity when a trigger
+        What <strong>Tares agents</strong> run on; their first look at an entity when a trigger
         fires. Set <code>ANTHROPIC_API_KEY</code> in the daemon's environment, or store one here.
         It is never returned by the API and never included in a catalog export.
       </p>
@@ -108,7 +108,7 @@ function AnthropicKeyPanel() {
           </p>
           {st.env_overrides && st.stored && (
             <div className="alert">
-              A key is set in the environment and takes precedence — the one stored here is not in
+              A key is set in the environment and takes precedence; the one stored here is not in
               use. Remove the environment variable, or clear the stored key to avoid confusion.
             </div>
           )}
@@ -182,7 +182,7 @@ function SlackTokenPanel() {
           </p>
           {st.env_overrides && st.stored && (
             <div className="alert">
-              A token is set in the environment and takes precedence — the one stored here is not in
+              A token is set in the environment and takes precedence; the one stored here is not in
               use. Remove the environment variable, or clear the stored token to avoid confusion.
             </div>
           )}
@@ -257,7 +257,7 @@ function SlackSigningSecretPanel() {
           </p>
           {st.env_overrides && st.stored && (
             <div className="alert">
-              A signing secret is set in the environment and takes precedence — the one stored here
+              A signing secret is set in the environment and takes precedence; the one stored here
               is not in use. Remove the environment variable, or clear the stored secret.
             </div>
           )}
@@ -283,9 +283,9 @@ function SlackSigningSecretPanel() {
 // Scope semantics (docs/design/api-keys.md): read = consume (queries, catalog reads, an agent's
 // own derive/subscribe) · ingest = contribute events · admin = configure the instance.
 const SCOPE_HELP: Record<string, string> = {
-  read: "consume — queries, timelines, catalog; agents' own views & subscriptions",
-  ingest: "contribute — POST events to /ingest and /v1/*, write memories",
-  admin: "configure — sources/views/triggers, credentials, keys (implies the rest)",
+  read: "consume: queries, timelines, catalog; agents' own views & subscriptions",
+  ingest: "contribute: POST events to /ingest and /v1/*, write memories",
+  admin: "configure: sources/views/triggers, credentials, keys (implies the rest)",
 };
 
 function ApiKeysPanel() {
@@ -307,7 +307,7 @@ function ApiKeysPanel() {
         <button className="primary" onClick={() => setCreating(true)}>Create key</button>
       </div>
       <p className="help" style={{ marginTop: 0 }}>
-        Scoped, revocable credentials — hand each producer and agent its own key instead of a
+        Scoped, revocable credentials; hand each producer and agent its own key instead of a
         shared token. <strong>read</strong>: agents over MCP · <strong>ingest</strong>: producers ·{" "}
         <strong>read + ingest</strong>: the Claude Code plugin · <strong>admin</strong>: full control.
       </p>
@@ -321,7 +321,7 @@ function ApiKeysPanel() {
 
       {minted && (
         <div className="alert ok">
-          Key <strong>{minted.name}</strong> created — copy the secret now; it is not shown again:
+          Key <strong>{minted.name}</strong> created; copy the secret now; it is not shown again:
           <div className="ingest-url" style={{ marginTop: 8 }}>
             <code className="mono">{minted.secret}</code>
             <CopySecret text={minted.secret} />
@@ -351,7 +351,7 @@ function ApiKeysPanel() {
           </tbody>
         </table>
       ) : (
-        <p className="help">no keys yet — <strong>Create key</strong> to issue one for a producer or agent.</p>
+        <p className="help">no keys yet; <strong>Create key</strong> to issue one for a producer or agent.</p>
       )}
 
       {creating && (
@@ -418,7 +418,7 @@ function KeyModal({ onClose, onCreated }: {
             <span className="lbl">name</span>
             <input type="text" placeholder="e.g. otel-prod, my-agent" value={name} autoFocus
                    onChange={(e) => setName(e.target.value)} />
-            <span className="help">who holds it — one key per producer or agent</span>
+            <span className="help">who holds it; one key per producer or agent</span>
           </label>
           <div className="field">
             <span className="lbl">scopes</span>

--- a/ui/src/pages/SourceClaudeCode.tsx
+++ b/ui/src/pages/SourceClaudeCode.tsx
@@ -39,7 +39,7 @@ export default function SourceClaudeCode() {
     <>
       <h1>Connect Claude Code</h1>
       <p className="subtitle">
-        Install the Tares plugin for Claude Code — it streams your sessions into the{" "}
+        Install the Tares plugin for Claude Code; it streams your sessions into the{" "}
         <span className="mono">claude_code</span> source (keyed by session, with project / branch /
         model labels; secrets redacted server-side) and adds MCP read-back. Same steps local or remote.
       </p>
@@ -51,7 +51,7 @@ export default function SourceClaudeCode() {
             <span className="badge ok">connected</span>
           </div>
           <p className="help" style={{ marginTop: 8 }}>
-            A <span className="mono">claude_code</span> source exists — sessions are streaming in.{" "}
+            A <span className="mono">claude_code</span> source exists; sessions are streaming in.{" "}
             <Link to="/sources/claude_code">Manage source</Link>.
           </p>
         </div>
@@ -89,12 +89,12 @@ export default function SourceClaudeCode() {
             <span className="help">
               Create an API key with the <span className="mono">read</span> +{" "}
               <span className="mono">ingest</span> scopes on the{" "}
-              <Link to="/security">Security page</Link> and paste it here — it lets the plugin
+              <Link to="/security">Security page</Link> and paste it here; it lets the plugin
               stream sessions <em>and</em> query Tares over MCP, without full admin rights.
             </span>
           ) : (
             <span className="help">
-              This instance is open (no auth configured) — leave it blank.
+              This instance is open (no auth configured); leave it blank.
             </span>
           )}
         </label>

--- a/ui/src/pages/SourceDetail.tsx
+++ b/ui/src/pages/SourceDetail.tsx
@@ -204,7 +204,7 @@ function LabelsSummary({ source, onEdit }: { source: Source; onEdit: () => void 
         </table>
       ) : (
         <p className="help" style={{ margin: 0, whiteSpace: "normal" }}>
-          No labels declared — events fall back to the connector&rsquo;s default key, and agents
+          No labels declared; events fall back to the connector&rsquo;s default key, and agents
           can&rsquo;t slice this source by any axis. Check <strong>Fields</strong> below for the
           candidates observed in your data, then declare them here.
         </p>
@@ -273,7 +273,7 @@ function FieldsPanel({ name, source }: { name: string; source: Source }) {
                   </div>
                   {l.coverage === 0 && (
                     <div className="help" style={{ fontFamily: "inherit" }}>
-                      no sampled event carries this label — check the field mapping / regex
+                      no sampled event carries this label; check the field mapping / regex
                     </div>
                   )}
                 </td>

--- a/ui/src/pages/SourceDiscover.tsx
+++ b/ui/src/pages/SourceDiscover.tsx
@@ -61,7 +61,7 @@ export default function SourceDiscover() {
         <button onClick={run} disabled={loading || busy}>rescan</button>
       </div>
       <p className="subtitle">
-        scan the local Docker environment and set up everything Tares can ingest — you just confirm
+        scan the local Docker environment and set up everything Tares can ingest; you just confirm
       </p>
 
       {loading && <div className="empty">scanning Docker…</div>}
@@ -111,7 +111,7 @@ export default function SourceDiscover() {
                 <>
                   <span className="badge ok">created</span>
                   <span className="help">
-                    added {created} source{created === 1 ? "" : "s"} — taking you to Sources…
+                    added {created} source{created === 1 ? "" : "s"}; taking you to Sources…
                   </span>
                 </>
               ) : (
@@ -122,7 +122,7 @@ export default function SourceDiscover() {
                   {results && (
                     <span className="help">
                       created {created} of {Object.keys(results).length}
-                      {failed ? `, ${failed} failed — fix and retry` : ""} ·{" "}
+                      {failed ? `, ${failed} failed; fix and retry` : ""} ·{" "}
                       <a href="#" onClick={(e) => { e.preventDefault(); nav("/sources"); }}>view sources</a>
                     </span>
                   )}

--- a/ui/src/pages/SourceNew.tsx
+++ b/ui/src/pages/SourceNew.tsx
@@ -8,6 +8,65 @@ import type { ConnectorSpec } from "../types";
 
 type Created = { name: string; key: string; authKey?: string; keyErr?: string };
 
+/** Paste a catalog snippet (from the docs, a tutorial, a teammate) and merge it in. Always merge,
+ *  never replace: this door is for ADDING deterministically, and it must be impossible to wipe a
+ *  catalog from here. The full import/export (including replace) stays under Sources → Import. */
+function YamlQuickAdd() {
+  const [text, setText] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string>();
+  const [done, setDone] = useState<{ label: string; to?: string }[]>();
+
+  const run = async () => {
+    setBusy(true); setErr(undefined); setDone(undefined);
+    try {
+      const r = await api.importYaml(text, "merge");
+      const links = [
+        ...r.names.sources.map((n) => ({ label: `source ${n}`, to: `/sources/${encodeURIComponent(n)}` })),
+        ...r.names.views.map((n) => ({ label: `view ${n}`, to: `/views/${encodeURIComponent(n)}` })),
+        ...r.names.triggers.map((n) => ({ label: `trigger ${n}`, to: `/triggers/${encodeURIComponent(n)}` })),
+        ...r.names.agents.map((n) => ({ label: `agent ${n}`, to: `/agents/${encodeURIComponent(n)}` })),
+        ...r.names.mcp_servers.map((n) => ({ label: `mcp server ${n}`, to: "/mcp-servers" })),
+      ];
+      if (!links.length) { setErr("nothing in that YAML — expected sources:, views:, triggers:, agents: or mcp_servers:"); }
+      else { setDone(links); setText(""); }
+    } catch (e) { setErr(String((e as Error).message ?? e)); }
+    setBusy(false);
+  };
+
+  return (
+    <div className="panel" style={{ marginBottom: 18 }}>
+      <h2 style={{ marginTop: 0 }}>Paste a catalog snippet</h2>
+      <p className="help" style={{ whiteSpace: "normal", marginTop: 0 }}>
+        the YAML from a docs page or tutorial, added as-is: validated first, then <strong>merged</strong>{" "}
+        into your catalog — nothing existing is removed. Works for sources, views, triggers, agents
+        and MCP servers.
+      </p>
+      {err && <div className="alert error">{err}</div>}
+      {done && (
+        <div className="alert ok">
+          added{" "}
+          {done.map((d, i) => (
+            <span key={d.label}>
+              {i > 0 && ", "}
+              {d.to ? <Link to={d.to} className="mono">{d.label}</Link> : <span className="mono">{d.label}</span>}
+            </span>
+          ))}
+        </div>
+      )}
+      <textarea className="code mono" style={{ minHeight: 120, width: "100%" }} value={text}
+                placeholder={"sources:\n  - name: metrics\n    connector: prometheus\n    config: ..."}
+                onChange={(e) => setText(e.target.value)} />
+      <div className="btnrow" style={{ marginTop: 8 }}>
+        <button className="primary" onClick={run} disabled={busy || !text.trim()}>
+          {busy ? "Adding…" : "Add to catalog"}
+        </button>
+        <Link className="btn" to="/sources/import">full import / export</Link>
+      </div>
+    </div>
+  );
+}
+
 export default function SourceNew() {
   const nav = useNavigate();
   const [specs, setSpecs] = useState<Record<string, ConnectorSpec>>();
@@ -20,6 +79,7 @@ export default function SourceNew() {
   // Auth mode. When ON, a push producer needs an ingest credential in the header, so we mint one for
   // the source at creation (show-once). When OFF, the ingest URL alone is enough — no key.
   const [authOn, setAuthOn] = useState(false);
+  const [showYaml, setShowYaml] = useState(false);
 
   useEffect(() => {
     api.connectors().then(setSpecs);
@@ -33,35 +93,46 @@ export default function SourceNew() {
 
   return (
     <>
-      <h1>Add source</h1>
-      <p className="subtitle">pick a connector, configure it, save — <em>no restart needed</em></p>
+      <div className="pagehead">
+        <div>
+          <h1>Add source</h1>
+          <p className="subtitle">pick a connector, configure it, save — <em>no restart needed</em></p>
+        </div>
+        {!connector && !created && (
+          <button className={showYaml ? "" : "dim"} onClick={() => setShowYaml((v) => !v)}>
+            Add via YAML
+          </button>
+        )}
+      </div>
+
+      {!connector && !created && showYaml && <YamlQuickAdd />}
 
       {!specs && <div className="dim">loading connectors…</div>}
 
       {specs && !connector && (
-        <table>
-          <thead><tr><th>connector</th><th>mode</th><th>what it does</th></tr></thead>
-          <tbody>
+        <>
+          <div className="connector-cards">
             {/* `internal` connectors are provisioned by Tares itself (the agent findings
                 source) — nothing to configure, so they're not offered here. */}
             {Object.entries(specs).filter(([, s]) => !s.internal).map(([key, s]) => (
-              unavailable(key) ? (
-                <tr key={key} className="dim">
-                  <td className="mono">{key}</td>
-                  <td><span className="badge starting">unavailable</span></td>
-                  <td>{s.description} <em>Needs Docker on the Tares host — not available on this deployment.</em></td>
-                </tr>
-              ) : (
-                <tr key={key} className="clickable"
-                    onClick={() => key === "claude_code" ? nav("/sources/claude-code") : setConnector(key)}>
-                  <td className="mono">{key}</td>
-                  <td><span className={`badge ${s.mode === "push" ? "push" : "ok"}`}>{s.mode}</span></td>
-                  <td>{s.description}</td>
-                </tr>
-              )
+              <button key={key} type="button"
+                      className={"connector-card" + (unavailable(key) ? " unavailable" : "")}
+                      disabled={unavailable(key)}
+                      onClick={() => key === "claude_code" ? nav("/sources/claude-code") : setConnector(key)}>
+                <div className="connector-card-head">
+                  <span className="mono name">{key}</span>
+                  <span className={`badge ${unavailable(key) ? "starting" : s.mode === "push" ? "push" : "ok"}`}>
+                    {unavailable(key) ? "unavailable" : s.mode}
+                  </span>
+                </div>
+                <div className="help desc">
+                  {s.description}
+                  {unavailable(key) && <em> Needs Docker on the Tares host — not available on this deployment.</em>}
+                </div>
+              </button>
             ))}
-          </tbody>
-        </table>
+          </div>
+        </>
       )}
 
       {/* a push source just got created: show its ingest URL right here so it can be pasted into

--- a/ui/src/pages/SourceNew.tsx
+++ b/ui/src/pages/SourceNew.tsx
@@ -28,7 +28,7 @@ function YamlQuickAdd() {
         ...r.names.agents.map((n) => ({ label: `agent ${n}`, to: `/agents/${encodeURIComponent(n)}` })),
         ...r.names.mcp_servers.map((n) => ({ label: `mcp server ${n}`, to: "/mcp-servers" })),
       ];
-      if (!links.length) { setErr("nothing in that YAML — expected sources:, views:, triggers:, agents: or mcp_servers:"); }
+      if (!links.length) { setErr("nothing in that YAML; expected sources:, views:, triggers:, agents: or mcp_servers:"); }
       else { setDone(links); setText(""); }
     } catch (e) { setErr(String((e as Error).message ?? e)); }
     setBusy(false);
@@ -38,9 +38,7 @@ function YamlQuickAdd() {
     <div className="panel" style={{ marginBottom: 18 }}>
       <h2 style={{ marginTop: 0 }}>Paste a catalog snippet</h2>
       <p className="help" style={{ whiteSpace: "normal", marginTop: 0 }}>
-        the YAML from a docs page or tutorial, added as-is: validated first, then <strong>merged</strong>{" "}
-        into your catalog — nothing existing is removed. Works for sources, views, triggers, agents
-        and MCP servers.
+        validated first, then <strong>merged</strong> into your catalog; nothing existing is removed
       </p>
       {err && <div className="alert error">{err}</div>}
       {done && (
@@ -96,7 +94,7 @@ export default function SourceNew() {
       <div className="pagehead">
         <div>
           <h1>Add source</h1>
-          <p className="subtitle">pick a connector, configure it, save — <em>no restart needed</em></p>
+          <p className="subtitle">pick a connector, configure it, save; <em>no restart needed</em></p>
         </div>
         {!connector && !created && (
           <button className={showYaml ? "" : "dim"} onClick={() => setShowYaml((v) => !v)}>
@@ -113,7 +111,7 @@ export default function SourceNew() {
         <>
           <div className="connector-cards">
             {/* `internal` connectors are provisioned by Tares itself (the agent findings
-                source) — nothing to configure, so they're not offered here. */}
+                source); nothing to configure, so they're not offered here. */}
             {Object.entries(specs).filter(([, s]) => !s.internal).map(([key, s]) => (
               <button key={key} type="button"
                       className={"connector-card" + (unavailable(key) ? " unavailable" : "")}
@@ -127,7 +125,7 @@ export default function SourceNew() {
                 </div>
                 <div className="help desc">
                   {s.description}
-                  {unavailable(key) && <em> Needs Docker on the Tares host — not available on this deployment.</em>}
+                  {unavailable(key) && <em> Needs Docker on the Tares host; not available on this deployment.</em>}
                 </div>
               </button>
             ))}
@@ -146,7 +144,7 @@ export default function SourceNew() {
           {created.authKey ? (
             <div className="alert ok" style={{ marginTop: 14 }}>
               This instance requires auth, so <span className="mono">{created.name}</span> got its own
-              ingest key — send it as <code>Authorization: Bearer …</code>. <strong>Copy it now; it
+              ingest key; send it as <code>Authorization: Bearer …</code>. <strong>Copy it now; it
               is not shown again</strong> (it's listed under <Link to="/security">Security</Link> as{" "}
               <span className="mono">ingest: {created.name}</span>):
               <div className="ingest-url" style={{ marginTop: 8 }}>
@@ -161,7 +159,7 @@ export default function SourceNew() {
             </div>
           ) : authOn === false ? (
             <p className="help" style={{ marginTop: 14, whiteSpace: "normal" }}>
-              This instance is open, so no key is needed — the URL alone accepts events. Run{" "}
+              This instance is open, so no key is needed; the URL alone accepts events. Run{" "}
               <code>tares up --auth</code> to require an ingest key per producer.
             </p>
           ) : null}

--- a/ui/src/pages/Sources.tsx
+++ b/ui/src/pages/Sources.tsx
@@ -60,7 +60,7 @@ export default function Sources() {
       <div className="pagehead">
         <div>
           <h1>Sources</h1>
-          <p className="subtitle">everything Tares ingests — <em>lossless, normalized, one project</em></p>
+          <p className="subtitle">everything Tares ingests; <em>lossless, normalized, one project</em></p>
         </div>
         <span className="btnrow">
           {caps?.discover_docker !== false && (
@@ -75,7 +75,7 @@ export default function Sources() {
 
       {sources && sources.length === 0 && (
         <div className="empty">
-          No sources yet — <Link to="/sources/new">add one by hand</Link> or <Link to="/sources/import">import a catalog YAML</Link>
+          No sources yet; <Link to="/sources/new">add one by hand</Link> or <Link to="/sources/import">import a catalog YAML</Link>
           {caps?.discover_docker !== false && (
             <>, or <Link to="/sources/discover">auto-discover from Docker</Link></>
           )}.

--- a/ui/src/pages/TriggerDetail.tsx
+++ b/ui/src/pages/TriggerDetail.tsx
@@ -57,7 +57,7 @@ export default function TriggerDetail() {
   if (!trigger) {
     return (
       <div className="alert error">
-        no trigger named <span className="mono">{name}</span> — see <Link to="/triggers">Triggers</Link>
+        no trigger named <span className="mono">{name}</span> · see <Link to="/triggers">Triggers</Link>
       </div>
     );
   }
@@ -79,7 +79,7 @@ export default function TriggerDetail() {
           <h1><span className="mono">{trigger.name}</span></h1>
           <p className="subtitle">
             watches <Link to={`/views/${encodeURIComponent(trigger.view)}`} className="mono">{trigger.view}</Link>
-            {" "}— fires when the condition trips, delivering to every subscriber
+            {" "}· fires when the condition trips, delivering to every subscriber
           </p>
         </div>
         {!editing && (
@@ -109,10 +109,10 @@ export default function TriggerDetail() {
                   </td></tr>
               <tr><td className="help">context window</td>
                   <td className="mono">{String(trigger.emit?.context_window ?? "15m")}
-                      <span className="help"> — timeline the woken agent receives</span></td></tr>
+                      <span className="help"> · timeline the woken agent receives</span></td></tr>
               <tr><td className="help">cooldown</td>
                   <td className="mono">{trigger.cooldown}
-                      <span className="help"> — minimum gap between firings per entity</span></td></tr>
+                      <span className="help"> · minimum gap between firings per entity</span></td></tr>
             </tbody>
           </table>
         </div>
@@ -172,11 +172,11 @@ export default function TriggerDetail() {
         </table>
       ) : (
         <p className="help" style={{ whiteSpace: "normal" }}>
-          none yet — add a Tares agent above, or connect an external agent's webhook below
+          none yet; add a Tares agent above, or connect an external agent's webhook below
         </p>
       )}
       <p className="help" style={{ margin: "4px 0", whiteSpace: "normal" }}>
-        or connect an external agent — its webhook gets POSTed the timeline on every firing.
+        or connect an external agent; its webhook gets POSTed the timeline on every firing.
         What your endpoint receives and how to acknowledge:{" "}
         <Link to="/connect?tab=push">Connect → Webhook (push)</Link>.
       </p>
@@ -198,7 +198,7 @@ export default function TriggerDetail() {
       {/* A Slack channel is the same thing as the webhook above — one more subscription row —
           so it lives here rather than in a Slack-shaped corner of the app. */}
       <p className="help" style={{ margin: "10px 0 4px" }}>
-        or post every firing to a <strong>Slack channel</strong> — retried and logged like any
+        or post every firing to a <strong>Slack channel</strong> · retried and logged like any
         other delivery:
       </p>
       <div className="btnrow" style={{ alignItems: "center", maxWidth: 720 }}>
@@ -237,7 +237,7 @@ export default function TriggerDetail() {
         }}>Subscribe channel</button>
       </div>
       {/* The list only contains channels the bot has been invited to, so a missing one almost
-          always means exactly this — a 10-second fix in Slack, but only if we say so. */}
+          always means exactly this; a 10-second fix in Slack, but only if we say so. */}
       {channels.length > 0 && (
         <p className="help" style={{ margin: "4px 0", whiteSpace: "normal" }}>
           not seeing a channel? add the bot to it in Slack, then hit Refresh.
@@ -246,13 +246,13 @@ export default function TriggerDetail() {
       {slack?.reason === "missing_scope" && (
         <p className="help" style={{ margin: "4px 0", whiteSpace: "normal" }}>
           this Slack token predates the <span className="mono">channels:read</span> and{" "}
-          <span className="mono">groups:read</span> scopes — reinstall the Slack app to pick a
+          <span className="mono">groups:read</span> scopes; reinstall the Slack app to pick a
           channel from a list instead of typing one.
         </p>
       )}
       {caps && caps.slack_configured === false && (
         <p className="help" style={{ margin: "4px 0", whiteSpace: "normal" }}>
-          no Slack bot token is configured yet — add one under{" "}
+          no Slack bot token is configured yet; add one under{" "}
           <Link to="/security">Security</Link>, and invite the bot to the channel.
         </p>
       )}
@@ -310,7 +310,7 @@ export default function TriggerDetail() {
           message={agentsError
             // Never reassure from a failed load. "No agents use this" and "we couldn't find out"
             // are different facts, and only one of them is safe to delete on.
-            ? `Couldn’t check what this trigger delivers to (${agentsError}) — deleting may break more than is shown here. This can’t be undone.`
+            ? `Couldn’t check what this trigger delivers to (${agentsError}); deleting may break more than is shown here. This can’t be undone.`
             : wired.length
               ? `${wired.length} subscriber(s) receive this trigger and will stop. This can't be undone.`
               : "This stops the condition from being evaluated. This can't be undone."}

--- a/ui/src/pages/TriggerNew.tsx
+++ b/ui/src/pages/TriggerNew.tsx
@@ -10,7 +10,7 @@ export default function TriggerNew() {
     <>
       <h1>New trigger</h1>
       <p className="subtitle">
-        a condition Tares evaluates continuously over a view — when it trips, subscribed agents
+        a condition Tares evaluates continuously over a view; when it trips, subscribed agents
         are woken with the correlated timeline
       </p>
       <TriggerEditor presetView={params.get("view") ?? undefined}

--- a/ui/src/pages/ViewDetail.tsx
+++ b/ui/src/pages/ViewDetail.tsx
@@ -27,7 +27,7 @@ export default function ViewDetail() {
   if (!view) {
     return (
       <div className="alert error">
-        no view named <span className="mono">{name}</span> — see <Link to="/views">Views</Link>
+        no view named <span className="mono">{name}</span> · see <Link to="/views">Views</Link>
       </div>
     );
   }
@@ -71,7 +71,7 @@ export default function ViewDetail() {
                   {(view.filters ?? []).length
                     ? (view.filters ?? []).map((f, i) => (
                         <span className="chip" key={i}>{f.field} {f.op} {String(f.value)}</span>))
-                    : <span className="help">none — everything the sources carry</span>}
+                    : <span className="help">none; everything the sources carry</span>}
                 </td></tr>
             <tr><td className="help">author</td>
                 <td>{(view.created_by ?? "human").startsWith("agent")
@@ -91,7 +91,7 @@ export default function ViewDetail() {
       {triggersError && <ErrorState error={triggersError} what="the triggers watching this view" />}
       {!triggersError && watchers.length === 0 && (
         <p className="help" style={{ whiteSpace: "normal" }}>
-          none — <Link to={`/triggers/new?view=${encodeURIComponent(view.name)}`}>create one</Link> to
+          none; <Link to={`/triggers/new?view=${encodeURIComponent(view.name)}`}>create one</Link> to
           wake agents when a condition trips on this timeline
         </p>
       )}
@@ -117,7 +117,7 @@ export default function ViewDetail() {
           title={`Delete view ${view.name}?`}
           message={triggersError
             // A failed load must never produce the calmer of the two messages — see TriggerDetail.
-            ? `Couldn’t check which triggers watch this view (${triggersError}) — deleting may break more than is shown here. This can’t be undone.`
+            ? `Couldn’t check which triggers watch this view (${triggersError}); deleting may break more than is shown here. This can’t be undone.`
             : watchers.length
               ? `${watchers.length} trigger(s) watch this view and will stop working. Agents querying it will start failing.`
               : "Agents querying this view will start failing. This can't be undone."}

--- a/ui/src/pages/ViewsTriggers.tsx
+++ b/ui/src/pages/ViewsTriggers.tsx
@@ -16,7 +16,7 @@ export function ViewsPage() {
   return (
     <>
       <h1>Views</h1>
-      <p className="subtitle">saved reads — <em>the queries you hand agents</em></p>
+      <p className="subtitle">saved reads; <em>the queries you hand agents</em></p>
       <ViewsSection views={views ?? []} loadError={error} onChange={reload} />
     </>
   );
@@ -95,7 +95,7 @@ function ViewsSection({ views, loadError, onChange }:
       {loadError && <ErrorState error={loadError} what="views" onRetry={onChange} />}
 
       {!views.length && !loadError && (
-        <EmptyState>no views — agents have nothing to query yet</EmptyState>
+        <EmptyState>no views; agents have nothing to query yet</EmptyState>
       )}
       {!!views.length && (
         <>
@@ -183,7 +183,7 @@ function TriggersSection({ triggers, viewNames, loadError, onChange }:
         <span />
         <Link className="btn primary" to="/triggers/new"
               style={!viewNames.length ? { pointerEvents: "none", opacity: 0.5 } : undefined}
-              title={viewNames.length ? undefined : "a trigger watches a view — create a view first"}>
+              title={viewNames.length ? undefined : "a trigger watches a view; create a view first"}>
           Add trigger
         </Link>
       </div>
@@ -193,12 +193,12 @@ function TriggersSection({ triggers, viewNames, loadError, onChange }:
       {!viewNames.length && !loadError && (
         <div className="alert">
           A trigger is a condition evaluated over a <strong>view</strong>, and this instance has no
-          views yet — <Link to="/views/new">create a view</Link> first (pick the sources and the
+          views yet; <Link to="/views/new">create a view</Link> first (pick the sources and the
           entity key it correlates by), then come back and add a trigger on it.
         </div>
       )}
       {!triggers.length && !!viewNames.length && !loadError && (
-        <EmptyState>no triggers — nothing wakes agents yet</EmptyState>
+        <EmptyState>no triggers; nothing wakes agents yet</EmptyState>
       )}
       {!!triggers.length && (
         <>
@@ -210,7 +210,7 @@ function TriggersSection({ triggers, viewNames, loadError, onChange }:
                 <tr key={t.name} style={t.paused ? { opacity: 0.55 } : undefined}>
                   <td className="mono">
                     <Link to={`/triggers/${encodeURIComponent(t.name)}`}>{t.name}</Link>
-                    {t.paused && <span className="badge starting" style={{ marginLeft: 8 }} title="paused — not evaluated, never fires until resumed">paused</span>}
+                    {t.paused && <span className="badge starting" style={{ marginLeft: 8 }} title="paused; not evaluated, never fires until resumed">paused</span>}
                   </td>
                   <td className="mono"><Link to={`/views/${encodeURIComponent(t.view)}`}>{t.view}</Link></td>
                   <td className="mono">

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -1207,3 +1207,19 @@ pre.payload {
   color: var(--ink-faint); font-size: 13px; line-height: 1;
 }
 .chip .chip-x:hover { color: var(--err); }
+
+/* Add-source connector cards: a scannable grid instead of a table — the description reads as a
+   card, and click targets are the whole card. */
+.connector-cards { display: grid; grid-template-columns: repeat(auto-fill, minmax(290px, 1fr)); gap: 10px; }
+.connector-card {
+  text-align: left; font: inherit; cursor: pointer;
+  background: var(--bg); border: 1.5px solid var(--border-strong); border-radius: 8px;
+  padding: 12px 14px; display: flex; flex-direction: column; gap: 6px;
+  box-shadow: 0 1px 3px oklch(0.2 0.04 65 / 0.10);
+}
+.connector-card:hover { border-color: var(--accent); box-shadow: 0 2px 6px oklch(0.2 0.04 65 / 0.16); }
+.connector-card.unavailable { cursor: default; opacity: 0.6; box-shadow: none; }
+.connector-card.unavailable:hover { border-color: var(--border-strong); }
+.connector-card-head { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+.connector-card-head .name { font-weight: 600; }
+.connector-card .desc { white-space: normal; }

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -289,6 +289,7 @@ export interface DispatchLogEntry {
 // One delivery attempt to a specific subscriber, for the dispatch detail page.
 export interface DispatchDelivery {
   agent: string;
+  kind: "tares" | "slack" | "webhook";
   endpoint: string;   // masked
   ok: boolean;
   error?: string | null;


### PR DESCRIPTION
Two commits, reviewable separately:

**1. Add-source redesign + incremental catalog paste.** The Add source page is now a connector card grid (heavier borders, slight shadow) with an "Add via YAML" button top right that opens a paste panel. Pasting a catalog snippet merges it into the live catalog: validated as a whole first, upsert-only, nothing existing removed (the replace mode stays on the full Import page, unreachable from here). The import response now returns the names of what was written, so the success message links straight to each created object. Works for sources, views, triggers, agents and MCP servers in one paste, which makes every YAML block in the docs copy-paste-runnable.

**2. UI copy pass.** All em dashes stripped from rendered strings (143 lines): semicolons for clause joins, the existing "·" separator for value annotations, colons for scope labels; the standalone "—" empty-cell glyph is kept deliberately. Redundant help lines under form fields removed or tightened.