### PR TITLE
Console: GlassFlow theme, sidebar rework, Slack finding formatting, em dash sweep (TR-140, TR-137, TR-141, TR-143)

### DIFF
--- a/demo/catalog.demo.yaml
+++ b/demo/catalog.demo.yaml
@@ -85,7 +85,7 @@ agents:
   # `incident` trigger fires it reads the correlated timeline (the fired alert plus the signals
   # behind it and the request logs) and writes a finding onto api-server's timeline. It's a real
   # agent, so it needs an Anthropic key: export ANTHROPIC_API_KEY before `tares up` (or set one in
-  # the console -> Security). Without a key the run is logged as "no key" and no finding is written.
+  # the console -> Settings). Without a key the run is logged as "no key" and no finding is written.
   # Enabled here (= subscribed to the trigger); disable it on the trigger's page any time.
   - name: incident-first-look
     trigger: incident

--- a/demo/catalog.demo.yaml
+++ b/demo/catalog.demo.yaml
@@ -93,8 +93,8 @@ agents:
     prompt: |
       You are an SRE taking the first look when Prometheus fires an alert on api-server. You are
       handed the correlated timeline: the firing alert (HighErrorRate / HighLatency / DependencyDown)
-      plus the signals behind it — 5xx request rate, p99 latency, active DB connections, dependency
-      health — and the service's request logs. That is your evidence.
+      plus the signals behind it (5xx request rate, p99 latency, active DB connections, dependency
+      health) and the service's request logs. That is your evidence.
 
       Produce a tight incident note: (1) what is failing and since when, (2) the most likely cause,
       tied to the specific evidence lines (which signal crossed, what the logs show), (3) a suggested

--- a/tares/agent.py
+++ b/tares/agent.py
@@ -48,7 +48,7 @@ TOOLS = [
      "input_schema": {"type": "object", "properties": {
          "label": {"type": "string", "description": "optional: one label axis"}}}},
     {"name": "recent_events",
-     "description": "Recent events for a source (key, type, text, time) — the actual data.",
+     "description": "Recent events for a source (key, type, text, time); the actual data.",
      "input_schema": {"type": "object", "properties": {
          "name": {"type": "string"}, "limit": {"type": "integer", "default": 20}},
          "required": ["name"]}},
@@ -70,7 +70,7 @@ PROPOSAL_TOOLS = [
     {"name": "propose_labels",
      "description": "Propose the labels (and primary key) for ONE source, as a card the user will "
                     "review. Propose only fields the source's field profile actually shows "
-                    "(source_fields) — anything else cannot be extracted. Give concrete evidence "
+                    "(source_fields); anything else cannot be extracted. Give concrete evidence "
                     "in `reasoning` (coverage, distinct counts, why the key is an entity). This "
                     "REPLACES the source's label set, so include every label it should end up with.",
      "input_schema": {"type": "object", "properties": {
@@ -123,7 +123,7 @@ PROPOSAL_TOOLS = [
          "reasoning": {"type": "string"}},
          "required": ["name", "key_field", "sources", "reasoning"]}},
     {"name": "propose_trigger",
-     "description": "Propose a trigger — a condition Tares evaluates continuously over a view; "
+     "description": "Propose a trigger; a condition Tares evaluates continuously over a view; "
                     "when it trips, subscribed agents are woken with the correlated timeline. Use "
                     "when the user's goal involves alerting or autonomous debugging. The view must "
                     "exist or be proposed in this conversation; `field` must be a numeric field "
@@ -212,16 +212,16 @@ connectors ingest events from sources (logs, metrics, deploys, Vercel/GitHub/Pos
 Every event has a key, named labels (correlation axes; one is the primary key), typed fields, and a \
 text line. Entities are label values. Views correlate sources for a key; triggers watch views.
 
-You help the user with their OWN ingested data — both to UNDERSTAND it (what's ingesting, the shape \
+You help the user with their OWN ingested data; both to UNDERSTAND it (what's ingesting, the shape \
 and entities of each source, coverage) and to DEBUG problems (a source not ingesting, an empty or \
 sparse entity, an unpopulated field, stale data). Adapt to whatever they ask.
 
-Always inspect with the read tools — never guess at what's there. For a problem, form a hypothesis \
+Always inspect with the read tools; never guess at what's there. For a problem, form a hypothesis \
 then verify it (health, field coverage, recent events, freshness). Be concrete: cite source names, \
 field coverage, entity values, counts. Prefer `describe` and `source_fields` to understand a source. \
 Keep answers tight and useful; use small tables or lists where they help. If a tool errors, say so.
 
-When the user wants the catalog changed — labels on a source, a view, a trigger — do not just \
+When the user wants the catalog changed; labels on a source, a view, a trigger; do not just \
 describe it: call propose_labels / propose_view / propose_trigger. Each proposal appears to the \
 user as a card they apply or skip; you never change the catalog directly. Ground every proposal \
 in evidence from the read tools.
@@ -230,39 +230,39 @@ HOW TO CHOOSE WHAT TO PROPOSE. These rules used to live in a separate "organize 
 user had to find; they apply to every proposal you make, so they are always in force:
 
 · A good KEY identifies a durable entity (a service, a session, a tenant): moderate distinct count, \
-high coverage, stable values. Check both before choosing one — a field with ONE distinct value \
+high coverage, stable values. Check both before choosing one; a field with ONE distinct value \
 cannot discriminate between entities and is never a key, however sensible its name. Dimensions \
 (http_method, level, status) make good secondary labels but bad keys. Sparse or constant fields \
 are weak.
-· Labels come from REAL fields — never invent one. A label's `field` MUST be a name source_fields \
+· Labels come from REAL fields; never invent one. A label's `field` MUST be a name source_fields \
 actually showed for that source; anything else extracts nothing. A label reads a `field`, a \
-`const`, or a regex over a field (`pattern`/`replace`, plus `map` for aliases) — reach for the \
+`const`, or a regex over a field (`pattern`/`replace`, plus `map` for aliases); reach for the \
 regex to clean messy values rather than guessing at a tidy field that isn't there.
 · FIRST check a source's existing labels (list_sources shows config.labels). If they already match \
 what you would propose, say so in text and do NOT call propose_labels. Otherwise call it ONCE with \
-the COMPLETE label set — the proposal replaces, it does not append. Same for views: don't propose \
+the COMPLETE label set; the proposal replaces, it does not append. Same for views: don't propose \
 a duplicate of one that already covers it.
 · Watch top values for VARIANTS of one entity (checkout / checkout-svc / checkout-service). \
 Correlation needs values to agree literally, so propose normalization on the label: \
 `pattern`/`replace` for whole families, `map` for irregular aliases (pattern runs first, map \
 applies to its result). This is often the highest-value fix available.
-· Views key and filter on LABELS only — never a raw field. A view's `key_field` and filters must be \
+· Views key and filter on LABELS only; never a raw field. A view's `key_field` and filters must be \
 a label the chosen sources EXPOSE. To correlate on something that isn't a label yet, promote it \
 first, then build the view. When sources share nothing but belong together, propose const labels \
 (same name and value) on each and key by that.
-· A view FILTER is always {"field": …, "op": …, "value": …} — three keys, never a flat \
-{"service": "checkout"} pair — and `op` is a NAME from eq / neq / contains / gt / gte / lt / lte. \
+· A view FILTER is always {"field": …, "op": …, "value": …}; three keys, never a flat \
+{"service": "checkout"} pair; and `op` is a NAME from eq / neq / contains / gt / gte / lt / lte. \
 Symbols are not operators here: write "eq", not "==". `field` may also be one of the built-in \
 columns event_type, source, text, key_value. Example: to keep only ingress-nginx events, \
 {"field": "service", "op": "eq", "value": "ingress-nginx"}. A view that needs no restriction takes \
-no filters at all — don't invent one.
-· To match a label across sources, ADD a new label — there is no rename, and a source's label set \
+no filters at all; don't invent one.
+· To match a label across sources, ADD a new label; there is no rename, and a source's label set \
 is declared whole. If source B should join A on `service`, propose a NEW label named `service` on \
 B reading B's matching field, keep B's other labels, and normalize B's values so they agree \
 literally with A's.
 · A trigger needs a numeric field the view's events actually carry, an aggregate and predicate, a \
 detection window, and a cooldown. Say what it would have fired on recently, in the data you just \
-read — a trigger that would fire constantly, or never, is not worth proposing.
+read; a trigger that would fire constantly, or never, is not worth proposing.
 
 Everything goes through proposals; the user applies or skips each card. Be decisive; don't ask \
 permission to inspect."""
@@ -329,7 +329,7 @@ async def run_agent(api_key: str, messages: list,
                         if cur is not None and _canon_labels(cur) == _canon_labels(tu.input.get("labels")):
                             results.append({"type": "tool_result", "tool_use_id": tu.id,
                                             "content": "this source ALREADY has exactly this label "
-                                                       "set — no card was shown. Tell the user its "
+                                                       "set; no card was shown. Tell the user its "
                                                        "labels already look right; propose only "
                                                        "changes."})
                             continue
@@ -337,7 +337,7 @@ async def run_agent(api_key: str, messages: list,
                     kind = {"propose_labels": "labels", "propose_view": "view", "propose_trigger": "trigger"}[tu.name]
                     yield _sse({"type": "proposal", "kind": kind, "id": tu.id, "payload": tu.input})
                     results.append({"type": "tool_result", "tool_use_id": tu.id,
-                                    "content": "proposal recorded — the user will review it as a "
+                                    "content": "proposal recorded; the user will review it as a "
                                                "card and apply or skip it"})
                     continue
                 # A start AND a finish. The console draws each call as a step that is visibly

--- a/tares/builtin_agents.py
+++ b/tares/builtin_agents.py
@@ -56,14 +56,14 @@ PRESETS = {
         "prompt": (
             "You are taking a first look at an entity in a system you monitor, because a condition "
             "you watch just tripped. You are handed the correlated timeline (logs, metrics, "
-            "deploys, commits, alerts) for that entity at the moment it tripped — that is your "
+            "deploys, commits, alerts) for that entity at the moment it tripped; that is your "
             "evidence.\n\n"
             "Establish what is happening and what CHANGED just before it started. Connect the "
             "change to the signature in the evidence. If the timeline is too narrow, read a wider "
             "window (1h) once before concluding.\n\n"
             "Write a short note: 1) what is happening and since when, 2) the most likely "
             "explanation with the specific evidence lines that support it, 3) what you would look "
-            "at next. Do not speculate beyond the evidence — if it is inconclusive, say so and say "
+            "at next. Do not speculate beyond the evidence; if it is inconclusive, say so and say "
             "what you would need. Your final message is recorded on this entity's timeline."
         ),
     },
@@ -72,7 +72,7 @@ PRESETS = {
         "prompt": (
             "You are an SRE taking the first look when an error condition trips on a running "
             "service. You are handed the correlated timeline (logs, metrics, deploys, commits) for "
-            "the affected entity — that is your primary evidence.\n\n"
+            "the affected entity; that is your primary evidence.\n\n"
             "Diagnose the most likely root cause: look for what changed (a deploy, a commit, a "
             "config value) just before the errors began, and connect it to the failure signature "
             "in the logs. If the timeline is insufficient, read a wider window (1h) once before "
@@ -261,7 +261,7 @@ class AgentRunner:
         servers = [m for m in self.store.list_mcp_servers() if m["name"] in selected]
         async with RemoteToolbox(servers) as toolbox:
             for failure in toolbox.failures:
-                print(f"[agent {agent['name']}] mcp connect failed — {failure}")
+                print(f"[agent {agent['name']}] mcp connect failed; {failure}")
             return await self._loop_with(agent, trigger_name, key, payload, api_key, toolbox)
 
     async def _loop_with(self, agent: dict, trigger_name: str, key: str, payload: str,
@@ -273,7 +273,7 @@ class AgentRunner:
             "content": (
                 f'The condition "{trigger_name}" tripped for "{key}".\n\n'
                 f"The correlated timeline at that moment:\n\n{payload}\n\n"
-                f"Take a first look, per your instructions. You already hold the evidence above — "
+                f"Take a first look, per your instructions. You already hold the evidence above; "
                 f"read again only if you need a wider window or a different entity."),
         }]
         rounds = tool_calls = 0

--- a/tares/builtin_agents.py
+++ b/tares/builtin_agents.py
@@ -427,12 +427,12 @@ class AgentRunner:
         if not token:
             print(f"[agent {agent_name}] slack: no bot token configured, channel post skipped")
             return
-        link = _slack_deep_link(key)
-        text = f"*{agent_name}* · `{trigger_name}` fired for *{key}*\n\n{finding}{link}"
+        msg = _slack_mod.build_finding_message(agent_name, trigger_name, key, finding,
+                                               _slack_deep_link(key))
         try:
             async with httpx.AsyncClient(timeout=15) as cx:
                 r = await cx.post(f"{_slack_mod.API_BASE}/chat.postMessage",
-                                  json={"channel": channel, "text": text},
+                                  json={"channel": channel, **msg},
                                   headers={"authorization": f"Bearer {token}"})
                 try:
                     data = r.json()
@@ -457,11 +457,13 @@ class AgentRunner:
         a `slack://channel/<id>` subscription (`tares/slack.py`), which is per-trigger, retried
         and logged in the delivery ledger; existing agents are not migrated.
         """
-        link = _slack_deep_link(key)
-        text = f"*{agent_name}* · `{trigger_name}` fired for *{key}*\n\n{finding}{link}"
+        # Incoming webhooks accept blocks too, so the finding renders the same way as on the
+        # channel path instead of as raw markdown.
+        from .slack import build_finding_message
+        msg = build_finding_message(agent_name, trigger_name, key, finding, _slack_deep_link(key))
         try:
             async with httpx.AsyncClient(timeout=15) as cx:
-                r = await cx.post(hook, json={"text": text})
+                r = await cx.post(hook, json=msg)
                 if r.status_code >= 300:
                     print(f"[agent {agent_name}] slack: HTTP {r.status_code} {r.text[:120]}")
         except Exception as e:   # notification failing must never lose the finding

--- a/tares/cli.py
+++ b/tares/cli.py
@@ -28,7 +28,7 @@ def _warn_if_exposed(host: str) -> None:
         print(
             f"\n  ⚠  Tares is binding {host} (reachable off this machine) with NO auth token.\n"
             "     Anyone who can reach this port can read your data. Set TARES_AUTH_TOKEN and put\n"
-            "     it behind TLS before exposing it — see https://docs.glassflow.ai/tares (Deployment).\n",
+            "     it behind TLS before exposing it; see https://docs.glassflow.ai/tares (Deployment).\n",
             flush=True,
         )
 
@@ -109,7 +109,7 @@ def _up(args: argparse.Namespace):
     if root_token:
         # print the login the operator uses — a click-through URL, since they're at the terminal.
         print(f"tares: console at {url}  ·  data in {home}", flush=True)
-        print(f"tares: auth ON — log in at {url}/?token={root_token}", flush=True)
+        print(f"tares: auth ON; log in at {url}/?token={root_token}", flush=True)
     else:
         print(f"tares: console at {url}  ·  data in {home}  ·  auth OFF (open; "
               f"run with --auth to require a login)", flush=True)
@@ -139,7 +139,7 @@ def _mcp(args: argparse.Namespace):
 def main():
     from .config import reject_legacy_env
     reject_legacy_env()
-    p = argparse.ArgumentParser(prog="tares", description="Tares — a data plane for AI agents.")
+    p = argparse.ArgumentParser(prog="tares", description="Tares; a data plane for AI agents.")
     p.add_argument("--version", action="version", version=f"tares {_pkg_version()}")
     sub = p.add_subparsers(dest="cmd")
 

--- a/tares/config.py
+++ b/tares/config.py
@@ -50,7 +50,7 @@ def reject_legacy_env(environ=None) -> None:
         "tares 1.0 renamed every NAVFLOW_* environment variable to TARES_*, and does NOT read the "
         "old names.\n\nStill set in this environment:\n"
         f"{mapping}\n\n"
-        "Rename them and start again. (The DuckDB file itself is unchanged — your data is where you "
+        "Rename them and start again. (The DuckDB file itself is unchanged; your data is where you "
         "left it.)"
     )
 
@@ -180,7 +180,7 @@ def validate_slack_channel(channel: str) -> str:
     if _SLACK_ID.match(chan) or _SLACK_NAME.match(chan):
         return chan
     raise ValueError(
-        f"{channel!r} is not a Slack channel — use the channel ID (C0123456789, from the channel's "
+        f"{channel!r} is not a Slack channel; use the channel ID (C0123456789, from the channel's "
         "'Copy link') or its lowercase name")
 
 
@@ -711,5 +711,5 @@ def validate_agent_dict(a: dict, trigger_names: set, triggers: dict | None = Non
         if view and FINDINGS_SOURCE in (view.get("sources") or []):
             raise CatalogError(
                 f"agent {a['name']!r}: trigger {a['trigger']!r} watches view "
-                f"{trig['view']!r}, which includes the {FINDINGS_SOURCE!r} source — an agent "
+                f"{trig['view']!r}, which includes the {FINDINGS_SOURCE!r} source; an agent "
                 f"cannot be woken by findings (it would fire itself forever)")

--- a/tares/connectors/__init__.py
+++ b/tares/connectors/__init__.py
@@ -46,20 +46,20 @@ SPECS = {
     "prometheus": {"label": "Prometheus", "mode": "poll", "discover": True,
                    "description": "Instant-query snapshots of PromQL expressions on every poll tick."},
     "docker_logs": {"label": "Docker logs", "mode": "poll", "discover": True,
-                    "description": "Tails a running container's logs — all lines by default; "
+                    "description": "Tails a running container's logs; all lines by default; "
                                    "optional match/drop regex filters."},
     "prometheus_alerts": {"label": "Prometheus alerts", "mode": "poll", "discover": True, "poll": "30s",
-                          "description": "Polls Prometheus's own /api/v1/alerts — the alerts its rules "
-                                         "have fired — and emits one event per active alert (keyed by a "
+                          "description": "Polls Prometheus's own /api/v1/alerts, the alerts its rules "
+                                         "have fired, and emits one event per active alert (keyed by a "
                                          "label), plus a resolved event when it clears. No Alertmanager, "
                                          "no PromQL."},
     "alertmanager": {"label": "Alertmanager alerts", "mode": "push",
-                     "description": "Push receiver for Alertmanager — point a webhook_configs.url at this "
+                     "description": "Push receiver for Alertmanager; point a webhook_configs.url at this "
                                     "source's ingest endpoint. Each alert Alertmanager routes (with its "
                                     "grouping, silencing and firing/resolved status) becomes one event, "
                                     "keyed by a label. No PromQL."},
     "reference": {"label": "Reference documents", "mode": "reference",
-                  "description": "Documents (json/csv/md/txt) attached to an entity by its labels — "
+                  "description": "Documents (json/csv/md/txt) attached to an entity by its labels; "
                                  "project notes, schemas, runbooks. Always surfaced when correlating "
                                  "on that entity, regardless of time window. Edit to add or remove."},
     "webhook": {"label": "Inbound webhook", "mode": "push",
@@ -77,7 +77,7 @@ SPECS = {
                "description": "Polls a repo's commits (cursor by SHA); one event per commit, "
                               "keyed by repo, with author as a label."},
     "vercel": {"label": "Vercel logs", "mode": "push",
-               "description": "Push source for Vercel logs — point a Vercel log drain (JSON) at this "
+               "description": "Push source for Vercel logs; point a Vercel log drain (JSON) at this "
                               "source's ingest endpoint; one event per log entry, keyed by project, "
                               "with environment + source labels."},
     "postgres": {"label": "Postgres table", "mode": "poll", "discover": True, "poll": "30s",
@@ -86,7 +86,7 @@ SPECS = {
                                 "Your application's source-of-truth data in the timeline."},
     "claude_code": {"label": "Claude Code sessions", "mode": "poll",
                     "description": "Tails local Claude Code session transcripts "
-                                   "(~/.claude/projects/*.jsonl) into the data plane — one event per "
+                                   "(~/.claude/projects/*.jsonl) into the data plane; one event per "
                                    "message, keyed by session, with project/branch/model labels and "
                                    "token-usage fields. Sub-agents roll up into the same source. "
                                    "Secrets are redacted before storage."},
@@ -94,7 +94,7 @@ SPECS = {
     # "Add source". Still a first-class source everywhere else — it appears on timelines, in the
     # catalog and in exports like any other.
     "finding": {"label": "Agent findings", "mode": "push", "internal": True,
-                "description": "What Tares agents conclude when a trigger fires — one finding per "
+                "description": "What Tares agents conclude when a trigger fires; one finding per "
                                "run, keyed to the entity, on that entity's timeline."},
 }
 

--- a/tares/connectors/alertmanager.py
+++ b/tares/connectors/alertmanager.py
@@ -70,7 +70,7 @@ class AlertmanagerConnector(Connector):
         key = primary_key or self._pick_key(labels)
         return Envelope(
             source=self.cfg.name, source_type=self.cfg.type, key_value=key,
-            event_type=alertname, text=f"{status.upper()}: {alertname} — {summary}",
+            event_type=alertname, text=f"{status.upper()}: {alertname} · {summary}",
             event_time=_parse_time(ts), payload=payload, labels=labels,
         )
 

--- a/tares/connectors/docker_logs.py
+++ b/tares/connectors/docker_logs.py
@@ -62,7 +62,7 @@ class DockerLogsConnector(Connector):
         "drop": {"type": "string",
                  "help": "skip lines matching this regex, e.g. 'HTTP/1.1\"' to drop access logs"},
         "key": {"type": "string", "advanced": True,
-                "help": "legacy fixed key — prefer a primary label"},
+                "help": "legacy fixed key; prefer a primary label"},
         "label_pattern": {"type": "string", "advanced": True,
                           "help": "regex with named groups → per-line label context"},
     }

--- a/tares/connectors/github.py
+++ b/tares/connectors/github.py
@@ -54,10 +54,10 @@ class GithubConnector(Connector):
                  "help": "owner/name, e.g. glassflow/tares (a pasted GitHub URL works too)"},
         "branch": {"type": "string",
                    "help": "branch to follow (empty = the repo's default branch, labeled by its "
-                           "real name). One source follows one branch — add a source per branch "
+                           "real name). One source follows one branch; add a source per branch "
                            "to watch several"},
         "token": {"type": "string", "secret": True, "discover_input": True,
-                  "help": "GitHub token — required for private repos, recommended otherwise: "
+                  "help": "GitHub token; required for private repos, recommended otherwise: "
                           "without one GitHub allows 60 API requests/hour per IP"},
         "limit": {"type": "number", "default": 20,
                   "help": "newest commits fetched per poll (the first poll imports this many)"},
@@ -89,11 +89,11 @@ class GithubConnector(Connector):
             return None
         if r.status_code in (403, 429) and r.headers.get("x-ratelimit-remaining") == "0":
             raise ValueError("GitHub rate limit exhausted (unauthenticated: 60 requests/hour per IP)"
-                             " — set a token or raise the poll interval")
+                             "; set a token or raise the poll interval")
         if r.status_code == 404:
             raise ValueError(f"repo {repo!r} not found"
-                             + (" — check owner/name (the token may also lack access)" if token
-                                else " — private repos need a token"))
+                             + ("; check owner/name (the token may also lack access)" if token
+                                else "; private repos need a token"))
         if r.status_code == 401:
             raise ValueError("GitHub rejected the token (401 unauthorized)")
         if r.status_code != 200:
@@ -178,7 +178,7 @@ class GithubConnector(Connector):
                 raise ValueError(f"could not reach GitHub: {e}")
             if meta.status_code == 404:
                 raise ValueError(f"repo {repo!r} not found"
-                                 + (" — check owner/name (the token may also lack access)" if token
+                                 + ("; check owner/name (the token may also lack access)" if token
                                     else " (private repos need a token)"))
             if meta.status_code != 200:
                 raise ValueError(f"GitHub returned {meta.status_code} for {repo!r}")

--- a/tares/connectors/postgres.py
+++ b/tares/connectors/postgres.py
@@ -37,7 +37,7 @@ def _dsn(config: dict) -> str:
     # comes only from the source's config — there is no daemon-level env fallback.
     dsn = config.get("dsn")
     if not dsn:
-        raise CatalogError("no Postgres DSN — set the source's `dsn` connection URL")
+        raise CatalogError("no Postgres DSN; set the source's `dsn` connection URL")
     return dsn
 
 
@@ -68,7 +68,7 @@ def _connect(dsn: str):
     try:
         import asyncpg
     except ImportError:
-        raise CatalogError("the postgres connector needs asyncpg (it ships with navflow — reinstall if missing)")
+        raise CatalogError("the postgres connector needs asyncpg (it ships with navflow; reinstall if missing)")
     # bounded connect: an unreachable host (firewalled DB, wrong IP) should fail in seconds with a
     # clear error, not sit on asyncpg's 60s default while the console appears hung
     return asyncpg.connect(dsn, timeout=10)
@@ -116,7 +116,7 @@ def _select_clause(config: dict, cursor_column: str) -> str:
 class PostgresConnector(Connector):
     CONFIG_SCHEMA = {
         "dsn": {"type": "string", "secret": True, "required": True, "discover_input": True,
-                "help": "postgresql://user:pass@host:port/dbname — this source's connection URL (the "
+                "help": "postgresql://user:pass@host:port/dbname; this source's connection URL (the "
                         "path after the slash picks the database; omitted, Postgres defaults to a db "
                         "named after the user). Must be reachable from the Tares host. Stored as a "
                         "secret: redacted in the API and omitted from catalog exports."},
@@ -124,18 +124,18 @@ class PostgresConnector(Connector):
         # needs the DSN) lists the tables and you pick one. So the form shows Discover right after
         # the DSN, and the table field below it.
         "table": {"type": "string", "required": True,
-                  "help": "table to poll, e.g. orders or public.orders — leave empty and Discover "
+                  "help": "table to poll, e.g. orders or public.orders; leave empty and Discover "
                           "lists the tables it can see"},
         "cursor_column": {"type": "string", "required": True,
                           "help": "column that only ever grows, used to fetch just the new rows on "
                                   "each poll: an autoincrement id (captures inserts only) or "
-                                  "updated_at (also captures row updates) — Discover picks this "
+                                  "updated_at (also captures row updates); Discover picks this "
                                   "for you"},
         "time_column": {"type": "string",
                         "help": "timestamp column for event_time (default: the cursor column if it "
                                 "is a timestamp, else ingest time)"},
         "columns": {"type": "string",
-                    "help": "comma-separated columns to pull, e.g. id,status,amount — empty pulls "
+                    "help": "comma-separated columns to pull, e.g. id,status,amount; empty pulls "
                             "every column (SELECT *). The cursor/key/time columns are always "
                             "included so the source still works. `database` and `table` are also "
                             "available as fields (from config) regardless of what you select."},
@@ -238,13 +238,13 @@ class PostgresConnector(Connector):
             finally:
                 await conn.close()
             if not rows:
-                raise ValueError(f"connected to database {db!r}, but no tables are visible — "
+                raise ValueError(f"connected to database {db!r}, but no tables are visible; "
                                  "wrong database in the DSN (the path after the slash), or the "
                                  "user lacks privileges")
             tables = [r["table_name"] if r["table_schema"] == "public"
                       else f"{r['table_schema']}.{r['table_name']}" for r in rows]
             return {"connector": "postgres", "tables": tables,
-                    "summary": f"connected to database {db!r} — {len(tables)} tables; "
+                    "summary": f"connected to database {db!r}: {len(tables)} tables; "
                                "pick one to introspect (another database needs its own "
                                "source with its DSN)"}
         table = _ident(config["table"], "table", _TABLE)

--- a/tares/connectors/prometheus.py
+++ b/tares/connectors/prometheus.py
@@ -56,7 +56,7 @@ class PrometheusConnector(Connector):
         "url": {"type": "string", "required": True, "discover_input": True,
                 "help": "Prometheus base URL, e.g. http://localhost:9090"},
         "bearer_token": {"type": "string", "secret": True, "discover_input": True,
-                         "help": "optional Authorization: Bearer token — for managed Prometheus "
+                         "help": "optional Authorization: Bearer token; for managed Prometheus "
                                  "(Thanos/Cortex/Mimir) or one behind an auth proxy"},
         "username": {"type": "string", "discover_input": True,
                      "help": "optional HTTP basic-auth username (e.g. a Grafana Cloud instance id)"},
@@ -66,7 +66,7 @@ class PrometheusConnector(Connector):
                         "help": "entity key for series that carry no key label"},
         "queries": {
             "type": "list", "required": True,
-            "help": "metrics to ingest — each a PromQL query mapped into the envelope",
+            "help": "metrics to ingest; each a PromQL query mapped into the envelope",
             "item": {
                 "promql": {"type": "string", "required": True,
                            "help": "PromQL (a bare metric name = raw, lossless ingest)"},

--- a/tares/connectors/prometheus_alerts.py
+++ b/tares/connectors/prometheus_alerts.py
@@ -40,7 +40,7 @@ class PrometheusAlertsConnector(Connector):
         "url": {"type": "string", "required": True, "discover_input": True,
                 "help": "Prometheus base URL, e.g. http://localhost:9090"},
         "bearer_token": {"type": "string", "secret": True, "discover_input": True,
-                         "help": "optional Authorization: Bearer token — for managed Prometheus or "
+                         "help": "optional Authorization: Bearer token; for managed Prometheus or "
                                  "one behind an auth proxy"},
         "username": {"type": "string", "discover_input": True,
                      "help": "optional HTTP basic-auth username"},
@@ -114,7 +114,7 @@ class PrometheusAlertsConnector(Connector):
                                  fallback=self.cfg.config.get("default_key", "unknown"))
         return Envelope(
             source=self.cfg.name, source_type=self.cfg.type, key_value=key,
-            event_type=alertname, text=f"{state.upper()}: {alertname} — {summary}",
+            event_type=alertname, text=f"{state.upper()}: {alertname} · {summary}",
             event_time=event_time, payload=payload, labels=labels,
         )
 

--- a/tares/connectors/vercel.py
+++ b/tares/connectors/vercel.py
@@ -39,10 +39,10 @@ class VercelConnector(Connector):
         # which is why a status label could not be built without a regex over the wrong field.
         {"name": "status_code", "help": "HTTP status code (proxy.statusCode). Label it as "
                                         "type=number to filter >= 400 and aggregate in triggers"},
-        {"name": "url", "help": "the request URL as asked for, with query string — unlike `path`, "
+        {"name": "url", "help": "the request URL as asked for, with query string; unlike `path`, "
                                 "which is rewritten (/tares?_rsc=… vs tares.segments/_head.segment)"},
         {"name": "method", "help": "GET | POST | HEAD | …"},
-        {"name": "referer", "help": "what linked here — the axis that finds the source of a 404"},
+        {"name": "referer", "help": "what linked here; the axis that finds the source of a 404"},
         {"name": "path_type", "help": "PRERENDER | STATIC | FUNCTION | …"},
         {"name": "region", "help": "edge region that served it, e.g. hnd1"},
         {"name": "cache", "help": "Vercel cache result: HIT | MISS | STALE | BYPASS (lambda only)"},

--- a/tares/connectors/webhook.py
+++ b/tares/connectors/webhook.py
@@ -26,9 +26,9 @@ class WebhookConnector(Connector):
         # key/key_field are the legacy way to set the entity key; the key is now just the label
         # marked primary. Kept (advanced) so existing configs round-trip and still work.
         "key": {"type": "string", "advanced": True,
-                "help": "legacy fixed entity key — prefer a primary label"},
+                "help": "legacy fixed entity key; prefer a primary label"},
         "key_field": {"type": "string", "advanced": True,
-                      "help": "legacy: payload field for the key — prefer a primary field-label"},
+                      "help": "legacy: payload field for the key; prefer a primary field-label"},
         "event_type": {"type": "string", "default": "webhook_event",
                        "help": "fixed event type"},
         "event_type_field": {"type": "string",

--- a/tares/daemon.py
+++ b/tares/daemon.py
@@ -510,7 +510,7 @@ def make_app() -> FastAPI:
                 _err(e)
             if not resolve_slack_token(store)[0]:
                 _err(ValueError("no Slack bot token configured; set TARES_SLACK_BOT_TOKEN or "
-                                "add one under Security before subscribing a channel"))
+                                "add one under Settings before subscribing a channel"))
         sid = "sub_" + uuid.uuid4().hex[:8]
         # record the creating credential: revoking a key removes its subscriptions (a revoked
         # agent must stop receiving trigger dispatches)
@@ -1420,7 +1420,7 @@ def make_app() -> FastAPI:
         key, _ = resolve_anthropic_key(store)
         if not key:
             _err(ValueError("no Anthropic key configured; set ANTHROPIC_API_KEY or add one "
-                            "under Security before enabling an agent"))
+                            "under Settings before enabling an agent"))
         # enable = subscribe to the trigger (the same wiring an external agent has). Idempotent.
         if not _agent_enabled(name):
             store.add_subscription("sub_" + uuid.uuid4().hex[:8], agent["trigger"],
@@ -1629,7 +1629,7 @@ def make_app() -> FastAPI:
             # Never "accept and hope". Refusing to serve is the only safe failure here.
             return JSONResponse({"detail": "Slack is not configured on this instance: set "
                                            f"{slack_verify.ENV_VAR} (or add the signing secret "
-                                           "under Security) and try again"}, status_code=503)
+                                           "under Settings) and try again"}, status_code=503)
         if (why := slack_verify.check(request.headers, raw, secret)) is not None:
             # The reason goes to the operator's log, not to the caller: telling a forger which part
             # of their forgery failed is free help.
@@ -1662,7 +1662,7 @@ def make_app() -> FastAPI:
         if not resolve_anthropic_key(store)[0]:
             return slack_mod.build_error(
                 ":warning: no Anthropic API key is configured on this Tares instance; set "
-                "`ANTHROPIC_API_KEY` or add one under Security in the console", thread_ts)
+                "`ANTHROPIC_API_KEY` or add one under Settings in the console", thread_ts)
         if not runtime.catalog.sources:
             return slack_mod.build_error(
                 ":warning: this Tares instance has no sources configured yet, so there is "

--- a/tares/daemon.py
+++ b/tares/daemon.py
@@ -149,7 +149,7 @@ def _serve_ui(path: str):
     """The built console SPA: a real file if it exists, else index.html (client-side routing)."""
     if not UI_DIST.exists():
         return JSONResponse(
-            {"detail": "console not built — run `npm install && npm run build` in ui/"},
+            {"detail": "console not built; run `npm install && npm run build` in ui/"},
             status_code=404)
     f = (UI_DIST / path).resolve()
     if path and f.is_file() and f.is_relative_to(UI_DIST.resolve()):
@@ -177,7 +177,7 @@ def _degraded_app(reason: str) -> FastAPI:
         return body
 
     async def unavailable():
-        return JSONResponse({"detail": f"database unavailable — {reason}", "status": "down"},
+        return JSONResponse({"detail": f"database unavailable; {reason}", "status": "down"},
                             status_code=503)
 
     # Everything that needs the store answers 503 (not a bare 500, and not the SPA's index.html).
@@ -307,7 +307,7 @@ def make_app() -> FastAPI:
         # traceback (degraded mode explains the failure to the user, it does not hide it from the
         # operator) and serve the console + 503s instead of exiting before uvicorn ever binds.
         traceback.print_exc()
-        print(f"taresd: DEGRADED — {e.reason}. Serving the console and 503s; fix the database "
+        print(f"taresd: DEGRADED; {e.reason}. Serving the console and 503s; fix the database "
               f"and restart.", flush=True)
         return _degraded_app(e.reason)
 
@@ -344,7 +344,7 @@ def make_app() -> FastAPI:
             runtime.reload_catalog()
             print("taresd: auto-provisioned OTLP source 'otlp'")
             return "otlp"
-        raise ValueError("multiple OTLP sources — set the X-Tares-Source header")
+        raise ValueError("multiple OTLP sources; set the X-Tares-Source header")
 
     @asynccontextmanager
     async def lifespan(_app):
@@ -509,7 +509,7 @@ def make_app() -> FastAPI:
             except ValueError as e:
                 _err(e)
             if not resolve_slack_token(store)[0]:
-                _err(ValueError("no Slack bot token configured — set TARES_SLACK_BOT_TOKEN or "
+                _err(ValueError("no Slack bot token configured; set TARES_SLACK_BOT_TOKEN or "
                                 "add one under Security before subscribing a channel"))
         sid = "sub_" + uuid.uuid4().hex[:8]
         # record the creating credential: revoking a key removes its subscriptions (a revoked
@@ -672,7 +672,7 @@ def make_app() -> FastAPI:
     async def derive(req: DeriveReq):
         name = req.name or "agent_view_" + uuid.uuid4().hex[:6]
         if name in runtime.catalog.views:
-            _err(ValueError(f"view {name!r} already exists — derived views must not "
+            _err(ValueError(f"view {name!r} already exists; derived views must not "
                             f"collide with existing entries"), 409)
         try:
             validate_view_dict({"name": name, "key_field": req.key_field,
@@ -684,7 +684,7 @@ def make_app() -> FastAPI:
                                   created_by=f"agent:{req.client}")
         runtime.reload_catalog()
         return {"handle": f"view:{name}", "name": name, "status": "active",
-                "note": "virtual view — query it by name like any other view"}
+                "note": "virtual view; query it by name like any other view"}
 
     # ── remember — the agent writes its own memory back (closes the loop) ─────
     @app.post("/remember", status_code=202)
@@ -902,7 +902,7 @@ def make_app() -> FastAPI:
             proposal = await asyncio.wait_for(
                 REGISTRY[connector].discover(body.get("config", {}) or {}), timeout=30)
         except (TimeoutError, asyncio.TimeoutError):
-            _err(ValueError("discover timed out — is the target reachable from the Tares "
+            _err(ValueError("discover timed out; is the target reachable from the Tares "
                             "server? (a hosted Tares can only reach public endpoints)"))
         except HTTPException:
             raise
@@ -1373,7 +1373,7 @@ def make_app() -> FastAPI:
                                    body.webhook_url, body.webhook_token, body.mcp_servers)
         runtime.reload_catalog()
         return {"ok": True, "enabled": False,
-                "note": "agents start disabled — enable it to run on the next firing"}
+                "note": "agents start disabled; enable it to run on the next firing"}
 
     @app.put("/api/agents/builtin/{name}")
     async def update_builtin_agent(name: str, body: AgentIn):
@@ -1419,7 +1419,7 @@ def make_app() -> FastAPI:
             _err(KeyError(f"unknown agent {name!r}"), 404)
         key, _ = resolve_anthropic_key(store)
         if not key:
-            _err(ValueError("no Anthropic key configured — set ANTHROPIC_API_KEY or add one "
+            _err(ValueError("no Anthropic key configured; set ANTHROPIC_API_KEY or add one "
                             "under Security before enabling an agent"))
         # enable = subscribe to the trigger (the same wiring an external agent has). Idempotent.
         if not _agent_enabled(name):
@@ -1488,7 +1488,7 @@ def make_app() -> FastAPI:
         if not token.startswith("xox"):
             # Caught here rather than on the first failed delivery: a pasted webhook URL or signing
             # secret would otherwise sit in the settings table looking configured.
-            _err(ValueError("that does not look like a Slack bot token — it should start with "
+            _err(ValueError("that does not look like a Slack bot token; it should start with "
                             "'xoxb-' (OAuth & Permissions → Bot User OAuth Token)"))
         store.set_setting(SLACK_TOKEN_SETTING, token)
         _, origin = resolve_slack_token(store)
@@ -1539,7 +1539,7 @@ def make_app() -> FastAPI:
             _err(ValueError("secret is required (use DELETE to remove the stored secret)"))
         if secret.startswith("xox"):
             # A bot token pasted into the wrong box would look configured and fail every signature.
-            _err(ValueError("that is a bot token, not the signing secret — take the Signing Secret "
+            _err(ValueError("that is a bot token, not the signing secret; take the Signing Secret "
                             "from the Slack app's Basic Information page"))
         store.set_setting(slack_verify.SETTING_KEY, secret)
         _, origin = slack_verify.resolve_secret(store)
@@ -1599,7 +1599,7 @@ def make_app() -> FastAPI:
                             error = ev.get("detail") or "the assistant failed"
             await asyncio.wait_for(_run(), timeout=SLACK_ASK_TIMEOUT)
         except asyncio.TimeoutError:
-            error = f"that took longer than {SLACK_ASK_TIMEOUT}s — try a narrower question"
+            error = f"that took longer than {SLACK_ASK_TIMEOUT}s; try a narrower question"
         except Exception as e:   # noqa: BLE001 — every failure has to reach the user as words
             error = f"{type(e).__name__}: {e}"
         if text.strip():
@@ -1657,11 +1657,11 @@ def make_app() -> FastAPI:
             return slack_mod.build_error(problem, thread_ts)
         if not response_url:
             return slack_mod.build_error(
-                ":warning: that request carried no response_url — Tares has nowhere to reply",
+                ":warning: that request carried no response_url; Tares has nowhere to reply",
                 thread_ts)
         if not resolve_anthropic_key(store)[0]:
             return slack_mod.build_error(
-                ":warning: no Anthropic API key is configured on this Tares instance — set "
+                ":warning: no Anthropic API key is configured on this Tares instance; set "
                 "`ANTHROPIC_API_KEY` or add one under Security in the console", thread_ts)
         if not runtime.catalog.sources:
             return slack_mod.build_error(

--- a/tares/discovery.py
+++ b/tares/discovery.py
@@ -38,7 +38,7 @@ async def _docker_ps() -> list[dict]:
     except Exception as e:
         raise ValueError(f"could not run `docker ps`: {e}")
     if proc.returncode != 0:
-        raise ValueError(f"`docker ps` failed — is the Docker daemon running? "
+        raise ValueError(f"`docker ps` failed; is the Docker daemon running? "
                          f"({err.decode(errors='replace').strip()})")
     containers = []
     for line in out.decode(errors="replace").strip().splitlines():
@@ -87,7 +87,7 @@ async def scan_docker() -> dict:
         except ValueError:
             cfg = normalize_config("prometheus", {"url": url, "default_key": "api-server",
                                                   "queries": [{"promql": "up"}]})
-            summary = f"detected at {url} but couldn't introspect — confirm it's reachable"
+            summary = f"detected at {url} but couldn't introspect; confirm it's reachable"
         proposed.append({
             "connector": "prometheus", "name": "metrics", "config": cfg,
             "summary": summary, "preselect": True, "from": f"container {prom['name']}"})
@@ -98,7 +98,7 @@ async def scan_docker() -> dict:
                             "reason": "a Postgres CDC connector would go here (not built yet)"})
         elif "grafana" in c["image"].lower():
             skipped.append({"service": c["service"], "image": c["image"],
-                            "reason": "a dashboard — nothing to ingest"})
+                            "reason": "a dashboard; nothing to ingest"})
 
     return {"provider": "docker",
             "summary": {"containers": len(containers), "proposed": len(proposed)},

--- a/tares/dispatch.py
+++ b/tares/dispatch.py
@@ -102,7 +102,7 @@ class Dispatcher:
         token, _origin = slack.resolve_token(self.store)
         if not token:
             # Not retryable and not transient: nothing about waiting 30s makes a token appear.
-            return False, "slack: no bot token configured (set TARES_SLACK_BOT_TOKEN or add one under Security)"
+            return False, "slack: no bot token configured (set TARES_SLACK_BOT_TOKEN or add one under Settings)"
         msg = {"channel": channel,
                **slack.build_message(trigger, key, payload, fired_at, dispatch_id)}
         headers = {"authorization": f"Bearer {token}", "content-type": "application/json"}

--- a/tares/slack.py
+++ b/tares/slack.py
@@ -415,6 +415,23 @@ def to_mrkdwn(text: str) -> str:
     return text
 
 
+def build_finding_message(agent_name: str, trigger: str, key: str, finding: str,
+                          link: str = "") -> dict:
+    """Block Kit body for a Tares agent's finding: a headline, the finding rendered as mrkdwn
+    (headers, emphasis, tables converted; split across sections so a long incident note never
+    trips Slack's 3000-char block cap), and a context line. `text` is the notification fallback.
+
+    The finding is the model's markdown; sending it raw is why findings showed up as literal
+    `**` and `##` and pipe tables in Slack (TR-141). Same converter `/tares ask` answers use."""
+    headline = f"*{agent_name}* · `{trigger}` fired for *{key}*"
+    blocks: list[dict] = [{"type": "section", "text": {"type": "mrkdwn", "text": headline}}]
+    blocks += _sections(finding)
+    context = "Tares agent finding" + (f" · {link.strip()}" if link.strip() else "")
+    blocks.append({"type": "context", "elements": [{"type": "mrkdwn", "text": context}]})
+    return {"text": f"{agent_name}: {trigger} fired for {key}", "blocks": blocks,
+            "unfurl_links": False, "unfurl_media": False}
+
+
 def _sections(text: str) -> list[dict]:
     """Split a long answer across section blocks — one section caps at 3000 characters, and an
     over-long block makes Slack reject the whole message (`invalid_blocks`) rather than truncate."""

--- a/tares/slack.py
+++ b/tares/slack.py
@@ -250,7 +250,7 @@ async def list_channels(token: str, timeout: float = 10.0
                         # only name both when it doesn't.
                         needed = str(data.get("needed") or "").strip() or "channels:read and groups:read"
                         return [], "missing_scope", (
-                            f"slack: missing_scope (the bot token is missing {needed} — "
+                            f"slack: missing_scope (the bot token is missing {needed}; "
                             "reconnect Slack to grant it)")
                     return [], "error", f"slack: {err}{_error_detail(err, data)}"
                 for c in data.get("channels") or []:
@@ -277,7 +277,7 @@ async def list_channels(token: str, timeout: float = 10.0
 # Everything below serves `POST /api/slack/events`. It is deliberately pure — parsing, cost
 # bounding and message shaping — so the endpoint itself is only plumbing: verify, ACK, answer.
 
-USAGE = ("usage: `/tares ask <question>` — e.g. "
+USAGE = ("usage: `/tares ask <question>`; e.g. "
          "`/tares ask what happened to checkout-svc in the last hour?`")
 
 # Cost ceiling, the same shape as `builtin_agents.DAILY_RUN_CAP`: a per-day count with an env

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,15 +1,15 @@
 {
-  "name": "navflow-console",
+  "name": "tares-console",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "navflow-console",
+      "name": "tares-console",
       "version": "0.0.1",
       "dependencies": {
         "@fontsource-variable/inter": "^5.3.0",
-        "@fontsource/jetbrains-mono": "^5.3.0",
+        "@fontsource/geist-mono": "^5.3.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-markdown": "^10.1.0",
@@ -709,10 +709,10 @@
         "url": "https://github.com/sponsors/ayuhito"
       }
     },
-    "node_modules/@fontsource/jetbrains-mono": {
+    "node_modules/@fontsource/geist-mono": {
       "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@fontsource/jetbrains-mono/-/jetbrains-mono-5.3.0.tgz",
-      "integrity": "sha512-fqDfB5I9f1p1TV486aUgB9t8zP84P0O1FtQR5Ol9vjwPy+S+EIGlVYm1cvj2W5shcZMTg2nZFdVMoH5wFu8a1A==",
+      "resolved": "https://registry.npmjs.org/@fontsource/geist-mono/-/geist-mono-5.3.0.tgz",
+      "integrity": "sha512-UtJ1BBBCVpMYdIcW7nEB45UAoAw5M53ZXs2t0ciPW+IokuAAIc56M8+kW5tXbRJCTpDw4XTtU7proT6NdQAHTg==",
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"

--- a/ui/package.json
+++ b/ui/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@fontsource-variable/inter": "^5.3.0",
-    "@fontsource/jetbrains-mono": "^5.3.0",
+    "@fontsource/geist-mono": "^5.3.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-markdown": "^10.1.0",

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -36,6 +36,7 @@ const NAV_GROUPS: { section: string; items: NavItem[] }[] = [
   { section: "Automate", items: [
     { to: "/triggers", label: "Triggers", icon: Bolt },
     { to: "/agents", label: "Tares agents", icon: Chat },
+    { to: "/mcp-servers", label: "MCP servers", icon: Terminal },
     { to: "/deliveries", label: "Deliveries", icon: Filter },
   ] },
   { section: "Agent access", items: [

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -21,26 +21,26 @@ type NavItem = {
   kbd?: string;     // keyboard-shortcut hint, e.g. "⌘K"
 };
 
-// The nav is the product story, in three acts: data in → the timeline → serve to agents.
-// Overview sits above the story rather than inside it — it is where you land and where you check
-// the instance's numbers, not one of the acts.
+// One layer, three named groups (TR-137): the confusion was naming and grouping, not depth.
+// Overview and Ask sit above the groups: where you land, and the global assistant (⌘K).
 const NAV_GROUPS: { section: string; items: NavItem[] }[] = [
   { section: "", items: [
     { to: "/", end: true, label: "Overview", icon: Grid },
-  ] },
-  { section: "Data in", items: [
-    { to: "/sources", label: "Sources", icon: Database },
     { to: "/ask", label: "Ask", icon: Chat, kbd: "⌘K" },
   ] },
-  { section: "The timeline", items: [
+  { section: "Data", items: [
+    { to: "/sources", label: "Sources", icon: Database },
     { to: "/explore", label: "Explore", icon: Activity },
-  ] },
-  { section: "Serve to agents", items: [
     { to: "/views", label: "Views", icon: Book },
+  ] },
+  { section: "Automate", items: [
     { to: "/triggers", label: "Triggers", icon: Bolt },
-    { to: "/agents", label: "Agents", icon: Chat },
-    { to: "/activity", label: "Activity", icon: Filter },
+    { to: "/agents", label: "Tares agents", icon: Chat },
+    { to: "/deliveries", label: "Deliveries", icon: Filter },
+  ] },
+  { section: "Agent access", items: [
     { to: "/connect", label: "Connect", icon: Terminal },
+    { to: "/reads", label: "Reads", icon: Activity },
   ] },
 ];
 
@@ -49,13 +49,13 @@ const SECTION_LABEL: Record<string, string> = {
   explore: "Explore",
   views: "Views",
   triggers: "Triggers",
-  agents: "Agents",
+  agents: "Tares agents",
+  deliveries: "Deliveries",
   connect: "Connect",
-  activity: "Activity",
+  reads: "Reads",
   catalog: "Catalog",
   "mcp-servers": "MCP servers",
   ask: "Ask",
-  security: "Security",
   settings: "Settings",
 };
 
@@ -84,7 +84,7 @@ function useCrumbs(): Crumb[] {
   if (parts[0] === "agents" && parts.length > 1) {
     const sub = decodeURIComponent(parts[1]);
     const last: Crumb = sub === "new" ? { label: "Create agent" } : { label: sub, mono: true };
-    return [{ label: "Agents", to: "/agents" }, last];
+    return [{ label: "Tares agents", to: "/agents" }, last];
   }
 
   return [{ label: SECTION_LABEL[parts[0]] ?? parts[0] }];
@@ -144,7 +144,7 @@ export default function App() {
 
         {NAV_GROUPS.map(({ section, items }) => (
           <div className="nav-group" key={section}>
-            {/* Overview has no section heading — it sits above the three acts, not in one. */}
+            {/* Overview and Ask have no section heading: they sit above the groups. */}
             {section && <div className="nav-section">{section}</div>}
             {items.map(({ to, end, label, icon: Icon, badge, locked, kbd }) => (
               <NavLink key={to} to={to} end={end} className={link}>
@@ -161,9 +161,9 @@ export default function App() {
         <div className="nav-spacer" />
         <div className="sep" />
 
-        <NavLink to="/security" className={link}>
+        <NavLink to="/settings" className={link}>
           <Lock className="ico" />
-          <span className="nav-label">Security</span>
+          <span className="nav-label">Settings</span>
         </NavLink>
         <ThemeToggle />
         {auth.get() && (

--- a/ui/src/components/AgentForm.tsx
+++ b/ui/src/components/AgentForm.tsx
@@ -229,7 +229,7 @@ export default function AgentForm({ initial, presetTrigger, triggers, presets, m
         <OptionRow title="Slack channel"
                    desc="the workspace bot posts the full finding to a channel"
                    on={channelOn} disabled={!slackWorkspace}
-                   disabledHint="connect a workspace bot under Security to enable this"
+                   disabledHint="connect a workspace bot under Settings to enable this"
                    onToggle={setChannelOn}>
           <Picker value={channel} onChange={setChannel}
                   options={["", ...chanList.map((c) => c.id)]} labels={chanLabels}

--- a/ui/src/components/AskChat.tsx
+++ b/ui/src/components/AskChat.tsx
@@ -474,7 +474,7 @@ function ToolNode({ tool }: { tool: ToolPart }) {
 
 const fmtMs = (ms: number) => (ms < 1000 ? `${ms}ms` : `${(ms / 1000).toFixed(1)}s`);
 
-/** The key is stored on the SERVER, under Security — the same one Slack and trigger-woken agents
+/** The key is stored on the SERVER, under Settings — the same one Slack and trigger-woken agents
  *  resolve. It used to live in this browser's localStorage and ride along as a header, so a key
  *  added here made Ask work while Slack still reported no key configured (NF-125). */
 function KeySetup({ onSaved }: { onSaved: () => void }) {
@@ -496,7 +496,7 @@ function KeySetup({ onSaved }: { onSaved: () => void }) {
         The assistant runs on your Tares daemon using this key. It is stored on this instance and
         used by everything that reasons over your data: this assistant, Tares agents woken by
         triggers, and <span className="mono">/tares ask</span> in Slack. You can change or remove it
-        later under <strong>Security</strong>. Get one at{" "}
+        later under <strong>Settings</strong>. Get one at{" "}
         <a href="https://console.anthropic.com/settings/keys" target="_blank" rel="noreferrer">console.anthropic.com</a>.
       </p>
       {err && <div className="alert error">{err}</div>}

--- a/ui/src/components/IngestSetup.tsx
+++ b/ui/src/components/IngestSetup.tsx
@@ -80,13 +80,13 @@ function KeyNote({ authKey }: { authKey?: string }) {
     <p className="muted">
       This instance requires auth; send this source's <strong>ingest key</strong> as{" "}
       <span className="mono">Authorization: Bearer …</span>. Copy it now; it's shown once and listed
-      under <Link to="/security">Security</Link>.
+      under <Link to="/settings">Settings</Link>.
     </p>
   ) : (
     <p className="muted">
       This instance requires auth; the producer needs this source's <strong>ingest key</strong> in{" "}
       <span className="mono">Authorization: Bearer …</span>. Use the key shown when you created the
-      source, or mint one under <Link to="/security">Security</Link> (scope <span className="mono">ingest</span>).
+      source, or mint one under <Link to="/settings">Settings</Link> (scope <span className="mono">ingest</span>).
     </p>
   );
 }

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -5,6 +5,7 @@ import { createBrowserRouter, Navigate, RouterProvider } from "react-router-dom"
 import App from "./App";
 import AuthGate from "./components/AuthGate";
 import AgentActivity, { ConnectPage } from "./pages/Activity";
+import Deliveries from "./pages/Deliveries";
 import Agents from "./pages/Agents";
 import AgentDetail from "./pages/AgentDetail";
 import AgentNew from "./pages/AgentNew";
@@ -27,6 +28,15 @@ import McpServers from "./pages/McpServers";
 import Sources from "./pages/Sources";
 import { TriggersPage, ViewsPage } from "./pages/ViewsTriggers";
 import "./styles.css";
+
+/** /activity?tab=dispatches (and the bare page, whose default tab was dispatches) → Deliveries;
+ *  /activity?tab=queries → Reads; ?agent=… → the subscriber roster on Deliveries. */
+function ActivityRedirect() {
+  const q = new URLSearchParams(window.location.search);
+  if (q.get("tab") === "queries") return <Navigate to="/reads" replace />;
+  const agent = q.get("agent");
+  return <Navigate to={agent ? `/deliveries?agent=${encodeURIComponent(agent)}` : "/deliveries"} replace />;
+}
 
 const router = createBrowserRouter([
   {
@@ -52,15 +62,19 @@ const router = createBrowserRouter([
       { path: "triggers/new", element: <TriggerNew /> },
       { path: "triggers/:name", element: <TriggerDetail /> },
       { path: "connect", element: <ConnectPage /> },
-      { path: "activity", element: <AgentActivity /> },
+      { path: "reads", element: <AgentActivity /> },
+      { path: "deliveries", element: <Deliveries /> },
+      // TR-137 renames: /activity split into /reads + /deliveries (dispatches live with their
+      // subscribers now); /security is /settings.
+      { path: "activity", element: <ActivityRedirect /> },
+      { path: "security", element: <Navigate to="/settings" replace /> },
       { path: "dispatches/:id", element: <DispatchDetail /> },
       { path: "agents", element: <Agents /> },
       { path: "mcp-servers", element: <McpServers /> },
       { path: "agents/new", element: <AgentNew /> },
       { path: "agents/:name", element: <AgentDetail /> },
       { path: "ask", element: <Ask /> },
-      { path: "security", element: <Security /> },
-      { path: "settings", element: <Navigate to="/sources" replace /> },
+      { path: "settings", element: <Security /> },
       // legacy paths → new homes (bookmarks, the old Entities/Activity/Catalog nav). Catalog
       // dissolved: source schema/freshness now lives on the source detail; the agent's-eye read
       // is Explore's Agent-view toggle.

--- a/ui/src/pages/Activity.tsx
+++ b/ui/src/pages/Activity.tsx
@@ -46,36 +46,14 @@ export function ConnectPage() {
   );
 }
 
-type ActivityTab = "queries" | "dispatches";
-const ACTIVITY_LABELS: Record<ActivityTab, string> = {
-  dispatches: "Trigger dispatches", queries: "Reads",
-};
-
-// The connected-agent roster moved to the Agents page (which lists Tares agents too); Activity is
-// now just what's been happening — reads agents ran, and trigger dispatches.
+// Reads: the one feed left on this page. Trigger dispatches moved to Deliveries (with the
+// subscriber roster they belong to); the connected-agent roster went the same way (TR-137).
 export default function AgentActivity() {
-  const [params, setParams] = useSearchParams();
-  const tab = (["queries", "dispatches"].includes(params.get("tab") ?? "")
-    ? params.get("tab") : "dispatches") as ActivityTab;
-  const setTab = (t: ActivityTab) => {
-    const next = new URLSearchParams(params);
-    next.set("tab", t);
-    setParams(next);
-  };
-
   return (
     <>
-      <h1>Activity</h1>
-      <p className="subtitle">what's been happening; the reads agents made and every trigger dispatch</p>
-
-      <div className="tabs">
-        {(Object.keys(ACTIVITY_LABELS) as ActivityTab[]).map((t) => (
-          <button key={t} className={tab === t ? "active" : ""} onClick={() => setTab(t)}>{ACTIVITY_LABELS[t]}</button>
-        ))}
-      </div>
-
-      {tab === "queries" && <Queries />}
-      {tab === "dispatches" && <Dispatches />}
+      <h1>Reads</h1>
+      <p className="subtitle">every read agents made over MCP or the API, newest first</p>
+      <Queries />
     </>
   );
 }
@@ -228,7 +206,7 @@ function Connect({ tab }: { tab: ConnectTab }) {
             This is your console access token; it works in the snippets below, but it carries{" "}
             <strong>full admin rights</strong>. For an agent, prefer a{" "}
             <span className="mono">read</span>-scoped API key from the{" "}
-            <Link to="/security">Security page</Link> (add <span className="mono">ingest</span> if
+            <Link to="/settings">Settings page</Link> (add <span className="mono">ingest</span> if
             the agent also writes memories) and paste it in place of the token.
           </p>
         </div>
@@ -285,7 +263,7 @@ function Connect({ tab }: { tab: ConnectTab }) {
                 Wire it on the trigger&rsquo;s page: open <Link to="/triggers">Triggers</Link>,
                 pick the trigger, and paste your endpoint there. From a script, the same action is
                 (needs a <span className="mono">read</span>-scoped{" "}
-                <Link to="/security">API key</Link>):
+                <Link to="/settings">API key</Link>):
               </p>
               <CodeBlock title="subscribe your agent's endpoint" code={subscribeCurl(shownTok)} copyText={subscribeCurl(tok)} />
             </>
@@ -597,7 +575,7 @@ function deliveryBadge(d: DispatchLogEntry) {
   return <span className={`badge ${cls}`}>{d.delivered}/{d.subscribers} delivered</span>;
 }
 
-function Dispatches() {
+export function Dispatches() {
   const nav = useNavigate();
   const { data, error } = usePolling(() => api.dispatches(150));
   const [q, setQ] = useState("");

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -45,7 +45,7 @@ export default function AgentDetail() {
     return (
       <div className="alert error">
         no Tares agent named <span className="mono">{name}</span>. Connected (external) agents are
-        listed under <Link to="/activity">Activity</Link>. See <Link to="/agents">Agents</Link>.
+        listed under <Link to="/deliveries">Deliveries</Link>. See <Link to="/agents">Agents</Link>.
       </div>
     );
   }
@@ -101,7 +101,7 @@ export default function AgentDetail() {
                   <td>
                     {agent.enabled ? <span className="badge ok">enabled</span> : <span className="badge">disabled</span>}
                     {!data.key_configured
-                      ? <span className="help"> · no Anthropic key: set one under <Link to="/security">Security</Link> to run</span>
+                      ? <span className="help"> · no Anthropic key: set one under <Link to="/settings">Settings</Link> to run</span>
                       : <span className="help"> · key from <span className="mono">{data.key_source}</span></span>}
                   </td>
                 </tr>

--- a/ui/src/pages/AgentNew.tsx
+++ b/ui/src/pages/AgentNew.tsx
@@ -42,7 +42,7 @@ export default function AgentNew() {
       {!keyOk && (
         <div className="alert">
           No Anthropic key configured; you can create the agent now, but it won't run until a key
-          is set under <Link to="/security">Security</Link>. It also starts disabled.
+          is set under <Link to="/settings">Settings</Link>. It also starts disabled.
         </div>
       )}
 

--- a/ui/src/pages/Agents.tsx
+++ b/ui/src/pages/Agents.tsx
@@ -1,13 +1,11 @@
 import { Link, useNavigate } from "react-router-dom";
 
 import { api } from "../api";
-import { AgentsRoster } from "./Activity";
 import { TimeAgo, usePolling } from "../components/bits";
 import type { AgentRun } from "../types";
 
-// The home for every agent a trigger can wake: Tares agents (configured here, run in-process) and
-// connected agents (external, reached over a webhook). Tares agents are created and managed on
-// this page; connected agents are listed from the roster and connected from a trigger's page.
+// Tares agents: the prompts you author that run in-process when a trigger fires. Subscribers
+// (external webhooks, Slack channels) are runtime state and live under Deliveries (TR-137).
 
 function runBadge(r: AgentRun | null | undefined) {
   if (!r) return <span className="dim">never run</span>;
@@ -27,10 +25,9 @@ export default function Agents() {
     <>
       <div className="pagehead">
         <div>
-          <h1>Agents</h1>
+          <h1>Tares agents</h1>
           <p className="subtitle">
-            everything your triggers can wake; <strong>Tares agents</strong> that run in-process,
-            and <strong>connected agents</strong> reached over a webhook
+            prompts that run inside Tares when a trigger fires and write a finding back
           </p>
         </div>
         <div className="btnrow">
@@ -42,11 +39,10 @@ export default function Agents() {
       {data && !data.key_configured && (
         <div className="alert">
           No Anthropic key configured; agents can be created but not enabled. Set one under{" "}
-          <Link to="/security">Security</Link>.
+          <Link to="/settings">Settings</Link>.
         </div>
       )}
 
-      <h2>Tares agents</h2>
       {!data ? <div className="dim">loading…</div>
         : data.agents.length === 0 ? (
           <div className="panel">
@@ -78,13 +74,6 @@ export default function Agents() {
             </tbody>
           </table>
         )}
-
-      <h2 style={{ marginTop: 28 }}>Connected agents</h2>
-      <p className="help" style={{ margin: "0 0 10px", whiteSpace: "normal" }}>
-        external agents subscribed to a trigger's webhook. Connect one from a{" "}
-        <Link to="/triggers">trigger's</Link> page.
-      </p>
-      <AgentsRoster only="connected" />
     </>
   );
 }

--- a/ui/src/pages/Agents.tsx
+++ b/ui/src/pages/Agents.tsx
@@ -30,10 +30,7 @@ export default function Agents() {
             prompts that run inside Tares when a trigger fires and write a finding back
           </p>
         </div>
-        <div className="btnrow">
-          <button onClick={() => nav("/mcp-servers")}>MCP servers</button>
-          <button className="primary" onClick={() => nav("/agents/new")}>Create Tares agent</button>
-        </div>
+        <button className="primary" onClick={() => nav("/agents/new")}>Create Tares agent</button>
       </div>
 
       {data && !data.key_configured && (

--- a/ui/src/pages/Deliveries.tsx
+++ b/ui/src/pages/Deliveries.tsx
@@ -1,0 +1,27 @@
+import { Link } from "react-router-dom";
+
+import { AgentsRoster, Dispatches } from "./Activity";
+
+// Deliveries: the runtime side of triggers. Who is subscribed (external webhooks and Slack
+// channels, with delivery health) and every firing. Tares agents are authored things and live on
+// their own page; a subscriber is a destination, not an agent (TR-137, and the TR-138 confusion).
+export default function Deliveries() {
+  return (
+    <>
+      <h1>Deliveries</h1>
+      <p className="subtitle">
+        where trigger firings go: every subscriber with its delivery health, and every firing
+      </p>
+
+      <h2>Subscribers</h2>
+      <p className="help" style={{ margin: "0 0 10px", whiteSpace: "normal" }}>
+        external agents (webhooks) and Slack channels subscribed to a trigger. Wire one from a{" "}
+        <Link to="/triggers">trigger's</Link> page.
+      </p>
+      <AgentsRoster only="connected" />
+
+      <h2 style={{ marginTop: 28 }}>Trigger firings</h2>
+      <Dispatches />
+    </>
+  );
+}

--- a/ui/src/pages/DispatchDetail.tsx
+++ b/ui/src/pages/DispatchDetail.tsx
@@ -14,7 +14,7 @@ export default function DispatchDetail() {
     return (
       <div className="alert error">
         {/unknown dispatch/i.test(error) ? <>no dispatch <span className="mono">{id}</span></> : error}
-        {" "}· see <Link to="/activity?tab=dispatches">Trigger dispatches</Link>
+        {" "}· see <Link to="/deliveries">Deliveries</Link>
       </div>
     );
   }
@@ -29,7 +29,7 @@ export default function DispatchDetail() {
       <div className="pagehead">
         <div>
           <p className="subtitle" style={{ marginBottom: 4 }}>
-            <Link to="/activity?tab=dispatches">Trigger dispatches</Link> ›
+            <Link to="/deliveries">Deliveries</Link> ›
           </p>
           <h1>
             <Link to={`/triggers/${encodeURIComponent(d.trigger)}`} className="mono">{d.trigger}</Link>

--- a/ui/src/pages/McpServers.tsx
+++ b/ui/src/pages/McpServers.tsx
@@ -106,7 +106,7 @@ export default function McpServers() {
     <>
       <h1>MCP servers</h1>
       <p className="subtitle">
-        external tool servers your <em>Tares agents</em> can use, connected once with their credential
+        external MCP servers, connected once; pick them per <em>Tares agent</em> to give it those tools
       </p>
 
       {error && <div className="alert error">{error}</div>}

--- a/ui/src/pages/Security.tsx
+++ b/ui/src/pages/Security.tsx
@@ -16,8 +16,8 @@ import type { ApiKey } from "../types";
 export default function Security() {
   return (
     <>
-      <h1>Security</h1>
-      <p className="subtitle">how this instance is secured, and the credentials it issues</p>
+      <h1>Settings</h1>
+      <p className="subtitle">access mode, API keys, and the instance credentials: Anthropic and Slack</p>
       <AccessPanel />
       <ApiKeysPanel />
       <AnthropicKeyPanel />

--- a/ui/src/pages/SourceClaudeCode.tsx
+++ b/ui/src/pages/SourceClaudeCode.tsx
@@ -89,7 +89,7 @@ export default function SourceClaudeCode() {
             <span className="help">
               Create an API key with the <span className="mono">read</span> +{" "}
               <span className="mono">ingest</span> scopes on the{" "}
-              <Link to="/security">Security page</Link> and paste it here; it lets the plugin
+              <Link to="/settings">Settings page</Link> and paste it here; it lets the plugin
               stream sessions <em>and</em> query Tares over MCP, without full admin rights.
             </span>
           ) : (

--- a/ui/src/pages/SourceNew.tsx
+++ b/ui/src/pages/SourceNew.tsx
@@ -145,7 +145,7 @@ export default function SourceNew() {
             <div className="alert ok" style={{ marginTop: 14 }}>
               This instance requires auth, so <span className="mono">{created.name}</span> got its own
               ingest key; send it as <code>Authorization: Bearer …</code>. <strong>Copy it now; it
-              is not shown again</strong> (it's listed under <Link to="/security">Security</Link> as{" "}
+              is not shown again</strong> (it's listed under <Link to="/settings">Settings</Link> as{" "}
               <span className="mono">ingest: {created.name}</span>):
               <div className="ingest-url" style={{ marginTop: 8 }}>
                 <code className="mono">{created.authKey}</code>
@@ -155,7 +155,7 @@ export default function SourceNew() {
           ) : created.keyErr ? (
             <div className="alert error" style={{ marginTop: 14 }}>
               The source was created, but minting its ingest key failed: {created.keyErr}. Create one
-              under <Link to="/security">Security</Link> (scope <span className="mono">ingest</span>).
+              under <Link to="/settings">Settings</Link> (scope <span className="mono">ingest</span>).
             </div>
           ) : authOn === false ? (
             <p className="help" style={{ marginTop: 14, whiteSpace: "normal" }}>

--- a/ui/src/pages/TriggerDetail.tsx
+++ b/ui/src/pages/TriggerDetail.tsx
@@ -149,7 +149,7 @@ export default function TriggerDetail() {
                   // channel list is already loaded on this page, so resolve it when we can and fall
                   // back to the id when the bot has since been removed from the channel.
                   ? <strong>{channelLabel(a.name)}</strong>
-                  : <Link to={`/activity?agent=${encodeURIComponent(a.name)}`}><strong>{a.name}</strong></Link>}</td>
+                  : <Link to={`/deliveries?agent=${encodeURIComponent(a.name)}`}><strong>{a.name}</strong></Link>}</td>
                 <td>{a.kind === "tares"
                   ? <span className="badge">Tares</span>
                   : a.kind === "slack"
@@ -270,7 +270,7 @@ export default function TriggerDetail() {
       {caps && caps.slack_configured === false && (
         <p className="help" style={{ margin: "4px 0", whiteSpace: "normal" }}>
           no Slack bot token is configured yet; add one under{" "}
-          <Link to="/security">Security</Link>, and invite the bot to the channel.
+          <Link to="/settings">Settings</Link>, and invite the bot to the channel.
         </p>
       )}
       {msg && <p className="help" style={{ margin: "6px 0 0" }}>{msg}</p>}

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -1,10 +1,10 @@
-/* Tares console — the 2026 design system (002.pdf deck): bone page, brown
-   ink, one sand accent, square corners, 1px hairlines, no shadows. Inter for
-   sentences, Departure Mono (the pixel voice) for labels and numerals,
-   JetBrains Mono for code. All colors flow through the same semantic tokens
-   as before, so [data-theme="dark"] re-skins the app onto the brown/ink scale
-   without touching component rules — the user's theme toggle survives; both
-   themes come from the one deck palette. */
+/* Tares console — the GlassFlow design system, sourced from the HeroUI Kit V3
+   Figma variables (TR-140): cream ground, eclipse ink, one Space Sand accent,
+   square corners, 1px hairlines, no shadows. Inter for sentences, Departure
+   Mono (the pixel voice) for labels and numerals, JetBrains Mono for code. All
+   colors flow through semantic tokens, so [data-theme="dark"] re-skins the app
+   onto the kit's dark anchors without touching component rules; the user's
+   theme toggle survives. */
 @import "tailwindcss";
 @import "@fontsource-variable/inter";
 @import "@fontsource/jetbrains-mono";
@@ -24,91 +24,129 @@
   --font-pixel: "Departure Mono", ui-monospace, monospace;
 }
 
-/* ── raw deck palette (website base.css upstream) ── */
+/* ── HeroUI Kit V3 (GlassFlow) variables — the single source of truth (TR-140) ──
+   Values are the kit's "02_Theme (HeroUI)" collection, verbatim hex, both modes; the same layer
+   Rius consumes as --agency-* (argus-ui src/app/theme.css), so the two products share one palette
+   by construction. Components never reference --kit-*; they consume the semantic tokens below.
+
+   Held back on purpose, matching Rius's logged decisions (RIUS-52): the kit's status colors
+   (success #17c964 / danger #ff383c are stock HeroUI brights that read neon on cream) and its
+   dark-mode zinc leftovers (background-secondary #0c0c0e, border #28282c) — Tares keeps its
+   cream-derived status tones and warm-brown dark neutrals for those. Radius/shadow language:
+   Tares stays square + hairline (a deliberate identity), consistent within the app. */
 :root {
-  --brown-950: oklch(0.1856 0.0403 69.81);
+  --kit-background: #f0efe2;          /* background/background */
+  --kit-surface: #faf9ec;             /* surface/surface */
+  --kit-surface-secondary: #f1efdf;   /* surface/surface-secondary */
+  --kit-surface-tertiary: #efeddb;    /* surface/surface-tertiary */
+  --kit-overlay: #ffffff;             /* overlay / field/background / default-hover */
+  --kit-foreground: #1e0f00;          /* foreground/foreground = eclipse */
+  --kit-muted: #6e5b3f;               /* foreground/muted */
+  --kit-border: #d8d5bc;              /* border */
+  --kit-accent: #ffac00;              /* accent/accent (fixed across modes) */
+  --kit-accent-hover: #ffd274;        /* accent/accent-hover (fixed across modes) */
+  --kit-accent-foreground: #1e0f00;   /* accent/accent-foreground = eclipse */
+  --kit-accent-soft: #ffac0026;       /* accent/accent-soft (light) */
+  --kit-snow: #fcfcfc;                /* base colors/snow (dark-mode foreground) */
+
+  --kit-dark-background: #1e0f00;     /* background/background (dark) = eclipse */
+  --kit-dark-surface: #492400;        /* surface/surface (dark) */
+  --kit-dark-default: #663b11;        /* default/default (dark) */
+  --kit-dark-background-tertiary: #5a3109;
+  --kit-dark-muted: #c2b197;          /* foreground/muted (dark) */
+  --kit-dark-separator: #895523;      /* separator/separator (dark) */
+  --kit-dark-accent-soft: #ffac001f;  /* accent/accent-soft (dark) */
+}
+
+/* ── raw palette: kit anchors first, cream/brown-derived ramps where the kit is held ── */
+:root {
+  /* the brown ink scale, anchored on eclipse; intermediates keep the deck's warm ramp */
+  --brown-950: var(--kit-foreground);
   --brown-900: oklch(0.222 0.05 64);
   --brown-850: oklch(0.256 0.0594 61.05);
   --brown-800: oklch(0.3047 0.0725 58.57);
   --brown-700: oklch(0.38 0.072 58);
-  --brown-600: oklch(0.462 0.062 60);
+  --brown-600: var(--kit-muted);
   --brown-500: oklch(0.51 0.05 64);
 
-  --bone-100: oklch(0.972 0.013 101);
-  --bone-200: oklch(0.9494 0.0213 100.99);
-  --bone-300: oklch(0.9214 0.0254 101.98);
-  --bone-400: oklch(0.876 0.03 102);
+  /* the cream ground, anchored on the kit's background/surface tiers */
+  --bone-100: var(--kit-surface);
+  --bone-200: var(--kit-background);
+  --bone-300: var(--kit-surface-tertiary);
+  --bone-400: var(--kit-border);
 
-  --on-brown-100: oklch(0.9494 0.0213 100.99);
-  --on-brown-300: oklch(0.74 0.036 88);
+  --on-brown-100: var(--kit-snow);
+  --on-brown-300: var(--kit-dark-muted);
   --on-brown-500: oklch(0.69 0.038 78);
-  --on-brown-border: oklch(0.372 0.055 60);
+  --on-brown-border: var(--kit-dark-separator);
 
-  --sand-500: oklch(0.8052 0.1704 74.31);
-  --sand-400: oklch(0.845 0.163 82);
+  /* accent: the kit's Space Sand, verbatim */
+  --sand-500: var(--kit-accent);
+  --sand-400: var(--kit-accent-hover);
   --sand-300: oklch(0.8857 0.1558 91.49);
-  --sand-700: oklch(0.52 0.148 62);
-  --sand-wash: oklch(0.8052 0.1704 74.31 / 0.14);
+  --sand-700: oklch(0.52 0.148 62);     /* AA ink form for text on cream; the kit has no dark accent */
+  --sand-wash: var(--kit-accent-soft);
 
+  /* status: held from the kit (stock brights); cream-derived tones stay */
   --green-500: oklch(0.56 0.14 150);
   --green-300: oklch(0.74 0.15 152);
   --red-500: oklch(0.552 0.196 28);
   --red-300: oklch(0.69 0.19 26);
   --blue-500: oklch(0.56 0.12 250);
   --blue-300: oklch(0.72 0.11 245);
-  --white: oklch(100% 0 0);
+  --white: var(--kit-overlay);
 }
 
-/* ── semantic tokens: light = the bone ground ── */
+/* ── semantic tokens: light = the cream ground ── */
 :root {
   color-scheme: light;
 
-  /* surfaces & text */
-  --bg: var(--bone-200);
-  --panel: var(--white);
-  --ink: var(--brown-800);
-  --ink-soft: var(--brown-600);
+  /* surfaces & text — kit tiers: background canvas, surface panels, overlay pops */
+  --bg: var(--kit-background);
+  --panel: var(--kit-surface);
+  --ink: var(--kit-foreground);
+  --ink-soft: var(--kit-muted);
   --ink-faint: var(--brown-500);
-  --line: var(--bone-300);
-  --input-bg: var(--white);
+  --line: var(--kit-border);
+  --input-bg: var(--kit-overlay);      /* field/background */
 
   /* accent — Space Sand carries fills; sand-700 is the AA text/ink form */
-  --accent: var(--sand-500);
-  --accent-soft: var(--sand-wash);
+  --accent: var(--kit-accent);
+  --accent-soft: var(--kit-accent-soft);
   --accent-deep: var(--sand-700);
-  --on-accent: var(--brown-950);
+  --on-accent: var(--kit-accent-foreground);
 
   /* status */
   --ok: var(--green-500);
-  --ok-soft: color-mix(in srgb, var(--green-500) 11%, var(--white));
-  --ok-border: color-mix(in srgb, var(--green-500) 28%, var(--white));
+  --ok-soft: color-mix(in srgb, var(--green-500) 11%, var(--kit-surface));
+  --ok-border: color-mix(in srgb, var(--green-500) 28%, var(--kit-surface));
   --err: var(--red-500);
-  --err-soft: color-mix(in srgb, var(--red-500) 9%, var(--white));
-  --danger-border: color-mix(in srgb, var(--red-500) 30%, var(--white));
+  --err-soft: color-mix(in srgb, var(--red-500) 9%, var(--kit-surface));
+  --danger-border: color-mix(in srgb, var(--red-500) 30%, var(--kit-surface));
   --warn: var(--sand-700);
-  --warn-soft: color-mix(in srgb, var(--sand-500) 16%, var(--white));
+  --warn-soft: color-mix(in srgb, var(--kit-accent) 16%, var(--kit-surface));
 
-  /* structural neutrals */
-  --hover: var(--bone-100);
-  --row-hover: var(--bone-100);
-  --th-bg: var(--bone-100);
-  --chip-bg: var(--bone-100);
-  --starting-bg: var(--bone-300);
-  --border-strong: var(--bone-400);
-  --wash: oklch(0.3047 0.0725 58.57 / 0.06);
-  --wash-2: oklch(0.3047 0.0725 58.57 / 0.1);
-  --code-bg: var(--bone-100);
+  /* structural neutrals — kit surface tiers */
+  --hover: var(--kit-surface-secondary);
+  --row-hover: var(--kit-surface-secondary);
+  --th-bg: var(--kit-surface-secondary);
+  --chip-bg: var(--kit-surface-tertiary);
+  --starting-bg: var(--kit-surface-tertiary);
+  --border-strong: var(--kit-border);
+  --wash: color-mix(in srgb, var(--kit-foreground) 6%, transparent);
+  --wash-2: color-mix(in srgb, var(--kit-foreground) 10%, transparent);
+  --code-bg: var(--kit-surface-secondary);
   --slate: var(--blue-500); /* structural tags (push mode, kind) */
-  --slate-soft: color-mix(in srgb, var(--blue-500) 10%, var(--white));
+  --slate-soft: color-mix(in srgb, var(--blue-500) 10%, var(--kit-surface));
 
-  /* primary action — the deck's sand button, both themes */
-  --btn-primary-bg: var(--sand-500);
-  --btn-primary-ink: var(--brown-950);
-  --btn-primary-bg-hover: var(--sand-400);
+  /* primary action — the kit's Button "Primary" maps to accent (fixed across modes) */
+  --btn-primary-bg: var(--kit-accent);
+  --btn-primary-ink: var(--kit-accent-foreground);
+  --btn-primary-bg-hover: var(--kit-accent-hover);
 
   /* overlays: hairline + tone, shadows only where something floats */
-  --overlay: oklch(0.1856 0.0403 69.81 / 0.45);
-  --sheet-shadow: oklch(0.1856 0.0403 69.81 / 0.25);
+  --overlay: color-mix(in srgb, var(--kit-foreground) 45%, transparent);
+  --sheet-shadow: color-mix(in srgb, var(--kit-foreground) 25%, transparent);
 
   --mono: var(--font-mono-jb);
   --pixel: var(--font-pixel);
@@ -119,43 +157,45 @@
 [data-theme="dark"] {
   color-scheme: dark;
 
-  --bg: var(--brown-950);
-  --panel: var(--brown-900);
-  --ink: var(--on-brown-100);
-  --ink-soft: var(--on-brown-300);
+  /* kit dark anchors: eclipse canvas, warm-brown surfaces, snow ink */
+  --bg: var(--kit-dark-background);
+  --panel: var(--kit-dark-surface);
+  --ink: var(--kit-snow);
+  --ink-soft: var(--kit-dark-muted);
   --ink-faint: var(--on-brown-500);
-  --line: var(--on-brown-border);
-  --input-bg: var(--brown-900);
+  --line: var(--kit-dark-separator);
+  --input-bg: var(--kit-dark-surface);
 
-  --accent: var(--sand-500);
-  --accent-soft: var(--sand-wash);
+  --accent: var(--kit-accent);
+  --accent-soft: var(--kit-dark-accent-soft);
   --accent-deep: var(--sand-300);
-  --on-accent: var(--brown-950);
+  --on-accent: var(--kit-accent-foreground);
 
   --ok: var(--green-300);
-  --ok-soft: color-mix(in srgb, var(--green-300) 14%, var(--brown-950));
-  --ok-border: color-mix(in srgb, var(--green-300) 30%, var(--brown-950));
+  --ok-soft: color-mix(in srgb, var(--green-300) 14%, var(--kit-dark-background));
+  --ok-border: color-mix(in srgb, var(--green-300) 30%, var(--kit-dark-background));
   --err: var(--red-300);
-  --err-soft: color-mix(in srgb, var(--red-300) 12%, var(--brown-950));
-  --danger-border: color-mix(in srgb, var(--red-300) 32%, var(--brown-950));
+  --err-soft: color-mix(in srgb, var(--red-300) 12%, var(--kit-dark-background));
+  --danger-border: color-mix(in srgb, var(--red-300) 32%, var(--kit-dark-background));
   --warn: var(--sand-300);
-  --warn-soft: color-mix(in srgb, var(--sand-300) 12%, var(--brown-950));
+  --warn-soft: color-mix(in srgb, var(--sand-300) 12%, var(--kit-dark-background));
 
-  --hover: var(--brown-850);
-  --row-hover: var(--brown-850);
-  --th-bg: var(--brown-850);
-  --chip-bg: var(--brown-850);
-  --starting-bg: var(--brown-850);
-  --border-strong: var(--brown-700);
-  --wash: oklch(0.9494 0.0213 100.99 / 0.07);
-  --wash-2: oklch(0.9494 0.0213 100.99 / 0.11);
-  --code-bg: var(--brown-950);
+  /* the kit's dark neutrals beyond these are zinc leftovers (held); warm-brown ramp stays */
+  --hover: var(--kit-dark-default);
+  --row-hover: var(--kit-dark-default);
+  --th-bg: var(--kit-dark-background-tertiary);
+  --chip-bg: var(--kit-dark-default);
+  --starting-bg: var(--kit-dark-default);
+  --border-strong: var(--kit-dark-separator);
+  --wash: color-mix(in srgb, var(--kit-snow) 7%, transparent);
+  --wash-2: color-mix(in srgb, var(--kit-snow) 11%, transparent);
+  --code-bg: var(--kit-dark-background);
   --slate: var(--blue-300);
-  --slate-soft: color-mix(in srgb, var(--blue-300) 14%, var(--brown-950));
+  --slate-soft: color-mix(in srgb, var(--blue-300) 14%, var(--kit-dark-background));
 
-  --btn-primary-bg: var(--sand-500);
-  --btn-primary-ink: var(--brown-950);
-  --btn-primary-bg-hover: var(--sand-400);
+  --btn-primary-bg: var(--kit-accent);
+  --btn-primary-ink: var(--kit-accent-foreground);
+  --btn-primary-bg-hover: var(--kit-accent-hover);
 
   --overlay: oklch(0 0 0 / 0.55);
   --sheet-shadow: oklch(0 0 0 / 0.5);
@@ -1161,7 +1201,7 @@ pre.payload {
 .ask-rail-list { display: flex; flex-direction: column; gap: 2px; }
 .ask-rail-item {
   display: flex; align-items: center; gap: 6px;
-  padding: 7px 9px; border-radius: 6px; cursor: pointer;
+  padding: 7px 9px; border-radius: 0; cursor: pointer;
   border: 1px solid transparent; font-size: 13.5px;
 }
 .ask-rail-item:hover { background: var(--wash); }
@@ -1179,13 +1219,13 @@ pre.payload {
 
 /* Delivery option rows on the agent form: collapsed rows that read before they open, an explicit
    toggle inside, fields only when on. */
-.opt-row { border: 1px solid var(--line); border-radius: 8px; margin-bottom: 6px; }
+.opt-row { border: 1px solid var(--line); border-radius: 0; margin-bottom: 6px; }
 .opt-head {
   display: flex; align-items: center; gap: 10px; width: 100%;
   padding: 10px 12px; background: none; border: none; cursor: pointer;
   font: inherit; text-align: left;
 }
-.opt-head:hover { background: var(--wash); border-radius: 8px; }
+.opt-head:hover { background: var(--wash); }
 .opt-caret { color: var(--ink-faint); width: 12px; flex-shrink: 0; }
 .opt-title { font-weight: 600; margin-right: 10px; }
 .opt-desc { display: inline; }
@@ -1196,7 +1236,7 @@ pre.payload {
 
 /* URL + bearer token as ONE control: a shared border, an inner divider, no gap — they are a
    credential pair, not two independent settings. */
-.hook-group { border: 1px solid var(--line); border-radius: 8px; overflow: hidden; }
+.hook-group { border: 1px solid var(--line); border-radius: 0; overflow: hidden; }
 .hook-group input { border: none; border-radius: 0; width: 100%; }
 .hook-group input + input { border-top: 1px solid var(--line); }
 .hook-group:focus-within { border-color: var(--accent); }
@@ -1211,14 +1251,15 @@ pre.payload {
 /* Add-source connector cards: a scannable grid instead of a table — the description reads as a
    card, and click targets are the whole card. */
 .connector-cards { display: grid; grid-template-columns: repeat(auto-fill, minmax(290px, 1fr)); gap: 10px; }
+/* Square, hairline, no shadow: the app's identity. Distinguishable by the panel surface against
+   the canvas plus a strong border, not by elevation. */
 .connector-card {
   text-align: left; font: inherit; cursor: pointer;
-  background: var(--bg); border: 1.5px solid var(--border-strong); border-radius: 8px;
+  background: var(--panel); border: 1.5px solid var(--border-strong); border-radius: 0;
   padding: 12px 14px; display: flex; flex-direction: column; gap: 6px;
-  box-shadow: 0 1px 3px oklch(0.2 0.04 65 / 0.10);
 }
-.connector-card:hover { border-color: var(--accent); box-shadow: 0 2px 6px oklch(0.2 0.04 65 / 0.16); }
-.connector-card.unavailable { cursor: default; opacity: 0.6; box-shadow: none; }
+.connector-card:hover { border-color: var(--accent); background: var(--hover); }
+.connector-card.unavailable { cursor: default; opacity: 0.6; }
 .connector-card.unavailable:hover { border-color: var(--border-strong); }
 .connector-card-head { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
 .connector-card-head .name { font-weight: 600; }

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -1,15 +1,16 @@
 /* Tares console — the GlassFlow design system, sourced from the HeroUI Kit V3
    Figma variables (TR-140): cream ground, eclipse ink, one Space Sand accent,
-   square corners, 1px hairlines, no shadows. Inter for sentences, Departure
-   Mono (the pixel voice) for labels and numerals, JetBrains Mono for code. All
+   square corners, 1px hairlines, no shadows. Inter for sentences, Geist Mono
+   for labels, badges, table headers and code (the kit's mono role), Departure
+   Mono (the pixel voice) reserved for headline KPI numerals. All
    colors flow through semantic tokens, so [data-theme="dark"] re-skins the app
    onto the kit's dark anchors without touching component rules; the user's
    theme toggle survives. */
 @import "tailwindcss";
 @import "@fontsource-variable/inter";
-@import "@fontsource/jetbrains-mono";
-@import "@fontsource/jetbrains-mono/500.css";
-@import "@fontsource/jetbrains-mono/600.css";
+@import "@fontsource/geist-mono";
+@import "@fontsource/geist-mono/500.css";
+@import "@fontsource/geist-mono/600.css";
 
 @font-face {
   font-family: "Departure Mono";
@@ -20,7 +21,7 @@
 
 @theme {
   --font-sans: "Inter Variable", ui-sans-serif, system-ui, sans-serif;
-  --font-mono-jb: "JetBrains Mono", ui-monospace, SFMono-Regular, monospace;
+  --font-mono-jb: "Geist Mono", ui-monospace, SFMono-Regular, monospace;
   --font-pixel: "Departure Mono", ui-monospace, monospace;
 }
 
@@ -225,7 +226,7 @@ b, strong { font-weight: 600; }
 
 /* the pixel voice — labels and numerals only, never body copy */
 .pixel-label {
-  font-family: var(--pixel);
+  font-family: var(--mono);
   font-size: 12px;
   line-height: 1;
   letter-spacing: 0.1em;
@@ -264,7 +265,7 @@ b, strong { font-weight: 600; }
 .sidebar .brand { display: flex; align-items: center; gap: 8px; }
 .brand-mark { width: 24px; height: auto; flex-shrink: 0; }
 .brand-word { display: block; line-height: 1.05; }
-.brand small { display: block; font-family: var(--pixel); font-size: 10px; color: var(--ink-faint); font-style: normal; letter-spacing: 0.08em; text-transform: uppercase; margin-top: 2px; }
+.brand small { display: block; font-family: var(--mono); font-size: 10px; color: var(--ink-faint); font-style: normal; letter-spacing: 0.08em; text-transform: uppercase; margin-top: 2px; }
 
 .navlink {
   display: flex;
@@ -282,7 +283,7 @@ b, strong { font-weight: 600; }
 
 /* nav badges & locks */
 .nav-badge {
-  font-family: var(--pixel);
+  font-family: var(--mono);
   font-size: 9px;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -367,7 +368,7 @@ code { font-family: var(--mono); font-size: 0.92em; }
 table { width: 100%; border-collapse: collapse; background: var(--panel); border: 1px solid var(--line); border-radius: 0; overflow: hidden; }
 thead th {
   text-align: left;
-  font-family: var(--pixel);
+  font-family: var(--mono);
   font-size: 10px;
   letter-spacing: 0.1em;
   text-transform: uppercase;
@@ -391,7 +392,7 @@ td .dim, .dim { color: var(--ink-faint); }
 /* ── table toolbar ── */
 .toolbar { display: flex; align-items: center; gap: 8px; margin: 0 0 12px; flex-wrap: wrap; }
 .toolbar .grow { flex: 1 1 auto; }
-.toolbar .count { font-family: var(--pixel); font-size: 11px; letter-spacing: 0.06em; color: var(--ink-faint); font-variant-numeric: tabular-nums; }
+.toolbar .count { font-family: var(--mono); font-size: 11px; letter-spacing: 0.06em; color: var(--ink-faint); font-variant-numeric: tabular-nums; }
 .toolbar select { width: auto; }
 .search-box { position: relative; display: inline-flex; align-items: center; }
 .search-box .ico { position: absolute; left: 9px; width: 15px; height: 15px; color: var(--ink-faint); pointer-events: none; }
@@ -402,7 +403,7 @@ td .dim, .dim { color: var(--ink-faint); }
   display: inline-flex;
   align-items: center;
   gap: 5px;
-  font-family: var(--pixel);
+  font-family: var(--mono);
   font-size: 10px;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -607,7 +608,7 @@ button:focus-visible, .btn:focus-visible, .navlink:focus-visible, .navbtn:focus-
 .panel { background: var(--panel); border: 1px solid var(--line); border-radius: 0; padding: 18px 20px; margin-bottom: 18px; }
 .cards { display: grid; grid-template-columns: repeat(auto-fill, minmax(170px, 1fr)); gap: 12px; margin-bottom: 18px; }
 .card { background: var(--panel); border: 1px solid var(--line); border-radius: 0; padding: 12px 16px; }
-.card .k { font-family: var(--pixel); font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase; font-variant-ligatures: none; color: var(--ink-faint); font-weight: 400; }
+.card .k { font-family: var(--mono); font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase; font-variant-ligatures: none; color: var(--ink-faint); font-weight: 400; }
 .card .v { font-family: var(--pixel); font-variant-ligatures: none; font-variant-numeric: tabular-nums; font-size: 22px; margin-top: 4px; }
 .card .v small { font-size: 11px; font-family: var(--mono); color: var(--ink-faint); }
 
@@ -762,7 +763,7 @@ pre.payload {
 
 /* key/value summary grid (sheet detail) */
 .kv { display: grid; grid-template-columns: auto 1fr; gap: 6px 16px; align-items: center; }
-.kv .k { font-family: var(--pixel); font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase; font-variant-ligatures: none; color: var(--ink-faint); font-weight: 400; }
+.kv .k { font-family: var(--mono); font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase; font-variant-ligatures: none; color: var(--ink-faint); font-weight: 400; }
 
 /* auth login gate — the brown ground, like the cloud console */
 .login-wrap {
@@ -858,7 +859,7 @@ pre.payload {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  font-family: var(--pixel);
+  font-family: var(--mono);
   font-size: 10px;
   letter-spacing: 0.1em;
   text-transform: uppercase;
@@ -890,7 +891,7 @@ pre.payload {
 /* nav sections — the 3-act grouping */
 .nav-group { display: flex; flex-direction: column; gap: 2px; margin-bottom: 8px; }
 .nav-section {
-  font-family: var(--pixel);
+  font-family: var(--mono);
   font-size: 10px;
   letter-spacing: 0.1em;
   text-transform: uppercase;
@@ -909,7 +910,7 @@ pre.payload {
 
 /* Explore — picker sections */
 .ent-section {
-  font-family: var(--pixel);
+  font-family: var(--mono);
   font-size: 10px;
   letter-spacing: 0.1em;
   text-transform: uppercase;
@@ -927,7 +928,7 @@ pre.payload {
 .tl-controls { display: flex; align-items: center; gap: 16px; flex-wrap: wrap; margin-bottom: 2px; }
 .tl-ctl { display: flex; align-items: center; gap: 8px; }
 .tl-ctl .lbl {
-  font-family: var(--pixel); font-size: 10px; text-transform: uppercase;
+  font-family: var(--mono); font-size: 10px; text-transform: uppercase;
   font-variant-ligatures: none;
   letter-spacing: 0.1em; color: var(--ink-faint); margin: 0;
 }
@@ -973,7 +974,7 @@ pre.payload {
 }
 .menu-item .menu-n { font-size: 11px; color: var(--ink-faint); font-variant-numeric: tabular-nums; flex-shrink: 0; }
 .menu-item.back {
-  color: var(--ink-faint); font-family: var(--pixel); font-size: 10px;
+  color: var(--ink-faint); font-family: var(--mono); font-size: 10px;
   text-transform: uppercase; letter-spacing: 0.1em; font-variant-ligatures: none; margin-bottom: 2px;
 }
 .menu-scroll { max-height: 260px; overflow-y: auto; }
@@ -1014,7 +1015,7 @@ pre.payload {
 .turn:first-of-type { border-top: 0; }
 .turn-who {
   display: flex; align-items: center; gap: 8px;
-  font-family: var(--pixel); font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase;
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase;
   color: var(--ink-faint); margin-bottom: 6px;
 }
 .turn-copy {
@@ -1107,7 +1108,7 @@ pre.payload {
 
 /* nav ⌘K hint on the Ask link */
 .nav-kbd {
-  font-family: var(--pixel); font-size: 9px; color: var(--ink-faint);
+  font-family: var(--mono); font-size: 9px; color: var(--ink-faint);
   border: 1px solid var(--line); border-radius: 0; padding: 2px 4px; line-height: 1.2;
 }
 .navlink.active .nav-kbd { color: var(--accent-deep); border-color: var(--accent-deep); }
@@ -1174,7 +1175,7 @@ pre.payload {
 .mcp-status.absent { background: var(--warn-soft); }
 .mcp-status.absent::before { background: var(--warn); }
 .codeblock { margin: 4px 0 16px; border: 1px solid var(--line); border-radius: 0; overflow: hidden; }
-.codeblock-head { display: flex; justify-content: space-between; align-items: center; padding: 6px 12px; background: var(--th-bg); font-family: var(--pixel); font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase; font-variant-ligatures: none; color: var(--ink-soft); }
+.codeblock-head { display: flex; justify-content: space-between; align-items: center; padding: 6px 12px; background: var(--th-bg); font-family: var(--mono); font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase; font-variant-ligatures: none; color: var(--ink-soft); }
 .codeblock pre { margin: 0; border: 0; border-radius: 0; }
 .copybtn { font-size: 12px; padding: 2px 10px; }
 

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -27,14 +27,26 @@
 
 /* ── HeroUI Kit V3 (GlassFlow) variables — the single source of truth (TR-140) ──
    Values are the kit's "02_Theme (HeroUI)" collection, verbatim hex, both modes; the same layer
-   Rius consumes as --agency-* (argus-ui src/app/theme.css), so the two products share one palette
-   by construction. Components never reference --kit-*; they consume the semantic tokens below.
+   Rius consumes as --agency-* (argus-ui src/app/theme.css; extraction in
+   argus-ui docs/design/heroui-v3-figma-variables.json, 2026-08-13). Both products share one
+   palette by construction. Components never reference --kit-*; they consume the semantic tokens.
 
-   Held back on purpose, matching Rius's logged decisions (RIUS-52): the kit's status colors
-   (success #17c964 / danger #ff383c are stock HeroUI brights that read neon on cream) and its
-   dark-mode zinc leftovers (background-secondary #0c0c0e, border #28282c) — Tares keeps its
-   cream-derived status tones and warm-brown dark neutrals for those. Radius/shadow language:
-   Tares stays square + hairline (a deliberate identity), consistent within the app. */
+   ADOPTED from the kit: canvas + surface tiers + overlay + border, eclipse ink + muted, the accent
+   (fixed across modes; the kit's Button "Primary" is the accent role), the dark anchors, and
+   Geist Mono for the label/interactive/code role.
+
+   HELD on purpose, matching Rius's logged decisions (RIUS-52):
+   - status colors: kit success/warning/danger (#17c964/#f5a524/#ff383c) are stock HeroUI brights
+     that read neon on cream; the cream-derived tones stay.
+   - dark-mode zinc leftovers (background-secondary #0c0c0e, border #28282c, ...): unfinished in
+     the kit; the warm-brown ramp stays for those roles.
+   - radius + shadow: the kit's 0/12/24 radius language and shadow-drawn borderless fields are not
+     adopted. Square corners, 1px hairlines, no shadows are Tares's identity; the rule is
+     "consistent within Tares".
+
+   RULES: no color literal below these token layers; new micro-labels/badges/code use var(--mono),
+   var(--pixel) is for headline numerals only; when the kit changes, re-extract the JSON in argus-ui
+   first, then update --kit-* here. */
 :root {
   --kit-background: #f0efe2;          /* background/background */
   --kit-surface: #faf9ec;             /* surface/surface */


### PR DESCRIPTION
One PR for the four stacked UI tickets; the intermediate PRs (#72, #73, #74) are closed in favour of this one, which holds every commit. Reviewable per commit:

**TR-140, theme (3 commits).** The console palette now comes from the HeroUI Kit V3 Figma variables via a `--kit-*` layer byte-identical to Rius's `--agency-*`, with Tares's semantic tokens on top; both products share one palette by construction. Geist Mono replaces JetBrains Mono and Departure Mono for the label/badge/header/code roles (the kit's mono role); the pixel voice survives only on Overview KPI numerals. Held on purpose, matching Rius's RIUS-52 decisions: the kit's stock-bright status colors, its dark-mode zinc leftovers, and its radius/shadow language (square + hairline + no shadow is Tares's identity; the few rounded/shadowed elements that had crept in are squared). Adopted-vs-held recorded at the top of `styles.css`.

**TR-143, em dashes.** 68 user-visible daemon strings (connector descriptions rendered on the Add source cards, field help, API errors, agent prompts, CLI output, demo prompt) rewritten; found by AST, docstrings and comments untouched.

**TR-141, Slack findings.** Both agent posting paths sent the finding's raw markdown; they now post Block Kit through the existing `to_mrkdwn` converter (headers, bold, links, pipe tables as aligned code) split under Slack's 3000-char block cap.

**TR-137, sidebar (2 commits).** One layer, rearranged: Overview, Ask, then Data / Automate / Agent access, Settings in the footer. Agents split into Tares agents + a new Deliveries page (subscriber roster with health + trigger firings); MCP servers gets its own entry under Automate; Activity shrinks to Reads; Security is Settings everywhere including daemon strings. Old routes redirect (`/security`, `/activity` and its query variants).

Verified in both themes and across the affected pages on a local instance; agents, slack, github, postgres, labels and catalog-sync suites pass.