### PR TITLE
Slack: agent findings render as formatted messages (TR-141)

### DIFF
--- a/demo/catalog.demo.yaml
+++ b/demo/catalog.demo.yaml
@@ -93,8 +93,8 @@ agents:
     prompt: |
       You are an SRE taking the first look when Prometheus fires an alert on api-server. You are
       handed the correlated timeline: the firing alert (HighErrorRate / HighLatency / DependencyDown)
-      plus the signals behind it — 5xx request rate, p99 latency, active DB connections, dependency
-      health — and the service's request logs. That is your evidence.
+      plus the signals behind it (5xx request rate, p99 latency, active DB connections, dependency
+      health) and the service's request logs. That is your evidence.
 
       Produce a tight incident note: (1) what is failing and since when, (2) the most likely cause,
       tied to the specific evidence lines (which signal crossed, what the logs show), (3) a suggested

--- a/tares/agent.py
+++ b/tares/agent.py
@@ -48,7 +48,7 @@ TOOLS = [
      "input_schema": {"type": "object", "properties": {
          "label": {"type": "string", "description": "optional: one label axis"}}}},
     {"name": "recent_events",
-     "description": "Recent events for a source (key, type, text, time) — the actual data.",
+     "description": "Recent events for a source (key, type, text, time); the actual data.",
      "input_schema": {"type": "object", "properties": {
          "name": {"type": "string"}, "limit": {"type": "integer", "default": 20}},
          "required": ["name"]}},
@@ -70,7 +70,7 @@ PROPOSAL_TOOLS = [
     {"name": "propose_labels",
      "description": "Propose the labels (and primary key) for ONE source, as a card the user will "
                     "review. Propose only fields the source's field profile actually shows "
-                    "(source_fields) — anything else cannot be extracted. Give concrete evidence "
+                    "(source_fields); anything else cannot be extracted. Give concrete evidence "
                     "in `reasoning` (coverage, distinct counts, why the key is an entity). This "
                     "REPLACES the source's label set, so include every label it should end up with.",
      "input_schema": {"type": "object", "properties": {
@@ -123,7 +123,7 @@ PROPOSAL_TOOLS = [
          "reasoning": {"type": "string"}},
          "required": ["name", "key_field", "sources", "reasoning"]}},
     {"name": "propose_trigger",
-     "description": "Propose a trigger — a condition Tares evaluates continuously over a view; "
+     "description": "Propose a trigger; a condition Tares evaluates continuously over a view; "
                     "when it trips, subscribed agents are woken with the correlated timeline. Use "
                     "when the user's goal involves alerting or autonomous debugging. The view must "
                     "exist or be proposed in this conversation; `field` must be a numeric field "
@@ -212,16 +212,16 @@ connectors ingest events from sources (logs, metrics, deploys, Vercel/GitHub/Pos
 Every event has a key, named labels (correlation axes; one is the primary key), typed fields, and a \
 text line. Entities are label values. Views correlate sources for a key; triggers watch views.
 
-You help the user with their OWN ingested data — both to UNDERSTAND it (what's ingesting, the shape \
+You help the user with their OWN ingested data; both to UNDERSTAND it (what's ingesting, the shape \
 and entities of each source, coverage) and to DEBUG problems (a source not ingesting, an empty or \
 sparse entity, an unpopulated field, stale data). Adapt to whatever they ask.
 
-Always inspect with the read tools — never guess at what's there. For a problem, form a hypothesis \
+Always inspect with the read tools; never guess at what's there. For a problem, form a hypothesis \
 then verify it (health, field coverage, recent events, freshness). Be concrete: cite source names, \
 field coverage, entity values, counts. Prefer `describe` and `source_fields` to understand a source. \
 Keep answers tight and useful; use small tables or lists where they help. If a tool errors, say so.
 
-When the user wants the catalog changed — labels on a source, a view, a trigger — do not just \
+When the user wants the catalog changed; labels on a source, a view, a trigger; do not just \
 describe it: call propose_labels / propose_view / propose_trigger. Each proposal appears to the \
 user as a card they apply or skip; you never change the catalog directly. Ground every proposal \
 in evidence from the read tools.
@@ -230,39 +230,39 @@ HOW TO CHOOSE WHAT TO PROPOSE. These rules used to live in a separate "organize 
 user had to find; they apply to every proposal you make, so they are always in force:
 
 · A good KEY identifies a durable entity (a service, a session, a tenant): moderate distinct count, \
-high coverage, stable values. Check both before choosing one — a field with ONE distinct value \
+high coverage, stable values. Check both before choosing one; a field with ONE distinct value \
 cannot discriminate between entities and is never a key, however sensible its name. Dimensions \
 (http_method, level, status) make good secondary labels but bad keys. Sparse or constant fields \
 are weak.
-· Labels come from REAL fields — never invent one. A label's `field` MUST be a name source_fields \
+· Labels come from REAL fields; never invent one. A label's `field` MUST be a name source_fields \
 actually showed for that source; anything else extracts nothing. A label reads a `field`, a \
-`const`, or a regex over a field (`pattern`/`replace`, plus `map` for aliases) — reach for the \
+`const`, or a regex over a field (`pattern`/`replace`, plus `map` for aliases); reach for the \
 regex to clean messy values rather than guessing at a tidy field that isn't there.
 · FIRST check a source's existing labels (list_sources shows config.labels). If they already match \
 what you would propose, say so in text and do NOT call propose_labels. Otherwise call it ONCE with \
-the COMPLETE label set — the proposal replaces, it does not append. Same for views: don't propose \
+the COMPLETE label set; the proposal replaces, it does not append. Same for views: don't propose \
 a duplicate of one that already covers it.
 · Watch top values for VARIANTS of one entity (checkout / checkout-svc / checkout-service). \
 Correlation needs values to agree literally, so propose normalization on the label: \
 `pattern`/`replace` for whole families, `map` for irregular aliases (pattern runs first, map \
 applies to its result). This is often the highest-value fix available.
-· Views key and filter on LABELS only — never a raw field. A view's `key_field` and filters must be \
+· Views key and filter on LABELS only; never a raw field. A view's `key_field` and filters must be \
 a label the chosen sources EXPOSE. To correlate on something that isn't a label yet, promote it \
 first, then build the view. When sources share nothing but belong together, propose const labels \
 (same name and value) on each and key by that.
-· A view FILTER is always {"field": …, "op": …, "value": …} — three keys, never a flat \
-{"service": "checkout"} pair — and `op` is a NAME from eq / neq / contains / gt / gte / lt / lte. \
+· A view FILTER is always {"field": …, "op": …, "value": …}; three keys, never a flat \
+{"service": "checkout"} pair; and `op` is a NAME from eq / neq / contains / gt / gte / lt / lte. \
 Symbols are not operators here: write "eq", not "==". `field` may also be one of the built-in \
 columns event_type, source, text, key_value. Example: to keep only ingress-nginx events, \
 {"field": "service", "op": "eq", "value": "ingress-nginx"}. A view that needs no restriction takes \
-no filters at all — don't invent one.
-· To match a label across sources, ADD a new label — there is no rename, and a source's label set \
+no filters at all; don't invent one.
+· To match a label across sources, ADD a new label; there is no rename, and a source's label set \
 is declared whole. If source B should join A on `service`, propose a NEW label named `service` on \
 B reading B's matching field, keep B's other labels, and normalize B's values so they agree \
 literally with A's.
 · A trigger needs a numeric field the view's events actually carry, an aggregate and predicate, a \
 detection window, and a cooldown. Say what it would have fired on recently, in the data you just \
-read — a trigger that would fire constantly, or never, is not worth proposing.
+read; a trigger that would fire constantly, or never, is not worth proposing.
 
 Everything goes through proposals; the user applies or skips each card. Be decisive; don't ask \
 permission to inspect."""
@@ -329,7 +329,7 @@ async def run_agent(api_key: str, messages: list,
                         if cur is not None and _canon_labels(cur) == _canon_labels(tu.input.get("labels")):
                             results.append({"type": "tool_result", "tool_use_id": tu.id,
                                             "content": "this source ALREADY has exactly this label "
-                                                       "set — no card was shown. Tell the user its "
+                                                       "set; no card was shown. Tell the user its "
                                                        "labels already look right; propose only "
                                                        "changes."})
                             continue
@@ -337,7 +337,7 @@ async def run_agent(api_key: str, messages: list,
                     kind = {"propose_labels": "labels", "propose_view": "view", "propose_trigger": "trigger"}[tu.name]
                     yield _sse({"type": "proposal", "kind": kind, "id": tu.id, "payload": tu.input})
                     results.append({"type": "tool_result", "tool_use_id": tu.id,
-                                    "content": "proposal recorded — the user will review it as a "
+                                    "content": "proposal recorded; the user will review it as a "
                                                "card and apply or skip it"})
                     continue
                 # A start AND a finish. The console draws each call as a step that is visibly

--- a/tares/builtin_agents.py
+++ b/tares/builtin_agents.py
@@ -56,14 +56,14 @@ PRESETS = {
         "prompt": (
             "You are taking a first look at an entity in a system you monitor, because a condition "
             "you watch just tripped. You are handed the correlated timeline (logs, metrics, "
-            "deploys, commits, alerts) for that entity at the moment it tripped — that is your "
+            "deploys, commits, alerts) for that entity at the moment it tripped; that is your "
             "evidence.\n\n"
             "Establish what is happening and what CHANGED just before it started. Connect the "
             "change to the signature in the evidence. If the timeline is too narrow, read a wider "
             "window (1h) once before concluding.\n\n"
             "Write a short note: 1) what is happening and since when, 2) the most likely "
             "explanation with the specific evidence lines that support it, 3) what you would look "
-            "at next. Do not speculate beyond the evidence — if it is inconclusive, say so and say "
+            "at next. Do not speculate beyond the evidence; if it is inconclusive, say so and say "
             "what you would need. Your final message is recorded on this entity's timeline."
         ),
     },
@@ -72,7 +72,7 @@ PRESETS = {
         "prompt": (
             "You are an SRE taking the first look when an error condition trips on a running "
             "service. You are handed the correlated timeline (logs, metrics, deploys, commits) for "
-            "the affected entity — that is your primary evidence.\n\n"
+            "the affected entity; that is your primary evidence.\n\n"
             "Diagnose the most likely root cause: look for what changed (a deploy, a commit, a "
             "config value) just before the errors began, and connect it to the failure signature "
             "in the logs. If the timeline is insufficient, read a wider window (1h) once before "
@@ -261,7 +261,7 @@ class AgentRunner:
         servers = [m for m in self.store.list_mcp_servers() if m["name"] in selected]
         async with RemoteToolbox(servers) as toolbox:
             for failure in toolbox.failures:
-                print(f"[agent {agent['name']}] mcp connect failed — {failure}")
+                print(f"[agent {agent['name']}] mcp connect failed; {failure}")
             return await self._loop_with(agent, trigger_name, key, payload, api_key, toolbox)
 
     async def _loop_with(self, agent: dict, trigger_name: str, key: str, payload: str,
@@ -273,7 +273,7 @@ class AgentRunner:
             "content": (
                 f'The condition "{trigger_name}" tripped for "{key}".\n\n'
                 f"The correlated timeline at that moment:\n\n{payload}\n\n"
-                f"Take a first look, per your instructions. You already hold the evidence above — "
+                f"Take a first look, per your instructions. You already hold the evidence above; "
                 f"read again only if you need a wider window or a different entity."),
         }]
         rounds = tool_calls = 0

--- a/tares/builtin_agents.py
+++ b/tares/builtin_agents.py
@@ -427,12 +427,12 @@ class AgentRunner:
         if not token:
             print(f"[agent {agent_name}] slack: no bot token configured, channel post skipped")
             return
-        link = _slack_deep_link(key)
-        text = f"*{agent_name}* · `{trigger_name}` fired for *{key}*\n\n{finding}{link}"
+        msg = _slack_mod.build_finding_message(agent_name, trigger_name, key, finding,
+                                               _slack_deep_link(key))
         try:
             async with httpx.AsyncClient(timeout=15) as cx:
                 r = await cx.post(f"{_slack_mod.API_BASE}/chat.postMessage",
-                                  json={"channel": channel, "text": text},
+                                  json={"channel": channel, **msg},
                                   headers={"authorization": f"Bearer {token}"})
                 try:
                     data = r.json()
@@ -457,11 +457,13 @@ class AgentRunner:
         a `slack://channel/<id>` subscription (`tares/slack.py`), which is per-trigger, retried
         and logged in the delivery ledger; existing agents are not migrated.
         """
-        link = _slack_deep_link(key)
-        text = f"*{agent_name}* · `{trigger_name}` fired for *{key}*\n\n{finding}{link}"
+        # Incoming webhooks accept blocks too, so the finding renders the same way as on the
+        # channel path instead of as raw markdown.
+        from .slack import build_finding_message
+        msg = build_finding_message(agent_name, trigger_name, key, finding, _slack_deep_link(key))
         try:
             async with httpx.AsyncClient(timeout=15) as cx:
-                r = await cx.post(hook, json={"text": text})
+                r = await cx.post(hook, json=msg)
                 if r.status_code >= 300:
                     print(f"[agent {agent_name}] slack: HTTP {r.status_code} {r.text[:120]}")
         except Exception as e:   # notification failing must never lose the finding

--- a/tares/cli.py
+++ b/tares/cli.py
@@ -28,7 +28,7 @@ def _warn_if_exposed(host: str) -> None:
         print(
             f"\n  ⚠  Tares is binding {host} (reachable off this machine) with NO auth token.\n"
             "     Anyone who can reach this port can read your data. Set TARES_AUTH_TOKEN and put\n"
-            "     it behind TLS before exposing it — see https://docs.glassflow.ai/tares (Deployment).\n",
+            "     it behind TLS before exposing it; see https://docs.glassflow.ai/tares (Deployment).\n",
             flush=True,
         )
 
@@ -109,7 +109,7 @@ def _up(args: argparse.Namespace):
     if root_token:
         # print the login the operator uses — a click-through URL, since they're at the terminal.
         print(f"tares: console at {url}  ·  data in {home}", flush=True)
-        print(f"tares: auth ON — log in at {url}/?token={root_token}", flush=True)
+        print(f"tares: auth ON; log in at {url}/?token={root_token}", flush=True)
     else:
         print(f"tares: console at {url}  ·  data in {home}  ·  auth OFF (open; "
               f"run with --auth to require a login)", flush=True)
@@ -139,7 +139,7 @@ def _mcp(args: argparse.Namespace):
 def main():
     from .config import reject_legacy_env
     reject_legacy_env()
-    p = argparse.ArgumentParser(prog="tares", description="Tares — a data plane for AI agents.")
+    p = argparse.ArgumentParser(prog="tares", description="Tares; a data plane for AI agents.")
     p.add_argument("--version", action="version", version=f"tares {_pkg_version()}")
     sub = p.add_subparsers(dest="cmd")
 

--- a/tares/config.py
+++ b/tares/config.py
@@ -50,7 +50,7 @@ def reject_legacy_env(environ=None) -> None:
         "tares 1.0 renamed every NAVFLOW_* environment variable to TARES_*, and does NOT read the "
         "old names.\n\nStill set in this environment:\n"
         f"{mapping}\n\n"
-        "Rename them and start again. (The DuckDB file itself is unchanged — your data is where you "
+        "Rename them and start again. (The DuckDB file itself is unchanged; your data is where you "
         "left it.)"
     )
 
@@ -180,7 +180,7 @@ def validate_slack_channel(channel: str) -> str:
     if _SLACK_ID.match(chan) or _SLACK_NAME.match(chan):
         return chan
     raise ValueError(
-        f"{channel!r} is not a Slack channel — use the channel ID (C0123456789, from the channel's "
+        f"{channel!r} is not a Slack channel; use the channel ID (C0123456789, from the channel's "
         "'Copy link') or its lowercase name")
 
 
@@ -711,5 +711,5 @@ def validate_agent_dict(a: dict, trigger_names: set, triggers: dict | None = Non
         if view and FINDINGS_SOURCE in (view.get("sources") or []):
             raise CatalogError(
                 f"agent {a['name']!r}: trigger {a['trigger']!r} watches view "
-                f"{trig['view']!r}, which includes the {FINDINGS_SOURCE!r} source — an agent "
+                f"{trig['view']!r}, which includes the {FINDINGS_SOURCE!r} source; an agent "
                 f"cannot be woken by findings (it would fire itself forever)")

--- a/tares/connectors/__init__.py
+++ b/tares/connectors/__init__.py
@@ -46,20 +46,20 @@ SPECS = {
     "prometheus": {"label": "Prometheus", "mode": "poll", "discover": True,
                    "description": "Instant-query snapshots of PromQL expressions on every poll tick."},
     "docker_logs": {"label": "Docker logs", "mode": "poll", "discover": True,
-                    "description": "Tails a running container's logs — all lines by default; "
+                    "description": "Tails a running container's logs; all lines by default; "
                                    "optional match/drop regex filters."},
     "prometheus_alerts": {"label": "Prometheus alerts", "mode": "poll", "discover": True, "poll": "30s",
-                          "description": "Polls Prometheus's own /api/v1/alerts — the alerts its rules "
-                                         "have fired — and emits one event per active alert (keyed by a "
+                          "description": "Polls Prometheus's own /api/v1/alerts, the alerts its rules "
+                                         "have fired, and emits one event per active alert (keyed by a "
                                          "label), plus a resolved event when it clears. No Alertmanager, "
                                          "no PromQL."},
     "alertmanager": {"label": "Alertmanager alerts", "mode": "push",
-                     "description": "Push receiver for Alertmanager — point a webhook_configs.url at this "
+                     "description": "Push receiver for Alertmanager; point a webhook_configs.url at this "
                                     "source's ingest endpoint. Each alert Alertmanager routes (with its "
                                     "grouping, silencing and firing/resolved status) becomes one event, "
                                     "keyed by a label. No PromQL."},
     "reference": {"label": "Reference documents", "mode": "reference",
-                  "description": "Documents (json/csv/md/txt) attached to an entity by its labels — "
+                  "description": "Documents (json/csv/md/txt) attached to an entity by its labels; "
                                  "project notes, schemas, runbooks. Always surfaced when correlating "
                                  "on that entity, regardless of time window. Edit to add or remove."},
     "webhook": {"label": "Inbound webhook", "mode": "push",
@@ -77,7 +77,7 @@ SPECS = {
                "description": "Polls a repo's commits (cursor by SHA); one event per commit, "
                               "keyed by repo, with author as a label."},
     "vercel": {"label": "Vercel logs", "mode": "push",
-               "description": "Push source for Vercel logs — point a Vercel log drain (JSON) at this "
+               "description": "Push source for Vercel logs; point a Vercel log drain (JSON) at this "
                               "source's ingest endpoint; one event per log entry, keyed by project, "
                               "with environment + source labels."},
     "postgres": {"label": "Postgres table", "mode": "poll", "discover": True, "poll": "30s",
@@ -86,7 +86,7 @@ SPECS = {
                                 "Your application's source-of-truth data in the timeline."},
     "claude_code": {"label": "Claude Code sessions", "mode": "poll",
                     "description": "Tails local Claude Code session transcripts "
-                                   "(~/.claude/projects/*.jsonl) into the data plane — one event per "
+                                   "(~/.claude/projects/*.jsonl) into the data plane; one event per "
                                    "message, keyed by session, with project/branch/model labels and "
                                    "token-usage fields. Sub-agents roll up into the same source. "
                                    "Secrets are redacted before storage."},
@@ -94,7 +94,7 @@ SPECS = {
     # "Add source". Still a first-class source everywhere else — it appears on timelines, in the
     # catalog and in exports like any other.
     "finding": {"label": "Agent findings", "mode": "push", "internal": True,
-                "description": "What Tares agents conclude when a trigger fires — one finding per "
+                "description": "What Tares agents conclude when a trigger fires; one finding per "
                                "run, keyed to the entity, on that entity's timeline."},
 }
 

--- a/tares/connectors/alertmanager.py
+++ b/tares/connectors/alertmanager.py
@@ -70,7 +70,7 @@ class AlertmanagerConnector(Connector):
         key = primary_key or self._pick_key(labels)
         return Envelope(
             source=self.cfg.name, source_type=self.cfg.type, key_value=key,
-            event_type=alertname, text=f"{status.upper()}: {alertname} — {summary}",
+            event_type=alertname, text=f"{status.upper()}: {alertname} · {summary}",
             event_time=_parse_time(ts), payload=payload, labels=labels,
         )
 

--- a/tares/connectors/docker_logs.py
+++ b/tares/connectors/docker_logs.py
@@ -62,7 +62,7 @@ class DockerLogsConnector(Connector):
         "drop": {"type": "string",
                  "help": "skip lines matching this regex, e.g. 'HTTP/1.1\"' to drop access logs"},
         "key": {"type": "string", "advanced": True,
-                "help": "legacy fixed key — prefer a primary label"},
+                "help": "legacy fixed key; prefer a primary label"},
         "label_pattern": {"type": "string", "advanced": True,
                           "help": "regex with named groups → per-line label context"},
     }

--- a/tares/connectors/github.py
+++ b/tares/connectors/github.py
@@ -54,10 +54,10 @@ class GithubConnector(Connector):
                  "help": "owner/name, e.g. glassflow/tares (a pasted GitHub URL works too)"},
         "branch": {"type": "string",
                    "help": "branch to follow (empty = the repo's default branch, labeled by its "
-                           "real name). One source follows one branch — add a source per branch "
+                           "real name). One source follows one branch; add a source per branch "
                            "to watch several"},
         "token": {"type": "string", "secret": True, "discover_input": True,
-                  "help": "GitHub token — required for private repos, recommended otherwise: "
+                  "help": "GitHub token; required for private repos, recommended otherwise: "
                           "without one GitHub allows 60 API requests/hour per IP"},
         "limit": {"type": "number", "default": 20,
                   "help": "newest commits fetched per poll (the first poll imports this many)"},
@@ -89,11 +89,11 @@ class GithubConnector(Connector):
             return None
         if r.status_code in (403, 429) and r.headers.get("x-ratelimit-remaining") == "0":
             raise ValueError("GitHub rate limit exhausted (unauthenticated: 60 requests/hour per IP)"
-                             " — set a token or raise the poll interval")
+                             "; set a token or raise the poll interval")
         if r.status_code == 404:
             raise ValueError(f"repo {repo!r} not found"
-                             + (" — check owner/name (the token may also lack access)" if token
-                                else " — private repos need a token"))
+                             + ("; check owner/name (the token may also lack access)" if token
+                                else "; private repos need a token"))
         if r.status_code == 401:
             raise ValueError("GitHub rejected the token (401 unauthorized)")
         if r.status_code != 200:
@@ -178,7 +178,7 @@ class GithubConnector(Connector):
                 raise ValueError(f"could not reach GitHub: {e}")
             if meta.status_code == 404:
                 raise ValueError(f"repo {repo!r} not found"
-                                 + (" — check owner/name (the token may also lack access)" if token
+                                 + ("; check owner/name (the token may also lack access)" if token
                                     else " (private repos need a token)"))
             if meta.status_code != 200:
                 raise ValueError(f"GitHub returned {meta.status_code} for {repo!r}")

--- a/tares/connectors/postgres.py
+++ b/tares/connectors/postgres.py
@@ -37,7 +37,7 @@ def _dsn(config: dict) -> str:
     # comes only from the source's config — there is no daemon-level env fallback.
     dsn = config.get("dsn")
     if not dsn:
-        raise CatalogError("no Postgres DSN — set the source's `dsn` connection URL")
+        raise CatalogError("no Postgres DSN; set the source's `dsn` connection URL")
     return dsn
 
 
@@ -68,7 +68,7 @@ def _connect(dsn: str):
     try:
         import asyncpg
     except ImportError:
-        raise CatalogError("the postgres connector needs asyncpg (it ships with navflow — reinstall if missing)")
+        raise CatalogError("the postgres connector needs asyncpg (it ships with navflow; reinstall if missing)")
     # bounded connect: an unreachable host (firewalled DB, wrong IP) should fail in seconds with a
     # clear error, not sit on asyncpg's 60s default while the console appears hung
     return asyncpg.connect(dsn, timeout=10)
@@ -116,7 +116,7 @@ def _select_clause(config: dict, cursor_column: str) -> str:
 class PostgresConnector(Connector):
     CONFIG_SCHEMA = {
         "dsn": {"type": "string", "secret": True, "required": True, "discover_input": True,
-                "help": "postgresql://user:pass@host:port/dbname — this source's connection URL (the "
+                "help": "postgresql://user:pass@host:port/dbname; this source's connection URL (the "
                         "path after the slash picks the database; omitted, Postgres defaults to a db "
                         "named after the user). Must be reachable from the Tares host. Stored as a "
                         "secret: redacted in the API and omitted from catalog exports."},
@@ -124,18 +124,18 @@ class PostgresConnector(Connector):
         # needs the DSN) lists the tables and you pick one. So the form shows Discover right after
         # the DSN, and the table field below it.
         "table": {"type": "string", "required": True,
-                  "help": "table to poll, e.g. orders or public.orders — leave empty and Discover "
+                  "help": "table to poll, e.g. orders or public.orders; leave empty and Discover "
                           "lists the tables it can see"},
         "cursor_column": {"type": "string", "required": True,
                           "help": "column that only ever grows, used to fetch just the new rows on "
                                   "each poll: an autoincrement id (captures inserts only) or "
-                                  "updated_at (also captures row updates) — Discover picks this "
+                                  "updated_at (also captures row updates); Discover picks this "
                                   "for you"},
         "time_column": {"type": "string",
                         "help": "timestamp column for event_time (default: the cursor column if it "
                                 "is a timestamp, else ingest time)"},
         "columns": {"type": "string",
-                    "help": "comma-separated columns to pull, e.g. id,status,amount — empty pulls "
+                    "help": "comma-separated columns to pull, e.g. id,status,amount; empty pulls "
                             "every column (SELECT *). The cursor/key/time columns are always "
                             "included so the source still works. `database` and `table` are also "
                             "available as fields (from config) regardless of what you select."},
@@ -238,13 +238,13 @@ class PostgresConnector(Connector):
             finally:
                 await conn.close()
             if not rows:
-                raise ValueError(f"connected to database {db!r}, but no tables are visible — "
+                raise ValueError(f"connected to database {db!r}, but no tables are visible; "
                                  "wrong database in the DSN (the path after the slash), or the "
                                  "user lacks privileges")
             tables = [r["table_name"] if r["table_schema"] == "public"
                       else f"{r['table_schema']}.{r['table_name']}" for r in rows]
             return {"connector": "postgres", "tables": tables,
-                    "summary": f"connected to database {db!r} — {len(tables)} tables; "
+                    "summary": f"connected to database {db!r}: {len(tables)} tables; "
                                "pick one to introspect (another database needs its own "
                                "source with its DSN)"}
         table = _ident(config["table"], "table", _TABLE)

--- a/tares/connectors/prometheus.py
+++ b/tares/connectors/prometheus.py
@@ -56,7 +56,7 @@ class PrometheusConnector(Connector):
         "url": {"type": "string", "required": True, "discover_input": True,
                 "help": "Prometheus base URL, e.g. http://localhost:9090"},
         "bearer_token": {"type": "string", "secret": True, "discover_input": True,
-                         "help": "optional Authorization: Bearer token — for managed Prometheus "
+                         "help": "optional Authorization: Bearer token; for managed Prometheus "
                                  "(Thanos/Cortex/Mimir) or one behind an auth proxy"},
         "username": {"type": "string", "discover_input": True,
                      "help": "optional HTTP basic-auth username (e.g. a Grafana Cloud instance id)"},
@@ -66,7 +66,7 @@ class PrometheusConnector(Connector):
                         "help": "entity key for series that carry no key label"},
         "queries": {
             "type": "list", "required": True,
-            "help": "metrics to ingest — each a PromQL query mapped into the envelope",
+            "help": "metrics to ingest; each a PromQL query mapped into the envelope",
             "item": {
                 "promql": {"type": "string", "required": True,
                            "help": "PromQL (a bare metric name = raw, lossless ingest)"},

--- a/tares/connectors/prometheus_alerts.py
+++ b/tares/connectors/prometheus_alerts.py
@@ -40,7 +40,7 @@ class PrometheusAlertsConnector(Connector):
         "url": {"type": "string", "required": True, "discover_input": True,
                 "help": "Prometheus base URL, e.g. http://localhost:9090"},
         "bearer_token": {"type": "string", "secret": True, "discover_input": True,
-                         "help": "optional Authorization: Bearer token — for managed Prometheus or "
+                         "help": "optional Authorization: Bearer token; for managed Prometheus or "
                                  "one behind an auth proxy"},
         "username": {"type": "string", "discover_input": True,
                      "help": "optional HTTP basic-auth username"},
@@ -114,7 +114,7 @@ class PrometheusAlertsConnector(Connector):
                                  fallback=self.cfg.config.get("default_key", "unknown"))
         return Envelope(
             source=self.cfg.name, source_type=self.cfg.type, key_value=key,
-            event_type=alertname, text=f"{state.upper()}: {alertname} — {summary}",
+            event_type=alertname, text=f"{state.upper()}: {alertname} · {summary}",
             event_time=event_time, payload=payload, labels=labels,
         )
 

--- a/tares/connectors/vercel.py
+++ b/tares/connectors/vercel.py
@@ -39,10 +39,10 @@ class VercelConnector(Connector):
         # which is why a status label could not be built without a regex over the wrong field.
         {"name": "status_code", "help": "HTTP status code (proxy.statusCode). Label it as "
                                         "type=number to filter >= 400 and aggregate in triggers"},
-        {"name": "url", "help": "the request URL as asked for, with query string — unlike `path`, "
+        {"name": "url", "help": "the request URL as asked for, with query string; unlike `path`, "
                                 "which is rewritten (/tares?_rsc=… vs tares.segments/_head.segment)"},
         {"name": "method", "help": "GET | POST | HEAD | …"},
-        {"name": "referer", "help": "what linked here — the axis that finds the source of a 404"},
+        {"name": "referer", "help": "what linked here; the axis that finds the source of a 404"},
         {"name": "path_type", "help": "PRERENDER | STATIC | FUNCTION | …"},
         {"name": "region", "help": "edge region that served it, e.g. hnd1"},
         {"name": "cache", "help": "Vercel cache result: HIT | MISS | STALE | BYPASS (lambda only)"},

--- a/tares/connectors/webhook.py
+++ b/tares/connectors/webhook.py
@@ -26,9 +26,9 @@ class WebhookConnector(Connector):
         # key/key_field are the legacy way to set the entity key; the key is now just the label
         # marked primary. Kept (advanced) so existing configs round-trip and still work.
         "key": {"type": "string", "advanced": True,
-                "help": "legacy fixed entity key — prefer a primary label"},
+                "help": "legacy fixed entity key; prefer a primary label"},
         "key_field": {"type": "string", "advanced": True,
-                      "help": "legacy: payload field for the key — prefer a primary field-label"},
+                      "help": "legacy: payload field for the key; prefer a primary field-label"},
         "event_type": {"type": "string", "default": "webhook_event",
                        "help": "fixed event type"},
         "event_type_field": {"type": "string",

--- a/tares/daemon.py
+++ b/tares/daemon.py
@@ -149,7 +149,7 @@ def _serve_ui(path: str):
     """The built console SPA: a real file if it exists, else index.html (client-side routing)."""
     if not UI_DIST.exists():
         return JSONResponse(
-            {"detail": "console not built — run `npm install && npm run build` in ui/"},
+            {"detail": "console not built; run `npm install && npm run build` in ui/"},
             status_code=404)
     f = (UI_DIST / path).resolve()
     if path and f.is_file() and f.is_relative_to(UI_DIST.resolve()):
@@ -177,7 +177,7 @@ def _degraded_app(reason: str) -> FastAPI:
         return body
 
     async def unavailable():
-        return JSONResponse({"detail": f"database unavailable — {reason}", "status": "down"},
+        return JSONResponse({"detail": f"database unavailable; {reason}", "status": "down"},
                             status_code=503)
 
     # Everything that needs the store answers 503 (not a bare 500, and not the SPA's index.html).
@@ -307,7 +307,7 @@ def make_app() -> FastAPI:
         # traceback (degraded mode explains the failure to the user, it does not hide it from the
         # operator) and serve the console + 503s instead of exiting before uvicorn ever binds.
         traceback.print_exc()
-        print(f"taresd: DEGRADED — {e.reason}. Serving the console and 503s; fix the database "
+        print(f"taresd: DEGRADED; {e.reason}. Serving the console and 503s; fix the database "
               f"and restart.", flush=True)
         return _degraded_app(e.reason)
 
@@ -344,7 +344,7 @@ def make_app() -> FastAPI:
             runtime.reload_catalog()
             print("taresd: auto-provisioned OTLP source 'otlp'")
             return "otlp"
-        raise ValueError("multiple OTLP sources — set the X-Tares-Source header")
+        raise ValueError("multiple OTLP sources; set the X-Tares-Source header")
 
     @asynccontextmanager
     async def lifespan(_app):
@@ -509,7 +509,7 @@ def make_app() -> FastAPI:
             except ValueError as e:
                 _err(e)
             if not resolve_slack_token(store)[0]:
-                _err(ValueError("no Slack bot token configured — set TARES_SLACK_BOT_TOKEN or "
+                _err(ValueError("no Slack bot token configured; set TARES_SLACK_BOT_TOKEN or "
                                 "add one under Security before subscribing a channel"))
         sid = "sub_" + uuid.uuid4().hex[:8]
         # record the creating credential: revoking a key removes its subscriptions (a revoked
@@ -672,7 +672,7 @@ def make_app() -> FastAPI:
     async def derive(req: DeriveReq):
         name = req.name or "agent_view_" + uuid.uuid4().hex[:6]
         if name in runtime.catalog.views:
-            _err(ValueError(f"view {name!r} already exists — derived views must not "
+            _err(ValueError(f"view {name!r} already exists; derived views must not "
                             f"collide with existing entries"), 409)
         try:
             validate_view_dict({"name": name, "key_field": req.key_field,
@@ -684,7 +684,7 @@ def make_app() -> FastAPI:
                                   created_by=f"agent:{req.client}")
         runtime.reload_catalog()
         return {"handle": f"view:{name}", "name": name, "status": "active",
-                "note": "virtual view — query it by name like any other view"}
+                "note": "virtual view; query it by name like any other view"}
 
     # ── remember — the agent writes its own memory back (closes the loop) ─────
     @app.post("/remember", status_code=202)
@@ -902,7 +902,7 @@ def make_app() -> FastAPI:
             proposal = await asyncio.wait_for(
                 REGISTRY[connector].discover(body.get("config", {}) or {}), timeout=30)
         except (TimeoutError, asyncio.TimeoutError):
-            _err(ValueError("discover timed out — is the target reachable from the Tares "
+            _err(ValueError("discover timed out; is the target reachable from the Tares "
                             "server? (a hosted Tares can only reach public endpoints)"))
         except HTTPException:
             raise
@@ -1373,7 +1373,7 @@ def make_app() -> FastAPI:
                                    body.webhook_url, body.webhook_token, body.mcp_servers)
         runtime.reload_catalog()
         return {"ok": True, "enabled": False,
-                "note": "agents start disabled — enable it to run on the next firing"}
+                "note": "agents start disabled; enable it to run on the next firing"}
 
     @app.put("/api/agents/builtin/{name}")
     async def update_builtin_agent(name: str, body: AgentIn):
@@ -1419,7 +1419,7 @@ def make_app() -> FastAPI:
             _err(KeyError(f"unknown agent {name!r}"), 404)
         key, _ = resolve_anthropic_key(store)
         if not key:
-            _err(ValueError("no Anthropic key configured — set ANTHROPIC_API_KEY or add one "
+            _err(ValueError("no Anthropic key configured; set ANTHROPIC_API_KEY or add one "
                             "under Security before enabling an agent"))
         # enable = subscribe to the trigger (the same wiring an external agent has). Idempotent.
         if not _agent_enabled(name):
@@ -1488,7 +1488,7 @@ def make_app() -> FastAPI:
         if not token.startswith("xox"):
             # Caught here rather than on the first failed delivery: a pasted webhook URL or signing
             # secret would otherwise sit in the settings table looking configured.
-            _err(ValueError("that does not look like a Slack bot token — it should start with "
+            _err(ValueError("that does not look like a Slack bot token; it should start with "
                             "'xoxb-' (OAuth & Permissions → Bot User OAuth Token)"))
         store.set_setting(SLACK_TOKEN_SETTING, token)
         _, origin = resolve_slack_token(store)
@@ -1539,7 +1539,7 @@ def make_app() -> FastAPI:
             _err(ValueError("secret is required (use DELETE to remove the stored secret)"))
         if secret.startswith("xox"):
             # A bot token pasted into the wrong box would look configured and fail every signature.
-            _err(ValueError("that is a bot token, not the signing secret — take the Signing Secret "
+            _err(ValueError("that is a bot token, not the signing secret; take the Signing Secret "
                             "from the Slack app's Basic Information page"))
         store.set_setting(slack_verify.SETTING_KEY, secret)
         _, origin = slack_verify.resolve_secret(store)
@@ -1599,7 +1599,7 @@ def make_app() -> FastAPI:
                             error = ev.get("detail") or "the assistant failed"
             await asyncio.wait_for(_run(), timeout=SLACK_ASK_TIMEOUT)
         except asyncio.TimeoutError:
-            error = f"that took longer than {SLACK_ASK_TIMEOUT}s — try a narrower question"
+            error = f"that took longer than {SLACK_ASK_TIMEOUT}s; try a narrower question"
         except Exception as e:   # noqa: BLE001 — every failure has to reach the user as words
             error = f"{type(e).__name__}: {e}"
         if text.strip():
@@ -1657,11 +1657,11 @@ def make_app() -> FastAPI:
             return slack_mod.build_error(problem, thread_ts)
         if not response_url:
             return slack_mod.build_error(
-                ":warning: that request carried no response_url — Tares has nowhere to reply",
+                ":warning: that request carried no response_url; Tares has nowhere to reply",
                 thread_ts)
         if not resolve_anthropic_key(store)[0]:
             return slack_mod.build_error(
-                ":warning: no Anthropic API key is configured on this Tares instance — set "
+                ":warning: no Anthropic API key is configured on this Tares instance; set "
                 "`ANTHROPIC_API_KEY` or add one under Security in the console", thread_ts)
         if not runtime.catalog.sources:
             return slack_mod.build_error(

--- a/tares/discovery.py
+++ b/tares/discovery.py
@@ -38,7 +38,7 @@ async def _docker_ps() -> list[dict]:
     except Exception as e:
         raise ValueError(f"could not run `docker ps`: {e}")
     if proc.returncode != 0:
-        raise ValueError(f"`docker ps` failed — is the Docker daemon running? "
+        raise ValueError(f"`docker ps` failed; is the Docker daemon running? "
                          f"({err.decode(errors='replace').strip()})")
     containers = []
     for line in out.decode(errors="replace").strip().splitlines():
@@ -87,7 +87,7 @@ async def scan_docker() -> dict:
         except ValueError:
             cfg = normalize_config("prometheus", {"url": url, "default_key": "api-server",
                                                   "queries": [{"promql": "up"}]})
-            summary = f"detected at {url} but couldn't introspect — confirm it's reachable"
+            summary = f"detected at {url} but couldn't introspect; confirm it's reachable"
         proposed.append({
             "connector": "prometheus", "name": "metrics", "config": cfg,
             "summary": summary, "preselect": True, "from": f"container {prom['name']}"})
@@ -98,7 +98,7 @@ async def scan_docker() -> dict:
                             "reason": "a Postgres CDC connector would go here (not built yet)"})
         elif "grafana" in c["image"].lower():
             skipped.append({"service": c["service"], "image": c["image"],
-                            "reason": "a dashboard — nothing to ingest"})
+                            "reason": "a dashboard; nothing to ingest"})
 
     return {"provider": "docker",
             "summary": {"containers": len(containers), "proposed": len(proposed)},

--- a/tares/slack.py
+++ b/tares/slack.py
@@ -415,6 +415,23 @@ def to_mrkdwn(text: str) -> str:
     return text
 
 
+def build_finding_message(agent_name: str, trigger: str, key: str, finding: str,
+                          link: str = "") -> dict:
+    """Block Kit body for a Tares agent's finding: a headline, the finding rendered as mrkdwn
+    (headers, emphasis, tables converted; split across sections so a long incident note never
+    trips Slack's 3000-char block cap), and a context line. `text` is the notification fallback.
+
+    The finding is the model's markdown; sending it raw is why findings showed up as literal
+    `**` and `##` and pipe tables in Slack (TR-141). Same converter `/tares ask` answers use."""
+    headline = f"*{agent_name}* · `{trigger}` fired for *{key}*"
+    blocks: list[dict] = [{"type": "section", "text": {"type": "mrkdwn", "text": headline}}]
+    blocks += _sections(finding)
+    context = "Tares agent finding" + (f" · {link.strip()}" if link.strip() else "")
+    blocks.append({"type": "context", "elements": [{"type": "mrkdwn", "text": context}]})
+    return {"text": f"{agent_name}: {trigger} fired for {key}", "blocks": blocks,
+            "unfurl_links": False, "unfurl_media": False}
+
+
 def _sections(text: str) -> list[dict]:
     """Split a long answer across section blocks — one section caps at 3000 characters, and an
     over-long block makes Slack reject the whole message (`invalid_blocks`) rather than truncate."""

--- a/tares/slack.py
+++ b/tares/slack.py
@@ -250,7 +250,7 @@ async def list_channels(token: str, timeout: float = 10.0
                         # only name both when it doesn't.
                         needed = str(data.get("needed") or "").strip() or "channels:read and groups:read"
                         return [], "missing_scope", (
-                            f"slack: missing_scope (the bot token is missing {needed} — "
+                            f"slack: missing_scope (the bot token is missing {needed}; "
                             "reconnect Slack to grant it)")
                     return [], "error", f"slack: {err}{_error_detail(err, data)}"
                 for c in data.get("channels") or []:
@@ -277,7 +277,7 @@ async def list_channels(token: str, timeout: float = 10.0
 # Everything below serves `POST /api/slack/events`. It is deliberately pure — parsing, cost
 # bounding and message shaping — so the endpoint itself is only plumbing: verify, ACK, answer.
 
-USAGE = ("usage: `/tares ask <question>` — e.g. "
+USAGE = ("usage: `/tares ask <question>`; e.g. "
          "`/tares ask what happened to checkout-svc in the last hour?`")
 
 # Cost ceiling, the same shape as `builtin_agents.DAILY_RUN_CAP`: a per-day count with an env


### PR DESCRIPTION
Fixes TR-141. Stacked on #72; merge that first.

A finding is the model's markdown (headers, `**bold**`, pipe tables, links, rules) and both agent posting paths sent it raw as a plain-text message, so Slack showed the literal `##`, `**` and pipes in the screenshots on the ticket.

The converter already existed: `to_mrkdwn` (Markdown → Slack mrkdwn, pipe tables rendered as aligned monospace blocks) and `_sections` (splits long text under Slack's 3000-char block cap) power `/tares ask` answers. This adds `build_finding_message` on top of them and routes both paths through it, the workspace-bot channel post and the legacy incoming webhook, as Block Kit: headline, the converted finding across as many sections as it needs, a context line with the deep link when the instance is reachable, and a plain-text notification fallback. Verified against the shape of a real finding (headers → bold, bold → single-star, link → `<url|text>`, table → aligned code with no pipes, rule dropped) and a 600-line finding splitting cleanly; slack and agents suites pass.