### PR TITLE
AI SRE demo as a use case (TR-176)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,6 @@ the project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-## [Unreleased]
-
 ### Fixed
 - **Auto-discover (Docker) works again.** The environment scan still read the Prometheus
   connector's old one-shot discover shape and failed with an internal error whenever a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 Notable changes to Tares (formerly NavFlow). Format follows [Keep a Changelog](https://keepachangelog.com/);
 the project follows [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+- **AI SRE demo as a use case.** Use cases > AI SRE demo (tagged demo) creates the same three sources,
+  `service_timeline` view, `incident` trigger and `incident-first-look` agent that
+  `demo/catalog.demo.yaml` seeds, with one click and no catalog import; an existing unowned demo
+  catalog is adopted rather than duplicated. The wizard lists what to do first (start the stack,
+  set an Anthropic key) with copyable commands, and the use case page has Cause an incident
+  (error_spike, latency, dependency_outage) and Clear the fault buttons that flip the api-server's
+  fault switch. Recipes can now declare `tags`, `SETUP` steps and `ACTIONS` (served at
+  `POST /api/usecases/{id}/actions/{name}`).
+
 ## [1.8.0] - 2026-08-18
 
 ### Added

--- a/demo/README.md
+++ b/demo/README.md
@@ -36,6 +36,14 @@ curl -s 'localhost:9090/api/v1/query?query=up'   # prometheus is scraping
 
 ## 2. Install and run Tares
 
+Two ways to wire Tares to the stack: one click in the console, or the catalog file.
+
+**In the console:** start Tares (`tares up`), open **Use cases**, pick **AI SRE demo** (tagged
+demo), click Start. That creates the same three sources, view, trigger and agent the catalog below
+does, and the use case page gets a "Cause an incident" button so you never need `curl` for step 4.
+
+**With the catalog file:**
+
 Install Tares the normal way (not in Docker) and point it at the demo catalog — from any
 directory:
 

--- a/tares/daemon.py
+++ b/tares/daemon.py
@@ -2068,6 +2068,17 @@ def make_app() -> FastAPI:
         except Exception as e:
             _uc_err(e)
 
+    @app.post("/api/usecases/{uid}/actions/{name}")
+    async def usecase_action(uid: str, name: str, request: Request):
+        try:
+            body = await request.json()
+        except Exception:
+            body = {}
+        try:
+            return await asyncio.to_thread(usecases.action, uid, name, body if isinstance(body, dict) else {})
+        except Exception as e:
+            _uc_err(e)
+
     @app.get("/api/usecases/{uid}/summary")
     async def usecase_summary(uid: str):
         try:

--- a/tares/daemon.py
+++ b/tares/daemon.py
@@ -2068,6 +2068,13 @@ def make_app() -> FastAPI:
         except Exception as e:
             _uc_err(e)
 
+    @app.post("/api/usecases/recipes/{key}/detect")
+    async def usecase_detect(key: str):
+        try:
+            return await usecases.detect(key)
+        except Exception as e:
+            _uc_err(e)
+
     @app.post("/api/usecases/{uid}/actions/{name}")
     async def usecase_action(uid: str, name: str, request: Request):
         try:

--- a/tares/usecases/__init__.py
+++ b/tares/usecases/__init__.py
@@ -10,6 +10,7 @@ from .base import PlannedObject, Recipe, UsecaseError
 from .engine import Engine
 from .registry import get_recipe, list_recipes, register
 from . import shared_code_context as _shared_code_context  # noqa: F401  (registers itself)
+from . import ai_sre_demo as _ai_sre_demo  # noqa: F401  (registers itself)
 
 __all__ = ["Engine", "PlannedObject", "Recipe", "UsecaseError",
            "get_recipe", "list_recipes", "register"]

--- a/tares/usecases/ai_sre_demo.py
+++ b/tares/usecases/ai_sre_demo.py
@@ -51,8 +51,9 @@ class AiSreDemo(Recipe):
     }
 
     SETUP = [
-        {"title": "Start the demo stack",
-         "text": "Docker Desktop running. Two files, no checkout needed.",
+        {"title": "Start the demo stack", "check": "detect",
+         "text": "Docker Desktop running. Two files, no checkout needed. The form below fills itself "
+                 "from what is running.",
          "command": "curl -O https://raw.githubusercontent.com/glassflow/tares/main/demo/docker-compose.yml\n"
                     "docker compose up -d"},
         {"title": "Check it is alive",
@@ -133,6 +134,43 @@ class AiSreDemo(Recipe):
             agent["model"] = params["model"]
         objs.append(PlannedObject("agent", "agent", agent))
         return objs
+
+    # ── detect: ask Docker what is running instead of assuming ports ─────────
+    async def detect(self, store, runtime) -> dict:
+        from ..discovery import _docker_ps, _published_port
+        out = {"params": {}, "found": {}, "missing": {}, "notes": []}
+        try:
+            containers = await _docker_ps()
+        except ValueError as e:
+            out["notes"].append(str(e))
+            for k in ("prometheus_url", "api_server_url", "container"):
+                out["missing"][k] = "Docker not reachable; using the default"
+            return out
+        api = next((c for c in containers if "tares-demo-api-server" in c["image"]
+                    or c["name"] == "tares-demo-api-server"), None)
+        prom = next((c for c in containers if "prom/prometheus" in c["image"]
+                     or _published_port(c["ports"], 9090)), None)
+        if api:
+            port = _published_port(api["ports"], 8080)
+            if port:
+                out["params"]["api_server_url"] = f"http://localhost:{port}"
+                out["found"]["api_server_url"] = f"container {api['name']} publishes port {port}"
+            else:
+                out["missing"]["api_server_url"] = f"container {api['name']} runs but publishes no port 8080"
+            out["params"]["container"] = api["name"]
+            out["found"]["container"] = f"container {api['name']} (image {api['image'].split('/')[-1]})"
+        else:
+            out["missing"]["api_server_url"] = "no demo api-server container is running; start the demo stack"
+            out["missing"]["container"] = "no demo api-server container is running"
+        if prom:
+            port = _published_port(prom["ports"], 9090) or 9090
+            out["params"]["prometheus_url"] = f"http://localhost:{port}"
+            out["found"]["prometheus_url"] = f"container {prom['name']} publishes port {port}"
+        else:
+            out["missing"]["prometheus_url"] = "no Prometheus container is running; start the demo stack"
+        if not containers:
+            out["notes"].append("Docker is running but no compose-managed containers were found")
+        return out
 
     # ── actions ──────────────────────────────────────────────────────────────
     def run_action(self, instance: dict, action: str, args: dict, store, runtime) -> dict:

--- a/tares/usecases/ai_sre_demo.py
+++ b/tares/usecases/ai_sre_demo.py
@@ -191,7 +191,8 @@ class AiSreDemo(Recipe):
         if r.status_code >= 300:
             raise UsecaseError(f"api-server answered {r.status_code} for {scenario}")
         msg = ("fault cleared; the alert resolves within about a minute" if scenario == "clear"
-               else f"{scenario} injected; watch Explore for the alert and the agent's finding")
+               else f"{scenario} injected; in about 30 seconds the alert fires, the trigger wakes the "
+                    f"agent, and its run appears under Runs below")
         return {"scenario": scenario, "message": msg}
 
     # ── summary ──────────────────────────────────────────────────────────────

--- a/tares/usecases/ai_sre_demo.py
+++ b/tares/usecases/ai_sre_demo.py
@@ -27,7 +27,9 @@ Produce a tight incident note: (1) what is failing and since when, (2) the most 
 tied to the specific evidence lines (which signal crossed, what the logs show), (3) a suggested \
 next action. If the timeline is too narrow, read a wider window (1h) once before concluding. Do \
 not speculate beyond the evidence; if it is inconclusive, say what you would look at next. Plain \
-sentences, no em dashes.
+sentences, no em dashes. The incident note is your final message and nothing else: reason through \
+tool calls, and only write the note once you have concluded; never narrate what you are about to \
+check.
 """
 
 
@@ -66,10 +68,20 @@ class AiSreDemo(Recipe):
 
     ACTIONS = [
         {"name": "inject", "label": "Cause an incident",
-         "help": "flips the api-server's fault switch; HighErrorRate, HighLatency or DependencyDown "
-                 "fires within about 30 seconds and the agent wakes",
-         "params": {"scenario": {"label": "scenario",
-                                 "options": ["error_spike", "latency", "dependency_outage"]}}},
+         "intro": "Break the demo api-server on purpose and watch the AI SRE work: the fault shows up "
+                  "in the metrics and logs, Prometheus fires an alert, the incident trigger wakes "
+                  "the agent, and its incident note lands under Runs.",
+         "help": "flips the api-server's fault switch; the matching Prometheus alert fires within "
+                 "about 30 seconds and the agent wakes",
+         "docs": {"label": "Build an AI SRE guide, step 4", "url": "https://docs.glassflow.ai/tares/guides/ai-sre#cause-an-incident-and-watch-the-sre-work"},
+         "params": {"scenario": {"label": "scenario", "options": [
+             {"value": "error_spike", "label": "error spike",
+              "help": "a share of requests start returning 5xx; the 5xx rate climbs and HighErrorRate fires"},
+             {"value": "latency", "label": "latency",
+              "help": "responses slow past the timeout; p99 climbs and HighLatency fires"},
+             {"value": "dependency_outage", "label": "dependency outage",
+              "help": "the api-server's database dependency goes down; dependency_up drops to 0 and DependencyDown fires"},
+         ]}}},
         {"name": "clear", "label": "Clear the fault",
          "help": "rolls the fault back; the alert resolves and a resolved event lands on the timeline"},
     ]

--- a/tares/usecases/ai_sre_demo.py
+++ b/tares/usecases/ai_sre_demo.py
@@ -57,9 +57,10 @@ class AiSreDemo(Recipe):
                     "docker compose up -d"},
         {"title": "Check it is alive",
          "command": "curl -s localhost:8080/api/stats\ncurl -s 'localhost:9090/api/v1/query?query=up'"},
-        {"title": "Give the agent a key",
-         "text": "The incident-first-look agent is a real agent: set an Anthropic key under Settings > "
-                 "Anthropic (or ANTHROPIC_API_KEY before tares up). Without one its runs log \"no key\"."},
+        {"title": "Give the agent a key", "check": "anthropic_key",
+         "text": "The incident-first-look agent is a real agent: it needs an Anthropic key. Set one here "
+                 "or under Settings > Anthropic (or ANTHROPIC_API_KEY before tares up). Without one its "
+                 "runs log \"no key\"."},
     ]
 
     ACTIONS = [

--- a/tares/usecases/ai_sre_demo.py
+++ b/tares/usecases/ai_sre_demo.py
@@ -35,9 +35,9 @@ class AiSreDemo(Recipe):
     key = "ai_sre_demo"
     title = "AI SRE demo"
     description = ("Watch a small demo system, correlate its metrics, logs and alerts on one timeline, "
-                   "and let an agent write the first incident note when Prometheus fires. The same setup "
-                   "as the Build an AI SRE guide, without importing a catalog.")
+                   "and let an agent write the first incident note when Prometheus fires.")
     tags = ("demo",)
+    guide = {"label": "Build an AI SRE guide", "url": "https://docs.glassflow.ai/tares/guides/ai-sre"}
 
     PARAMS = {
         "prometheus_url": {"type": "string", "default": "http://localhost:9090", "label": "Prometheus URL",

--- a/tares/usecases/ai_sre_demo.py
+++ b/tares/usecases/ai_sre_demo.py
@@ -1,0 +1,189 @@
+"""The AI SRE demo as a use case: the same six objects `demo/catalog.demo.yaml` seeds (three
+sources keyed by `service`, the `service_timeline` view, the `incident` trigger, the
+`incident-first-look` agent), created with one click in the console instead of importing the
+catalog. Same names on purpose, so the docs guide (docs.glassflow.ai/tares/guides/ai-sre) reads
+the same whichever way you set it up; an unowned object of the same name is adopted, never
+duplicated.
+
+The demo stack itself (api-server, Prometheus, traffic) is Docker on the user's machine and stays
+outside Tares: SETUP shows the two commands, and the `inject` action calls the api-server's fault
+switch so an incident can be caused and cleared from the use case page.
+"""
+from __future__ import annotations
+
+import httpx
+
+from .base import PlannedObject, Recipe, UsecaseError
+from .registry import register
+
+SCENARIOS = ("error_spike", "latency", "dependency_outage", "clear")
+
+PROMPT = """You are an SRE taking the first look when Prometheus fires an alert on api-server. You are \
+handed the correlated timeline: the firing alert (HighErrorRate / HighLatency / DependencyDown) \
+plus the signals behind it (5xx request rate, p99 latency, active DB connections, dependency \
+health) and the service's request logs. That is your evidence.
+
+Produce a tight incident note: (1) what is failing and since when, (2) the most likely cause, \
+tied to the specific evidence lines (which signal crossed, what the logs show), (3) a suggested \
+next action. If the timeline is too narrow, read a wider window (1h) once before concluding. Do \
+not speculate beyond the evidence; if it is inconclusive, say what you would look at next. Plain \
+sentences, no em dashes.
+"""
+
+
+class AiSreDemo(Recipe):
+    key = "ai_sre_demo"
+    title = "AI SRE demo"
+    description = ("Watch a small demo system, correlate its metrics, logs and alerts on one timeline, "
+                   "and let an agent write the first incident note when Prometheus fires. The same setup "
+                   "as the Build an AI SRE guide, without importing a catalog.")
+    tags = ("demo",)
+
+    PARAMS = {
+        "prometheus_url": {"type": "string", "default": "http://localhost:9090", "label": "Prometheus URL",
+                           "help": "the demo stack's Prometheus, as reachable from this Tares"},
+        "api_server_url": {"type": "string", "default": "http://localhost:8080", "label": "api-server URL",
+                           "help": "the demo api-server; used by the Cause an incident action"},
+        "container": {"type": "string", "default": "tares-demo-api-server", "label": "Log container",
+                      "help": "the api-server's Docker container name (fixed in docker-compose.yml)"},
+        "model": {"type": "string", "default": "", "label": "Model",
+                  "help": "model for the agent (empty = the instance default)"},
+    }
+
+    SETUP = [
+        {"title": "Start the demo stack",
+         "text": "Docker Desktop running. Two files, no checkout needed.",
+         "command": "curl -O https://raw.githubusercontent.com/glassflow/tares/main/demo/docker-compose.yml\n"
+                    "docker compose up -d"},
+        {"title": "Check it is alive",
+         "command": "curl -s localhost:8080/api/stats\ncurl -s 'localhost:9090/api/v1/query?query=up'"},
+        {"title": "Give the agent a key",
+         "text": "The incident-first-look agent is a real agent: set an Anthropic key under Settings > "
+                 "Anthropic (or ANTHROPIC_API_KEY before tares up). Without one its runs log \"no key\"."},
+    ]
+
+    ACTIONS = [
+        {"name": "inject", "label": "Cause an incident",
+         "help": "flips the api-server's fault switch; HighErrorRate, HighLatency or DependencyDown "
+                 "fires within about 30 seconds and the agent wakes",
+         "params": {"scenario": {"label": "scenario",
+                                 "options": ["error_spike", "latency", "dependency_outage"]}}},
+        {"name": "clear", "label": "Clear the fault",
+         "help": "rolls the fault back; the alert resolves and a resolved event lands on the timeline"},
+    ]
+
+    # ── params ───────────────────────────────────────────────────────────────
+    def validate(self, params: dict) -> dict:
+        p = super().validate(params)
+        for k in ("prometheus_url", "api_server_url"):
+            v = str(p.get(k) or self.PARAMS[k]["default"]).strip().rstrip("/")
+            if not v.startswith(("http://", "https://")):
+                raise UsecaseError(f"{k} must start with http:// or https://")
+            p[k] = v
+        p["container"] = str(p.get("container") or self.PARAMS["container"]["default"]).strip()
+        p["model"] = str(p.get("model") or "").strip()
+        return p
+
+    # ── plan: the demo catalog, verbatim ─────────────────────────────────────
+    def plan(self, params: dict) -> list[PlannedObject]:
+        prom = params["prometheus_url"]
+        objs = [
+            PlannedObject("source", "metrics", {
+                "name": "demo_metrics", "connector": "prometheus", "poll": "5s",
+                "config": {
+                    "url": prom,
+                    "queries": [
+                        {"promql": 'sum(rate(http_requests_total{status=~"5.."}[1m])) by (service)',
+                         "event_type": "5xx_rate", "text": "5xx rate {service}={val}/s"},
+                        {"promql": 'histogram_quantile(0.99, sum(rate(http_request_duration_milliseconds_bucket[2m])) by (le, service))',
+                         "event_type": "p99", "text": "p99 {service}={val}ms"},
+                        {"promql": "db_connections_active", "event_type": "db_active",
+                         "text": "db connections active={val}"},
+                        {"promql": "dependency_up", "event_type": "dependency",
+                         "text": "dependency {dependency} up={val}"},
+                    ],
+                    "labels": [{"name": "service", "const": "api-server", "primary": True},
+                               {"name": "value", "field": "value", "type": "number"}],
+                }}),
+            PlannedObject("source", "logs", {
+                "name": "demo_logs", "connector": "docker_logs", "poll": "5s",
+                "config": {"container": params["container"],
+                           "labels": [{"name": "service", "const": "api-server", "primary": True}]}}),
+            PlannedObject("source", "alerts", {
+                "name": "demo_alerts", "connector": "prometheus_alerts", "poll": "10s",
+                "config": {"url": prom,
+                           "labels": [{"name": "service", "field": "labels.service", "primary": True},
+                                      {"name": "alertname", "field": "labels.alertname"},
+                                      {"name": "severity", "field": "labels.severity"},
+                                      {"name": "state", "field": "state"},
+                                      {"name": "alert_active", "const": 1, "type": "number"}]}}),
+            PlannedObject("view", "view", {
+                "name": "service_timeline", "key_field": "service",
+                "sources": ["demo_logs", "demo_metrics", "demo_alerts"]}),
+            PlannedObject("trigger", "trigger", {
+                "name": "incident", "view": "service_timeline",
+                "condition": {"aggregate": "sum", "field": "alert_active", "predicate": "> 0",
+                              "window": "1m", "group_by": ["key_value"]},
+                "emit": {"kind": "incident", "attach_view": True, "context_window": "15m"},
+                "cooldown": "5m"}),
+        ]
+        agent = {"name": "incident-first-look", "trigger": "incident", "enabled": True, "prompt": PROMPT}
+        if params.get("model"):
+            agent["model"] = params["model"]
+        objs.append(PlannedObject("agent", "agent", agent))
+        return objs
+
+    # ── actions ──────────────────────────────────────────────────────────────
+    def run_action(self, instance: dict, action: str, args: dict, store, runtime) -> dict:
+        params = self.validate(instance["params"])
+        if action == "inject":
+            scenario = str(args.get("scenario") or "error_spike")
+            if scenario not in SCENARIOS or scenario == "clear":
+                raise UsecaseError(f"scenario must be one of {[s for s in SCENARIOS if s != 'clear']}")
+        elif action == "clear":
+            scenario = "clear"
+        else:
+            raise UsecaseError(f"{self.key}: no action {action!r}")
+        url = params["api_server_url"] + "/demo/inject"
+        try:
+            r = httpx.post(url, json={"scenario": scenario}, timeout=10)
+        except Exception as e:
+            raise UsecaseError(f"could not reach the demo api-server at {url}: {e}") from e
+        if r.status_code >= 300:
+            raise UsecaseError(f"api-server answered {r.status_code} for {scenario}")
+        msg = ("fault cleared; the alert resolves within about a minute" if scenario == "clear"
+               else f"{scenario} injected; watch Explore for the alert and the agent's finding")
+        return {"scenario": scenario, "message": msg}
+
+    # ── summary ──────────────────────────────────────────────────────────────
+    def summary(self, instance: dict, store) -> dict:
+        params = self.validate(instance["params"])
+        all_stats = {x["source"]: x for x in store.event_stats()}
+        stats = {}
+        for name in ("demo_metrics", "demo_logs", "demo_alerts"):
+            st = all_stats.get(name) or {}
+            stats[name] = {"events": int(st.get("events") or 0), "last": _iso(st.get("last_ingest"))}
+        runs = []
+        try:
+            for r in store.list_agent_runs("incident-first-look", limit=10):
+                runs.append({"id": r.get("id"), "started_at": _iso(r.get("started_at")),
+                             "key": r.get("key"), "repo": r.get("key"), "agent": "incident-first-look",
+                             "status": r.get("status"), "rounds": r.get("rounds"),
+                             "max_rounds": r.get("max_rounds"), "finding": r.get("finding"),
+                             "error": r.get("error")})
+        except Exception:
+            pass
+        last_fired = _iso(store.last_fired("incident", "api-server"))
+        return {"prometheus_url": params["prometheus_url"], "api_server_url": params["api_server_url"],
+                "container": params["container"], "sources": stats, "runs": runs,
+                "runs_total": len(runs), "last_fired": last_fired,
+                "guide": "https://docs.glassflow.ai/tares/guides/ai-sre"}
+
+
+def _iso(v):
+    if v is None:
+        return None
+    return v.isoformat() if hasattr(v, "isoformat") else str(v)
+
+
+register(AiSreDemo())

--- a/tares/usecases/base.py
+++ b/tares/usecases/base.py
@@ -80,6 +80,13 @@ class Recipe:
         instance and never undoes the create."""
         return None
 
+    async def detect(self, store, runtime) -> dict:
+        """Optional: look at the environment (running containers, reachable services) and propose
+        parameter values. Returns {"params": {name: value}, "found": {name: "where it came from"},
+        "missing": {name: "why not"}, "notes": [str]}; the wizard prefills what it can and says the
+        rest. Default: nothing detected."""
+        return {"params": {}, "found": {}, "missing": {}, "notes": []}
+
     def run_action(self, instance: dict, action: str, args: dict, store, runtime) -> dict:
         """Perform one of ACTIONS for a running instance; return what the page should show.
         Raise UsecaseError for a bad action or arguments."""

--- a/tares/usecases/base.py
+++ b/tares/usecases/base.py
@@ -44,6 +44,8 @@ class Recipe:
     # Free-form labels the console shows on the card ("demo" marks a use case that needs the demo
     # stack rather than your systems).
     tags: tuple = ()
+    # An optional walkthrough the console links next to the description: {label, url}.
+    guide: dict | None = None
     # Steps a user must do outside Tares before Start (start a stack, export a key), each
     # {title, text?, command?}; the wizard shows them above the Start button.
     SETUP: list = []
@@ -95,4 +97,4 @@ class Recipe:
     def describe(self) -> dict:
         return {"key": self.key, "title": self.title, "description": self.description,
                 "params": self.PARAMS, "tags": list(self.tags), "setup": list(self.SETUP),
-                "actions": list(self.ACTIONS)}
+                "actions": list(self.ACTIONS), "guide": dict(self.guide) if self.guide else None}

--- a/tares/usecases/base.py
+++ b/tares/usecases/base.py
@@ -41,6 +41,15 @@ class Recipe:
     title: str = ""
     description: str = ""
     PARAMS: dict = {}
+    # Free-form labels the console shows on the card ("demo" marks a use case that needs the demo
+    # stack rather than your systems).
+    tags: tuple = ()
+    # Steps a user must do outside Tares before Start (start a stack, export a key), each
+    # {title, text?, command?}; the wizard shows them above the Start button.
+    SETUP: list = []
+    # Buttons the instance page offers, each {name, label, help?, params?: {name: {label, options}}};
+    # the engine routes them to run_action().
+    ACTIONS: list = []
 
     def validate(self, params: dict) -> dict:
         """Check required params and fill defaults; return the normalized params. Recipes may
@@ -71,6 +80,12 @@ class Recipe:
         instance and never undoes the create."""
         return None
 
+    def run_action(self, instance: dict, action: str, args: dict, store, runtime) -> dict:
+        """Perform one of ACTIONS for a running instance; return what the page should show.
+        Raise UsecaseError for a bad action or arguments."""
+        raise UsecaseError(f"{self.key}: no action {action!r}")
+
     def describe(self) -> dict:
         return {"key": self.key, "title": self.title, "description": self.description,
-                "params": self.PARAMS}
+                "params": self.PARAMS, "tags": list(self.tags), "setup": list(self.SETUP),
+                "actions": list(self.ACTIONS)}

--- a/tares/usecases/engine.py
+++ b/tares/usecases/engine.py
@@ -199,6 +199,16 @@ class Engine:
         return {"ok": True, "deleted": [f"{o.kind}:{o.name}" for o in objs],
                 "purged_events": purged}
 
+    def action(self, uid: str, name: str, args: dict | None = None) -> dict:
+        """Run one of the recipe's ACTIONS on an instance and log it."""
+        inst = self._require(uid)
+        recipe = get_recipe(inst["recipe"])
+        if not any(a.get("name") == name for a in recipe.ACTIONS):
+            raise UsecaseError(f"{recipe.key}: no action {name!r}")
+        result = recipe.run_action(inst, name, dict(args or {}), self.store, self.runtime) or {}
+        self.store.log_usecase(uid, f"action:{name}", str(result.get("message", "")) if result else "")
+        return {"ok": True, "action": name, **result}
+
     def repair(self, uid: str, key: str) -> dict:
         """Re-apply one planned object from the current params: re-creates a hand-deleted object,
         or resets a customized one back to the plan (ownership is re-claimed either way)."""

--- a/tares/usecases/engine.py
+++ b/tares/usecases/engine.py
@@ -199,6 +199,10 @@ class Engine:
         return {"ok": True, "deleted": [f"{o.kind}:{o.name}" for o in objs],
                 "purged_events": purged}
 
+    async def detect(self, recipe_key: str) -> dict:
+        recipe = get_recipe(recipe_key)
+        return await recipe.detect(self.store, self.runtime)
+
     def action(self, uid: str, name: str, args: dict | None = None) -> dict:
         """Run one of the recipe's ACTIONS on an instance and log it."""
         inst = self._require(uid)

--- a/tests/test_ai_sre_demo.py
+++ b/tests/test_ai_sre_demo.py
@@ -1,0 +1,146 @@
+"""The AI SRE demo as a use case (TR-176): recipe shape, the six demo objects, adopting an
+existing unowned demo catalog, and the inject/clear actions against a fake api-server.
+Run: .venv/bin/python tests/test_ai_sre_demo.py   (no Docker needed)
+"""
+import asyncio
+import json
+import os
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+DB = "/tmp/tares-ai-sre-demo-test.duckdb"
+CATALOG = "/tmp/tares-ai-sre-demo-test.catalog.yaml"
+os.environ["TARES_DB"] = DB
+os.environ["TARES_CATALOG"] = CATALOG
+
+import httpx
+
+PASS = FAIL = 0
+
+
+def check(label, cond, detail=""):
+    global PASS, FAIL
+    if cond:
+        PASS += 1; print(f"  ok   {label}")
+    else:
+        FAIL += 1; print(f"  FAIL {label}  {detail}")
+
+
+# a fake api-server that records what /demo/inject receives
+INJECTED = []
+
+
+class FakeApi(BaseHTTPRequestHandler):
+    def log_message(self, *a):
+        pass
+
+    def do_POST(self):
+        n = int(self.headers.get("content-length") or 0)
+        body = json.loads(self.rfile.read(n) or b"{}")
+        if self.path == "/demo/inject":
+            INJECTED.append(body.get("scenario"))
+            self.send_response(200); self.end_headers(); self.wfile.write(b'{"ok":true}')
+        else:
+            self.send_response(404); self.end_headers()
+
+
+async def main():
+    for p in (DB, DB + ".wal", CATALOG):
+        if os.path.exists(p):
+            os.remove(p)
+    srv = HTTPServer(("127.0.0.1", 0), FakeApi)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    api_url = f"http://127.0.0.1:{srv.server_port}"
+
+    from tares.usecases import get_recipe
+    from tares.usecases.base import UsecaseError
+    r = get_recipe("ai_sre_demo")
+
+    print("== recipe ==")
+    d = r.describe()
+    check("tagged demo", d["tags"] == ["demo"])
+    check("setup steps and actions advertised", len(d["setup"]) == 3 and
+          [a["name"] for a in d["actions"]] == ["inject", "clear"])
+    p = r.validate({})
+    check("defaults", p["prometheus_url"] == "http://localhost:9090" and
+          p["container"] == "tares-demo-api-server", json.dumps(p))
+    try:
+        r.validate({"prometheus_url": "localhost:9090"}); check("bad url rejected", False)
+    except UsecaseError:
+        check("bad url rejected", True)
+    plan = r.plan(r.validate({"prometheus_url": "http://prom:9090/"}))
+    names = [(o.kind, o.name) for o in plan]
+    check("the six demo objects by their catalog names",
+          names == [("source", "demo_metrics"), ("source", "demo_logs"), ("source", "demo_alerts"),
+                    ("view", "service_timeline"), ("trigger", "incident"), ("agent", "incident-first-look")], str(names))
+    check("prometheus url applied without trailing slash",
+          plan[0].spec["config"]["url"] == "http://prom:9090" and plan[2].spec["config"]["url"] == "http://prom:9090")
+    check("agent prompt has no em dash", "—" not in plan[5].spec["prompt"])
+
+    from tares.daemon import make_app
+    app = make_app()
+    async with app.router.lifespan_context(app):
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as cx:
+            print("== adopt an existing demo catalog ==")
+            # a user who imported catalog.demo.yaml first: same names, unowned -> adopted, not duplicated
+            demo_yaml = open(os.path.join(os.path.dirname(__file__), "..", "demo", "catalog.demo.yaml")).read()
+            rr = await cx.post("/api/catalog/import", json={"yaml": demo_yaml, "mode": "merge"})
+            check("demo catalog imported", rr.status_code == 200, rr.text[:200])
+            before = {s["name"] for s in (await cx.get("/api/sources")).json()}
+
+            print("== create ==")
+            rr = await cx.post("/api/usecases", json={"recipe": "ai_sre_demo", "name": "AI SRE demo",
+                                                     "params": {"api_server_url": api_url}})
+            check("create -> 201", rr.status_code == 201, rr.text[:300])
+            inst = rr.json(); uid = inst["id"]
+            after = {s["name"] for s in (await cx.get("/api/sources")).json()}
+            check("no duplicate sources: adopted the existing ones", after == before, str(after ^ before))
+            srcs = {s["name"]: s for s in (await cx.get("/api/sources")).json()}
+            check("demo sources owned by the use case",
+                  all(srcs[n]["owned_by"] == uid for n in ("demo_metrics", "demo_logs", "demo_alerts")))
+            agents = (await cx.get("/api/agents/builtin")).json()["agents"]
+            a = next(x for x in agents if x["name"] == "incident-first-look")
+            check("agent owned and on the incident trigger", a["owned_by"] == uid and a["trigger"] == "incident")
+
+            print("== actions ==")
+            rr = await cx.post(f"/api/usecases/{uid}/actions/inject", json={"scenario": "latency"})
+            check("inject latency -> ok", rr.status_code == 200 and rr.json().get("scenario") == "latency", rr.text[:200])
+            rr = await cx.post(f"/api/usecases/{uid}/actions/inject", json={"scenario": "clear"})
+            check("inject rejects clear as a scenario", rr.status_code == 400, rr.text[:200])
+            rr = await cx.post(f"/api/usecases/{uid}/actions/clear", json={})
+            check("clear -> ok", rr.status_code == 200 and rr.json().get("scenario") == "clear", rr.text[:200])
+            rr = await cx.post(f"/api/usecases/{uid}/actions/nope", json={})
+            check("unknown action -> 400", rr.status_code == 400, rr.text[:200])
+            check("fake api-server received latency then clear", INJECTED == ["latency", "clear"], str(INJECTED))
+            log = (await cx.get(f"/api/usecases/{uid}/summary")).json()["log"]
+            check("actions logged", any(l["action"] == "action:inject" for l in log) and
+                  any(l["action"] == "action:clear" for l in log), str([l["action"] for l in log]))
+
+            print("== summary ==")
+            s = (await cx.get(f"/api/usecases/{uid}/summary")).json()
+            check("summary has sources, runs, guide",
+                  set(s["sources"]) == {"demo_metrics", "demo_logs", "demo_alerts"} and "runs" in s and s["guide"].endswith("/guides/ai-sre"),
+                  json.dumps({k: s.get(k) for k in ("sources", "guide")})[:300])
+
+            print("== unreachable api-server ==")
+            rr = await cx.put(f"/api/usecases/{uid}", json={"params": {"api_server_url": "http://127.0.0.1:1"}})
+            check("update ok", rr.status_code == 200, rr.text[:200])
+            rr = await cx.post(f"/api/usecases/{uid}/actions/inject", json={"scenario": "error_spike"})
+            check("inject with unreachable api-server -> 400 with a named reason",
+                  rr.status_code == 400 and "could not reach" in rr.text, rr.text[:200])
+
+            print("== delete ==")
+            rr = await cx.delete(f"/api/usecases/{uid}")
+            check("delete -> 200", rr.status_code == 200, rr.text[:200])
+            after = {s["name"] for s in (await cx.get("/api/sources")).json()}
+            check("demo sources gone", not ({"demo_metrics", "demo_logs", "demo_alerts"} & after), str(after))
+
+    srv.shutdown()
+    print(f"\n{PASS} passed, {FAIL} failed")
+    sys.exit(1 if FAIL else 0)
+
+
+asyncio.run(main())

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -275,6 +275,10 @@ export const api = {
     request<Usecase>(`/api/usecases/${encodeURIComponent(id)}/pause`, { method: "POST" }),
   resumeUsecase: (id: string) =>
     request<Usecase>(`/api/usecases/${encodeURIComponent(id)}/resume`, { method: "POST" }),
+  usecaseAction: (id: string, name: string, args: Record<string, unknown> = {}) =>
+    request<{ ok: boolean; action: string; message?: string }>(
+      `/api/usecases/${encodeURIComponent(id)}/actions/${encodeURIComponent(name)}`,
+      { method: "POST", body: JSON.stringify(args) }),
   repairUsecase: (id: string, key: string) =>
     request<Usecase>(`/api/usecases/${encodeURIComponent(id)}/repair`,
       { method: "POST", body: JSON.stringify({ key }) }),

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -275,6 +275,9 @@ export const api = {
     request<Usecase>(`/api/usecases/${encodeURIComponent(id)}/pause`, { method: "POST" }),
   resumeUsecase: (id: string) =>
     request<Usecase>(`/api/usecases/${encodeURIComponent(id)}/resume`, { method: "POST" }),
+  detectRecipe: (key: string) =>
+    request<{ params: Record<string, unknown>; found: Record<string, string>; missing: Record<string, string>; notes: string[] }>(
+      `/api/usecases/recipes/${encodeURIComponent(key)}/detect`, { method: "POST" }),
   usecaseAction: (id: string, name: string, args: Record<string, unknown> = {}) =>
     request<{ ok: boolean; action: string; message?: string }>(
       `/api/usecases/${encodeURIComponent(id)}/actions/${encodeURIComponent(name)}`,

--- a/ui/src/pages/UsecaseDetail.tsx
+++ b/ui/src/pages/UsecaseDetail.tsx
@@ -1,10 +1,10 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 
 import { api } from "../api";
-import { ErrorState, TimeAgo, usePolling } from "../components/bits";
+import { ErrorState, Picker, TimeAgo, usePolling } from "../components/bits";
 import ConfirmDialog from "../components/ConfirmDialog";
-import type { UsecaseObject, UsecaseSummary } from "../types";
+import type { Recipe, UsecaseObject, UsecaseSummary } from "../types";
 
 // One use case instance: what it created, what it has done lately, and the actions on the whole
 // (pause, resume, edit, delete). The objects are ordinary; this page is the combined view of them,
@@ -36,6 +36,25 @@ function prLink(r: { pr_url?: string | null; finding?: string | null }): string 
   return m?.[0];
 }
 
+const HOW_IT_WORKS: Record<string, string[]> = {
+  shared_code_context: [
+    "Each source repo is a commits source keyed by repo; the view puts every repo on its own timeline.",
+    "The trigger fires when commits land, once per repo per cooldown, with the recent commits attached.",
+    "The agent reads each diff through the GitHub MCP server, updates the context repo, and writes a finding on the timeline.",
+    "Pause stops the trigger and agent; sources keep ingesting so the timeline stays complete.",
+  ],
+  ai_sre_demo: [
+    "Three sources keyed by service: Prometheus metrics, the api-server's container logs, and the alerts Prometheus's own rules fire.",
+    "The service_timeline view merges them on one clock; Explore shows exactly what an agent reads.",
+    "The incident trigger fires when an alert event lands (Prometheus keeps owning alerting; nothing is re-thresholded).",
+    "incident-first-look wakes with the correlated timeline and writes an incident note back onto it. Cause an incident above and watch it happen.",
+  ],
+  default: [
+    "The use case created ordinary sources, views, triggers and agents; see Configuration for the list.",
+    "Pause stops the trigger and agent; sources keep ingesting so the timeline stays complete.",
+  ],
+};
+
 export default function UsecaseDetail() {
   const { id = "" } = useParams();
   const navigate = useNavigate();
@@ -46,6 +65,22 @@ export default function UsecaseDetail() {
   const [confirmDel, setConfirmDel] = useState(false);
   const [purge, setPurge] = useState(false);
   const [busyKey, setBusyKey] = useState<string>();
+  const [recipe, setRecipe] = useState<Recipe>();
+  const [actionArgs, setActionArgs] = useState<Record<string, string>>({});
+  const [actionMsg, setActionMsg] = useState<string>();
+  const [actionBusy, setActionBusy] = useState<string>();
+  useEffect(() => {
+    if (!s?.recipe) return;
+    api.recipes().then((r) => setRecipe(r.recipes.find((x) => x.key === s.recipe))).catch(() => {});
+  }, [s?.recipe]);
+  const runAction = async (name: string, params?: Record<string, { options?: string[] }>) => {
+    setActionBusy(name); setActionError(undefined); setActionMsg(undefined);
+    const args: Record<string, unknown> = {};
+    for (const [k, spec] of Object.entries(params ?? {})) args[k] = actionArgs[`${name}.${k}`] ?? spec.options?.[0];
+    try { const r = await api.usecaseAction(id, name, args); setActionMsg(r.message); reload(); }
+    catch (e) { setActionError(String((e as Error).message ?? e)); }
+    setActionBusy(undefined);
+  };
 
   const act = (fn: () => Promise<unknown>) => async () => {
     setActionError(undefined);
@@ -106,12 +141,12 @@ export default function UsecaseDetail() {
       )}
 
       <div className="cards">
-        <div className="card"><div className="k">repos</div><div className="v">{repos ? repos.length : sourceObjects.length}</div></div>
+        <div className="card"><div className="k">{repos ? "repos" : "sources"}</div><div className="v">{repos ? repos.length : sourceObjects.length}</div></div>
         <div className="card"><div className="k">runs</div><div className="v">{typeof s.runs_total === "number" ? <>{s.runs_total} {typeof s.runs_ok === "number" && <small>{s.runs_ok} ok</small>}</> : runs ? runs.length : <span className="dim">—</span>}</div></div>
-        <div className="card">
+        {(s.prs || typeof s.prs_opened === "number") && <div className="card">
           <div className="k">pull requests</div>
           <div className="v">{s.prs ? <>{s.prs.open ?? 0} <small>open</small> {s.prs.merged ?? 0} <small>merged</small></> : typeof s.prs_opened === "number" ? <>{s.prs_opened} <small>opened</small></> : <span className="dim">—</span>}</div>
-        </div>
+        </div>}
         <div className="card"><div className="k">trigger last fired</div><div className="v" style={{ fontSize: 15 }}><TimeAgo ts={s.trigger_last_fired ?? s.last_fired ?? null} /></div></div>
         <div className="card"><div className="k">created</div><div className="v" style={{ fontSize: 15 }}><TimeAgo ts={s.created_at} /></div></div>
       </div>
@@ -120,12 +155,29 @@ export default function UsecaseDetail() {
       <details className="panel uc-how" style={{ marginBottom: 14 }}>
         <summary>How it works</summary>
         <ol className="help" style={{ margin: "8px 0 0", paddingLeft: 20 }}>
-          <li>Each source repo is a commits source keyed by repo; the view puts every repo on its own timeline.</li>
-          <li>The trigger fires when commits land, once per repo per cooldown, with the recent commits attached.</li>
-          <li>The agent reads each diff through the GitHub MCP server, updates that repo's page in the context repo, and writes a finding on the timeline.</li>
-          <li>Pause stops the trigger and agent; sources keep ingesting so the timeline stays complete.</li>
+          {(HOW_IT_WORKS[s.recipe] ?? HOW_IT_WORKS.default).map((t) => <li key={t}>{t}</li>)}
         </ol>
       </details>
+
+      {recipe?.actions && recipe.actions.length > 0 && (
+        <div className="panel" style={{ marginBottom: 14 }}>
+          <div className="uc-actions">
+            {recipe.actions.map((a) => (
+              <span key={a.name} className="uc-actions" title={a.help}>
+                {Object.entries(a.params ?? {}).map(([k, spec]) => (
+                  <Picker key={k} value={actionArgs[`${a.name}.${k}`] ?? spec.options?.[0] ?? ""}
+                          onChange={(v) => setActionArgs({ ...actionArgs, [`${a.name}.${k}`]: v })}
+                          options={spec.options ?? []} ariaLabel={spec.label ?? k} style={{ width: 200 }} />
+                ))}
+                <button className="primary" disabled={!!actionBusy || s.status !== "active"} onClick={() => runAction(a.name, a.params)}>
+                  {actionBusy === a.name ? "working…" : a.label}
+                </button>
+              </span>
+            ))}
+            {actionMsg && <span className="help">{actionMsg}</span>}
+          </div>
+        </div>
+      )}
 
       <div className="tabs">
         <button className={tab === "runs" ? "active" : ""} onClick={() => setTab("runs")}>Runs</button>
@@ -184,6 +236,24 @@ export default function UsecaseDetail() {
       </>)}
 
       {tab === "config" && (<>
+      {s.sources && (
+        <div className="panel">
+          <h2 style={{ marginTop: 0 }}>Sources</h2>
+          <table>
+            <thead><tr><th>source</th><th>events</th><th>last event</th></tr></thead>
+            <tbody>
+              {Object.entries(s.sources).map(([name, st]) => (
+                <tr key={name}>
+                  <td><Link to={`/sources/${encodeURIComponent(name)}`} className="mono">{name}</Link></td>
+                  <td>{st.events}</td>
+                  <td><TimeAgo ts={st.last ?? null} /></td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          {s.guide && <p className="help" style={{ marginBottom: 0 }}>Walkthrough: <a href={s.guide} target="_blank" rel="noreferrer">{s.guide}</a></p>}
+        </div>
+      )}
       {(s.context_repo || typeof p.context_repo === "string") && (
         <div className="panel">
           <h2 style={{ marginTop: 0 }}>Context repo</h2>
@@ -202,6 +272,7 @@ export default function UsecaseDetail() {
         </div>
       )}
 
+      {!s.sources && (
       <div className="panel">
         <h2 style={{ marginTop: 0 }}>Source repos</h2>
         {repos && repos.length > 0 ? (
@@ -235,6 +306,7 @@ export default function UsecaseDetail() {
           </table>
         ) : <div className="empty">no sources yet</div>}
       </div>
+      )}
 
       <div className="panel">
         <h2 style={{ marginTop: 0 }}>What it created</h2>

--- a/ui/src/pages/UsecaseDetail.tsx
+++ b/ui/src/pages/UsecaseDetail.tsx
@@ -4,7 +4,8 @@ import { Link, useNavigate, useParams } from "react-router-dom";
 import { api } from "../api";
 import { ErrorState, Picker, TimeAgo, usePolling } from "../components/bits";
 import ConfirmDialog from "../components/ConfirmDialog";
-import type { Recipe, UsecaseObject, UsecaseSummary } from "../types";
+import type { Recipe, RecipeActionOption, UsecaseObject, UsecaseSummary } from "../types";
+import InfoDialog, { HelpButton } from "../components/InfoDialog";
 
 // One use case instance: what it created, what it has done lately, and the actions on the whole
 // (pause, resume, edit, delete). The objects are ordinary; this page is the combined view of them,
@@ -69,14 +70,17 @@ export default function UsecaseDetail() {
   const [actionArgs, setActionArgs] = useState<Record<string, string>>({});
   const [actionMsg, setActionMsg] = useState<string>();
   const [actionBusy, setActionBusy] = useState<string>();
+  const [actionHelp, setActionHelp] = useState(false);
   useEffect(() => {
     if (!s?.recipe) return;
     api.recipes().then((r) => setRecipe(r.recipes.find((x) => x.key === s.recipe))).catch(() => {});
   }, [s?.recipe]);
-  const runAction = async (name: string, params?: Record<string, { options?: string[] }>) => {
+  const opts = (o?: (string | RecipeActionOption)[]): RecipeActionOption[] =>
+    (o ?? []).map((x) => (typeof x === "string" ? { value: x } : x));
+  const runAction = async (name: string, params?: Record<string, { options?: (string | RecipeActionOption)[] }>) => {
     setActionBusy(name); setActionError(undefined); setActionMsg(undefined);
     const args: Record<string, unknown> = {};
-    for (const [k, spec] of Object.entries(params ?? {})) args[k] = actionArgs[`${name}.${k}`] ?? spec.options?.[0];
+    for (const [k, spec] of Object.entries(params ?? {})) args[k] = actionArgs[`${name}.${k}`] ?? opts(spec.options)[0]?.value;
     try { const r = await api.usecaseAction(id, name, args); setActionMsg(r.message); reload(); }
     catch (e) { setActionError(String((e as Error).message ?? e)); }
     setActionBusy(undefined);
@@ -161,14 +165,25 @@ export default function UsecaseDetail() {
 
       {recipe?.actions && recipe.actions.length > 0 && (
         <div className="panel" style={{ marginBottom: 14 }}>
+          {recipe.actions.some((a) => a.intro) && (
+            <p className="help" style={{ margin: "0 0 10px" }}>
+              {recipe.actions.find((a) => a.intro)?.intro}
+              <HelpButton onClick={() => setActionHelp(true)} label="What do these do?" />
+            </p>
+          )}
           <div className="uc-actions">
             {recipe.actions.map((a) => (
               <span key={a.name} className="uc-actions" title={a.help}>
-                {Object.entries(a.params ?? {}).map(([k, spec]) => (
-                  <Picker key={k} value={actionArgs[`${a.name}.${k}`] ?? spec.options?.[0] ?? ""}
-                          onChange={(v) => setActionArgs({ ...actionArgs, [`${a.name}.${k}`]: v })}
-                          options={spec.options ?? []} ariaLabel={spec.label ?? k} style={{ width: 200 }} />
-                ))}
+                {Object.entries(a.params ?? {}).map(([k, spec]) => {
+                  const o = opts(spec.options);
+                  return (
+                    <Picker key={k} value={actionArgs[`${a.name}.${k}`] ?? o[0]?.value ?? ""}
+                            onChange={(v) => setActionArgs({ ...actionArgs, [`${a.name}.${k}`]: v })}
+                            options={o.map((x) => x.value)}
+                            labels={Object.fromEntries(o.map((x) => [x.value, x.label ?? x.value]))}
+                            ariaLabel={spec.label ?? k} style={{ width: 200 }} />
+                  );
+                })}
                 <button className="primary" disabled={!!actionBusy || s.status !== "active"} onClick={() => runAction(a.name, a.params)}>
                   {actionBusy === a.name ? "working…" : a.label}
                 </button>
@@ -176,7 +191,38 @@ export default function UsecaseDetail() {
             ))}
             {actionMsg && <span className="help">{actionMsg}</span>}
           </div>
+          {(() => {
+            const cur = recipe.actions.find((a) => a.params?.scenario);
+            const o = cur ? opts(cur.params!.scenario.options) : [];
+            const sel = cur ? (actionArgs[`${cur.name}.scenario`] ?? o[0]?.value) : undefined;
+            const h = o.find((x) => x.value === sel)?.help;
+            return h ? <p className="help" style={{ margin: "8px 0 0" }}>{h}</p> : null;
+          })()}
         </div>
+      )}
+
+      {actionHelp && recipe?.actions && (
+        <InfoDialog title="Causing an incident" onClose={() => setActionHelp(false)}>
+          {recipe.actions.filter((a) => a.intro).map((a) => <p key={a.name} className="help" style={{ margin: 0 }}>{a.intro}</p>)}
+          {recipe.actions.filter((a) => a.params?.scenario).map((a) => (
+            <table key={a.name} className="perm-table">
+              <thead><tr><th>scenario</th><th>what happens</th></tr></thead>
+              <tbody>
+                {opts(a.params!.scenario.options).map((x) => (
+                  <tr key={x.value}><td className="mono">{x.value}</td><td>{x.help ?? ""}</td></tr>
+                ))}
+              </tbody>
+            </table>
+          ))}
+          <ul className="help" style={{ margin: 0, paddingLeft: 18 }}>
+            {recipe.actions.filter((a) => a.help).map((a) => <li key={a.name}><strong>{a.label}</strong>: {a.help}</li>)}
+          </ul>
+          {recipe.actions.find((a) => a.docs)?.docs && (
+            <p className="help" style={{ margin: 0 }}>
+              Walkthrough: <a href={recipe.actions.find((a) => a.docs)!.docs!.url} target="_blank" rel="noreferrer">{recipe.actions.find((a) => a.docs)!.docs!.label}</a>
+            </p>
+          )}
+        </InfoDialog>
       )}
 
       <div className="tabs">

--- a/ui/src/pages/UsecaseNewGeneric.tsx
+++ b/ui/src/pages/UsecaseNewGeneric.tsx
@@ -30,8 +30,23 @@ export default function UsecaseNewGeneric() {
   const [name, setName] = useState("");
   const [vals, setVals] = useState<Record<string, string>>({});
   const [busy, setBusy] = useState(false);
+  const [models, setModels] = useState<string[]>([]);
+  const [defaultModel, setDefaultModel] = useState("");
+  const [keyStatus, setKeyStatus] = useState<{ configured: boolean; source: string }>();
+  const [keyInput, setKeyInput] = useState("");
+  const [keyBusy, setKeyBusy] = useState(false);
+  const [keyErr, setKeyErr] = useState<string>();
+  const loadKey = () => api.anthropicKeyStatus().then((k) => setKeyStatus(k)).catch(() => setKeyStatus(undefined));
+  const saveKey = async () => {
+    setKeyBusy(true); setKeyErr(undefined);
+    try { await api.setAnthropicKey(keyInput.trim()); setKeyInput(""); await loadKey(); }
+    catch (e) { setKeyErr(String((e as Error).message ?? e)); }
+    setKeyBusy(false);
+  };
 
   useEffect(() => {
+    loadKey();
+    api.builtinAgents().then((r) => { setModels(r.models); setDefaultModel(r.default_model); }).catch(() => {});
     api.recipes().then((r) => {
       const found = r.recipes.find((x) => x.key === key);
       if (!found) { setErr(`this instance has no use case named ${key}`); return; }
@@ -73,10 +88,32 @@ export default function UsecaseNewGeneric() {
         <div className="panel">
           <h2 style={{ marginTop: 0 }}>Before you start</h2>
           <ol className="uc-setup">
-            {recipe.setup.map((st, i) => (
-              <li key={i}>
-                <div className="uc-setup-title">{st.title}</div>
-                {st.text && <p className="help" style={{ margin: "2px 0 6px" }}>{st.text}</p>}
+            {recipe.setup.map((st, i) => {
+              const keyStep = st.check === "anthropic_key";
+              const done = keyStep && keyStatus?.configured;
+              return (
+              <li key={i} className={done ? "uc-setup-done" : undefined}>
+                <div className="uc-setup-title">
+                  {st.title}
+                  {done && <span className="badge ok" style={{ marginLeft: 8 }}>done</span>}
+                </div>
+                {done ? (
+                  <p className="help" style={{ margin: "2px 0 0" }}>
+                    an Anthropic key is set{keyStatus?.source ? ` (${keyStatus.source})` : ""}; the agent can run. Change it under Settings.
+                  </p>
+                ) : (
+                  <>
+                    {st.text && <p className="help" style={{ margin: "2px 0 6px" }}>{st.text}</p>}
+                    {keyStep && (
+                      <div className="btnrow" style={{ alignItems: "center", maxWidth: 640 }}>
+                        <input type="password" className="mono" style={{ flex: 1 }} autoComplete="new-password" data-1p-ignore data-lpignore="true"
+                               placeholder="sk-ant-..." value={keyInput} onChange={(e) => setKeyInput(e.target.value)} />
+                        <button className="primary" disabled={keyBusy || !keyInput.trim()} onClick={saveKey}>{keyBusy ? "saving..." : "Save key"}</button>
+                        {keyErr && <span className="help" style={{ color: "var(--err)" }}>{keyErr}</span>}
+                      </div>
+                    )}
+                  </>
+                )}
                 {st.command && (
                   <div className="uc-setup-cmd">
                     <pre className="mono">{st.command}</pre>
@@ -84,7 +121,8 @@ export default function UsecaseNewGeneric() {
                   </div>
                 )}
               </li>
-            ))}
+              );
+            })}
           </ol>
         </div>
       )}
@@ -100,6 +138,11 @@ export default function UsecaseNewGeneric() {
               {p.type === "bool" ? (
                 <Picker value={vals[k] ?? "false"} onChange={(v) => setVals({ ...vals, [k]: v })}
                         options={["true", "false"]} ariaLabel={k} />
+              ) : k === "model" ? (
+                <Picker value={vals[k] ?? ""} onChange={(v) => setVals({ ...vals, [k]: v })}
+                        options={["", ...models.filter((m) => m !== defaultModel)]}
+                        labels={{ "": defaultModel ? `${defaultModel} · instance default` : "instance default" }}
+                        ariaLabel="model" />
               ) : p.choices?.length ? (
                 <Picker value={vals[k] ?? ""} onChange={(v) => setVals({ ...vals, [k]: v })}
                         options={p.choices} ariaLabel={k} />

--- a/ui/src/pages/UsecaseNewGeneric.tsx
+++ b/ui/src/pages/UsecaseNewGeneric.tsx
@@ -13,6 +13,15 @@ function initial(p: RecipeParam): string {
   return typeof p.default === "string" ? p.default : JSON.stringify(p.default);
 }
 
+function CopyBtn({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <button type="button" onClick={() => { navigator.clipboard?.writeText(text); setCopied(true); setTimeout(() => setCopied(false), 1500); }}>
+      {copied ? "copied" : "copy"}
+    </button>
+  );
+}
+
 export default function UsecaseNewGeneric() {
   const { recipe: key = "" } = useParams();
   const navigate = useNavigate();
@@ -60,6 +69,25 @@ export default function UsecaseNewGeneric() {
         </div>
       </div>
       {err && <div className="alert error">{err}</div>}
+      {recipe && recipe.setup && recipe.setup.length > 0 && (
+        <div className="panel">
+          <h2 style={{ marginTop: 0 }}>Before you start</h2>
+          <ol className="uc-setup">
+            {recipe.setup.map((st, i) => (
+              <li key={i}>
+                <div className="uc-setup-title">{st.title}</div>
+                {st.text && <p className="help" style={{ margin: "2px 0 6px" }}>{st.text}</p>}
+                {st.command && (
+                  <div className="uc-setup-cmd">
+                    <pre className="mono">{st.command}</pre>
+                    <CopyBtn text={st.command} />
+                  </div>
+                )}
+              </li>
+            ))}
+          </ol>
+        </div>
+      )}
       {recipe && (
         <div className="panel">
           <label className="field">

--- a/ui/src/pages/UsecaseNewGeneric.tsx
+++ b/ui/src/pages/UsecaseNewGeneric.tsx
@@ -30,6 +30,21 @@ export default function UsecaseNewGeneric() {
   const [name, setName] = useState("");
   const [vals, setVals] = useState<Record<string, string>>({});
   const [busy, setBusy] = useState(false);
+  const [detected, setDetected] = useState<{ params: Record<string, unknown>; found: Record<string, string>; missing: Record<string, string>; notes: string[] }>();
+  const [detectBusy, setDetectBusy] = useState(false);
+  const detect = async (rk: string, current: Record<string, string>) => {
+    setDetectBusy(true);
+    try {
+      const d = await api.detectRecipe(rk);
+      setDetected(d);
+      setVals((v) => {
+        const next = { ...current, ...v };
+        for (const [k, val] of Object.entries(d.params)) next[k] = typeof val === "string" ? val : JSON.stringify(val);
+        return next;
+      });
+    } catch { setDetected(undefined); }
+    setDetectBusy(false);
+  };
   const [models, setModels] = useState<string[]>([]);
   const [defaultModel, setDefaultModel] = useState("");
   const [keyStatus, setKeyStatus] = useState<{ configured: boolean; source: string }>();
@@ -52,7 +67,9 @@ export default function UsecaseNewGeneric() {
       if (!found) { setErr(`this instance has no use case named ${key}`); return; }
       setRecipe(found);
       setName(found.title);
-      setVals(Object.fromEntries(Object.entries(found.params).map(([k, p]) => [k, initial(p)])));
+      const init = Object.fromEntries(Object.entries(found.params).map(([k, p]) => [k, initial(p)]));
+      setVals(init);
+      detect(found.key, init);
     }).catch((e) => setErr(String((e as Error).message ?? e)));
   }, [key]);
 
@@ -90,7 +107,9 @@ export default function UsecaseNewGeneric() {
           <ol className="uc-setup">
             {recipe.setup.map((st, i) => {
               const keyStep = st.check === "anthropic_key";
-              const done = keyStep && keyStatus?.configured;
+              const detectStep = st.check === "detect";
+              const detectDone = !!detected && Object.keys(detected.found).length > 0 && Object.keys(detected.missing).length === 0;
+              const done = (keyStep && keyStatus?.configured) || (detectStep && detectDone);
               return (
               <li key={i} className={done ? "uc-setup-done" : undefined}>
                 <div className="uc-setup-title">
@@ -99,7 +118,9 @@ export default function UsecaseNewGeneric() {
                 </div>
                 {done ? (
                   <p className="help" style={{ margin: "2px 0 0" }}>
-                    an Anthropic key is set{keyStatus?.source ? ` (${keyStatus.source})` : ""}; the agent can run. Change it under Settings.
+                    {keyStep
+                      ? <>an Anthropic key is set{keyStatus?.source ? ` (${keyStatus.source})` : ""}; the agent can run. Change it under Settings.</>
+                      : <>running: {Array.from(new Set(Object.values(detected?.found ?? {}).map((v) => v.split(" (")[0].split(" publishes")[0]))).join(", ")}; the fields below were filled from it</>}
                   </p>
                 ) : (
                   <>
@@ -154,8 +175,16 @@ export default function UsecaseNewGeneric() {
                        onChange={(e) => setVals({ ...vals, [k]: e.target.value })} />
               )}
               {p.help && <span className="help">{p.help}</span>}
+              {detected?.found[k] && <span className="help" style={{ color: "var(--ok)" }}>detected: {detected.found[k]}</span>}
+              {detected?.missing[k] && <span className="help" style={{ color: "var(--warn, var(--err))" }}>not detected: {detected.missing[k]}</span>}
             </label>
           ))}
+          {detected && (
+            <div className="btnrow" style={{ marginBottom: 12 }}>
+              <button onClick={() => recipe && detect(recipe.key, vals)} disabled={detectBusy}>{detectBusy ? "scanning…" : "Rescan"}</button>
+              {detected.notes.map((n) => <span key={n} className="help">{n}</span>)}
+            </div>
+          )}
           <div className="btnrow">
             <button className="primary" disabled={busy} onClick={submit}>{busy ? "starting…" : "Start"}</button>
             <Link className="btn" to="/usecases">Cancel</Link>

--- a/ui/src/pages/UsecaseNewGeneric.tsx
+++ b/ui/src/pages/UsecaseNewGeneric.tsx
@@ -97,7 +97,10 @@ export default function UsecaseNewGeneric() {
       <div className="pagehead">
         <div>
           <h1>{recipe?.title ?? key}</h1>
-          <p className="subtitle">{recipe?.description}</p>
+          <p className="subtitle">
+            {recipe?.description}
+            {recipe?.guide && <> Follows the <a href={recipe.guide.url} target="_blank" rel="noreferrer">{recipe.guide.label}</a>.</>}
+          </p>
         </div>
       </div>
       {err && <div className="alert error">{err}</div>}

--- a/ui/src/pages/Usecases.tsx
+++ b/ui/src/pages/Usecases.tsx
@@ -27,6 +27,10 @@ export function usecaseKindCounts(u: Usecase) {
 // What each recipe wires up, in the user's words. Keyed by recipe so a new recipe without an
 // entry still gets a card, just without the "what it sets up" column.
 const RECIPE_FACTS: Record<string, { you: string[]; tares: string[] }> = {
+  ai_sre_demo: {
+    you: ["start the demo stack with docker compose", "give the agent an Anthropic key", "cause an incident from the use case page"],
+    tares: ["three sources keyed by service: Prometheus metrics, the api-server's logs, the alerts Prometheus fires", "one timeline per service to explore", "a trigger that wakes the agent when an alert fires", "an agent that writes the first incident note back onto the timeline"],
+  },
   shared_code_context: {
     you: ["pick the code repos to watch", "pick the repo that holds the shared context", "choose when it runs and how it writes"],
     tares: ["a source for each repo, so its commits flow into Tares", "a timeline per repo you can explore and query", "a trigger that wakes the agent when new commits land", "an agent that reads each change and updates the context repo, opening a pull request"],
@@ -40,7 +44,10 @@ function RecipeCard({ r }: { r: Recipe }) {
   return (
     <div className="panel uc-card">
       <div className="uc-card-main">
-        <div className="uc-card-title">{r.title}</div>
+        <div className="uc-card-title">
+          {r.title}
+          {(r.tags ?? []).map((t) => <span key={t} className="badge" style={{ marginLeft: 8, verticalAlign: "middle" }}>{t}</span>)}
+        </div>
         <p className="help uc-card-desc">{r.description}</p>
         {facts && (
           <div className="uc-card-facts">

--- a/ui/src/pages/Usecases.tsx
+++ b/ui/src/pages/Usecases.tsx
@@ -48,7 +48,10 @@ function RecipeCard({ r }: { r: Recipe }) {
           {r.title}
           {(r.tags ?? []).map((t) => <span key={t} className="badge" style={{ marginLeft: 8, verticalAlign: "middle" }}>{t}</span>)}
         </div>
-        <p className="help uc-card-desc">{r.description}</p>
+        <p className="help uc-card-desc">
+          {r.description}
+          {r.guide && <> Follows the <a href={r.guide.url} target="_blank" rel="noreferrer">{r.guide.label}</a>.</>}
+        </p>
         {facts && (
           <div className="uc-card-facts">
             <div>

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -1333,3 +1333,4 @@ pre.payload {
 .uc-setup-cmd { display: flex; align-items: flex-start; gap: 10px; }
 .uc-setup-cmd pre { margin: 0; padding: 8px 10px; border: 1px solid var(--line); background: var(--wash); font-size: 12px; flex: 1; overflow-x: auto; white-space: pre; }
 .uc-actions { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; }
+.uc-setup-done .uc-setup-title { color: var(--ink-soft); }

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -1326,3 +1326,10 @@ pre.payload {
 .help-btn:hover { color: var(--ink); border-color: var(--border-strong); }
 .perm-table { width: 100%; }
 .perm-table td, .perm-table th { padding: 6px 8px; font-size: 13px; }
+
+/* use case setup steps (the generic wizard) */
+.main ol.uc-setup { margin: 0; padding-left: 20px; display: flex; flex-direction: column; gap: 12px; }
+.uc-setup-title { font-weight: 600; }
+.uc-setup-cmd { display: flex; align-items: flex-start; gap: 10px; }
+.uc-setup-cmd pre { margin: 0; padding: 8px 10px; border: 1px solid var(--line); background: var(--wash); font-size: 12px; flex: 1; overflow-x: auto; white-space: pre; }
+.uc-actions { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; }

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -392,6 +392,7 @@ export interface Recipe {
   description: string;
   params: Record<string, RecipeParam>;
   tags?: string[];
+  guide?: { label: string; url: string } | null;
   setup?: RecipeSetupStep[];
   actions?: RecipeAction[];
 }

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -382,9 +382,11 @@ export interface RecipeParam {
   item?: Record<string, RecipeParam>;   // for lists of objects
 }
 export interface RecipeSetupStep { title: string; text?: string; command?: string; check?: "anthropic_key" | "detect" }
+export interface RecipeActionOption { value: string; label?: string; help?: string }
 export interface RecipeAction {
-  name: string; label: string; help?: string;
-  params?: Record<string, { label?: string; options?: string[] }>;
+  name: string; label: string; help?: string; intro?: string;
+  docs?: { label: string; url: string };
+  params?: Record<string, { label?: string; options?: (string | RecipeActionOption)[] }>;
 }
 export interface Recipe {
   key: string;

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -381,7 +381,7 @@ export interface RecipeParam {
   choices?: string[];
   item?: Record<string, RecipeParam>;   // for lists of objects
 }
-export interface RecipeSetupStep { title: string; text?: string; command?: string }
+export interface RecipeSetupStep { title: string; text?: string; command?: string; check?: "anthropic_key" }
 export interface RecipeAction {
   name: string; label: string; help?: string;
   params?: Record<string, { label?: string; options?: string[] }>;

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -381,7 +381,7 @@ export interface RecipeParam {
   choices?: string[];
   item?: Record<string, RecipeParam>;   // for lists of objects
 }
-export interface RecipeSetupStep { title: string; text?: string; command?: string; check?: "anthropic_key" }
+export interface RecipeSetupStep { title: string; text?: string; command?: string; check?: "anthropic_key" | "detect" }
 export interface RecipeAction {
   name: string; label: string; help?: string;
   params?: Record<string, { label?: string; options?: string[] }>;

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -381,11 +381,19 @@ export interface RecipeParam {
   choices?: string[];
   item?: Record<string, RecipeParam>;   // for lists of objects
 }
+export interface RecipeSetupStep { title: string; text?: string; command?: string }
+export interface RecipeAction {
+  name: string; label: string; help?: string;
+  params?: Record<string, { label?: string; options?: string[] }>;
+}
 export interface Recipe {
   key: string;
   title: string;
   description: string;
   params: Record<string, RecipeParam>;
+  tags?: string[];
+  setup?: RecipeSetupStep[];
+  actions?: RecipeAction[];
 }
 export type UsecaseObjectKind = "source" | "view" | "trigger" | "agent" | "mcp_server";
 export interface UsecaseObject {
@@ -418,6 +426,8 @@ export interface UsecaseSummary extends Usecase {
             events?: number }[];
   context_repo?: string; context_branch?: string; context_path?: string; write_mode?: string;
   runs_total?: number; runs_ok?: number; prs_opened?: number; last_fired?: string | null;
+  sources?: Record<string, { events: number; last: string | null }>;
+  guide?: string;
   runs?: { id?: string; started_at?: string; key?: string; repo?: string; status?: string; rounds?: number; first_look?: boolean;
            max_rounds?: number | null; pr_url?: string | null; agent?: string; finding?: string | null }[];
   prs?: { open?: number; merged?: number };


### PR DESCRIPTION
Use cases > AI SRE demo (tagged demo): one click creates the same six objects `demo/catalog.demo.yaml` seeds (same names, so the guide reads the same; an existing unowned demo catalog is adopted, not duplicated). The wizard shows the setup steps first (docker compose, alive check, Anthropic key) with copyable commands; the use case page has Cause an incident (error_spike / latency / dependency_outage) and Clear the fault buttons that call the api-server's fault switch.

Framework additions used by it: recipe `tags`, `SETUP` steps, `ACTIONS` + `run_action`, `POST /api/usecases/{id}/actions/{name}`; the instance page renders actions and a generic Sources table; How it works is per recipe.

Tested: `tests/test_ai_sre_demo.py` (23) incl. adopting an imported demo catalog and the actions against a fake api-server; full loop shows only the two known-failing scripts; `tsc` and build clean. Live against the real demo stack: Start, Cause an incident, HighErrorRate arrived, the incident trigger fired, the agent ran ("no key" on that throwaway daemon, as expected).

Noticed, out of scope: on this Docker Desktop (28.0.4) `docker logs --since` returns nothing while `--tail` works, so the `docker_logs` connector ingests nothing; same via the YAML catalog. Worth a small fallback ticket.