### PR TITLE
Console: workspace link and Settings banner on cloud cells (TR-142)

### DIFF
--- a/tares/daemon.py
+++ b/tares/daemon.py
@@ -63,6 +63,11 @@ AUTH_TOKEN = os.getenv("TARES_AUTH_TOKEN", "").strip()
 # URL, e.g. https://app.navflow.dev/login; unset for self-host (behaves exactly as before). Surfaced
 # on the PUBLIC /health so a logged-out console knows where to send the browser to authenticate.
 LOGIN_URL = os.getenv("TARES_LOGIN_URL", "").strip()
+# The workspace this cell belongs to in the control plane (additive, env-gated; TR-142). Users,
+# plan, storage and the Slack app install are managed there, not in the cell; the console links
+# out to it so a user never has to know the control plane exists to find them. Unset for
+# self-host: no link. Public, non-secret, surfaced on /health next to login_url.
+WORKSPACE_URL = os.getenv("TARES_WORKSPACE_URL", "").strip()
 # The Anthropic key for the in-app Ask agent (and Tares agents) is resolved at request time via
 # resolve_anthropic_key(store): env ANTHROPIC_API_KEY, else the console-stored key.
 # Never returned by any API — capabilities exposes only a boolean.
@@ -465,6 +470,8 @@ def make_app() -> FastAPI:
         if LOGIN_URL:
             # public, non-secret: where the logged-out console sends the browser to authenticate.
             body["login_url"] = LOGIN_URL
+        if WORKSPACE_URL:
+            body["workspace_url"] = WORKSPACE_URL
         return body
 
     @app.post("/query")

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -5,7 +5,7 @@ import { api, auth } from "./api";
 import CommandPalette from "./components/CommandPalette";
 import {
   Activity, Bolt, Book, Chat, ChevronRight, Database, Filter, GitHub, Grid, Lock, Moon,
-  SignOut, Sun, Terminal,
+  Settings, SignOut, Sun, Terminal,
 } from "./components/icons";
 import { applyTheme, currentTheme, type Theme } from "./theme";
 
@@ -132,8 +132,13 @@ function ThemeToggle() {
 
 export default function App() {
   const [version, setVersion] = useState<string | null>(null);
+  // Cloud only: the control-plane workspace this cell belongs to. Users, plan, storage and the
+  // Slack app are managed there; the link is the missing half of Settings (TR-142). Self-host
+  // sets no TARES_WORKSPACE_URL and never sees it.
+  const [workspaceUrl, setWorkspaceUrl] = useState<string>();
   useEffect(() => {
     api.capabilities().then((c) => setVersion(c.version ?? null)).catch(() => {});
+    api.health().then((h) => setWorkspaceUrl(h.workspace_url || undefined)).catch(() => {});
   }, []);
   return (
     <>
@@ -166,6 +171,13 @@ export default function App() {
           <Lock className="ico" />
           <span className="nav-label">Settings</span>
         </NavLink>
+        {workspaceUrl && (
+          <a className="navlink" href={workspaceUrl} title="users, plan, storage and the Slack app: managed in your workspace">
+            <Settings className="ico" />
+            <span className="nav-label">Workspace</span>
+            <span className="nav-badge">↗</span>
+          </a>
+        )}
         <ThemeToggle />
         {auth.get() && (
           <button className="navbtn" onClick={signOut}>

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -79,6 +79,7 @@ export const api = {
   // isn't ok; `pct_used` is on /api/usage's 0-100 scale and null when no limit is configured.
   health: () => request<{
     status: string; auth_required: boolean; login_url?: string;
+    workspace_url?: string;   // cloud only: the control-plane workspace this cell belongs to
     detail?: string; pct_used?: number | null;
   }>("/health"),
   // Swap a one-time ?code= (handed to us in the redirect back from the control plane) for the real

--- a/ui/src/pages/Security.tsx
+++ b/ui/src/pages/Security.tsx
@@ -14,10 +14,24 @@ import type { ApiKey } from "../types";
 //                  signing secret that authenticates the /tares slash command (inbound)
 // The per-source ingest URL is an address, not a secret — it lives on the source page, not here.
 export default function Security() {
+  // Cloud only (TR-142): the half of "settings" a user comes here looking for that lives in the
+  // control plane, named and linked, so nobody has to know the control plane exists.
+  const [workspaceUrl, setWorkspaceUrl] = useState<string>();
+  useEffect(() => {
+    api.health().then((h) => setWorkspaceUrl(h.workspace_url || undefined)).catch(() => {});
+  }, []);
   return (
     <>
       <h1>Settings</h1>
       <p className="subtitle">access mode, API keys, and the instance credentials: Anthropic and Slack</p>
+      {workspaceUrl && (
+        <div className="alert" style={{ marginBottom: 14 }}>
+          <strong>Users, the Slack app, plan and storage</strong> are managed in your workspace, not
+          here. The Slack <em>bot token</em> below is what this instance posts with; installing the
+          app into your Slack happens in the workspace.{" "}
+          <a href={workspaceUrl}>Open workspace ↗</a>
+        </div>
+      )}
       <AccessPanel />
       <ApiKeysPanel />
       <AnthropicKeyPanel />


### PR DESCRIPTION
Fixes TR-142, the recommended way: the cell becomes workspace-aware and links out precisely; management itself stays in the control plane.

A new generic, env-gated hook: `TARES_WORKSPACE_URL`, surfaced on the public `/health` as `workspace_url` next to `login_url` (same pattern as the existing cloud hooks). When set, the console shows a **Workspace ↗** link in the sidebar footer under Settings, and a banner at the top of the Settings page naming what lives in the workspace (users, the Slack app install, plan, storage) with an "Open workspace" link; the banner also explains the Slack split, since the bot token lives here while the app install happens there. Self-host never sets the var and sees neither.

Contract with the control plane (tares-cloud, being done in parallel under TR-145): the URL is the workspace detail page with a `#settings` fragment, `https://console.tares-glassflow.com/workspaces/<slug>#settings`; provisioning sets it per cell like `publicUrl`. Verified live: env var read, `/health` carries it, both surfaces render; UI builds.