### PR TITLE
Shared code context recipe links its guide

### DIFF
--- a/tares/usecases/shared_code_context.py
+++ b/tares/usecases/shared_code_context.py
@@ -140,6 +140,8 @@ class SharedCodeContext(Recipe):
     title = "Shared code context"
     description = ("Keep one repository of shared context current: Tares watches commits across "
                    "your code repos and an agent updates the context repo when something changes.")
+    guide = {"label": "Shared code context guide",
+             "url": "https://docs.glassflow.ai/tares/guides/shared-code-context"}
     PARAMS = {
         "credential": {"type": "string", "required": True, "label": "GitHub credential",
                        "help": "name of a stored GitHub credential (Settings > GitHub); read on the "


### PR DESCRIPTION
Sets the recipe's guide field to https://docs.glassflow.ai/tares/guides/shared-code-context (live since docs PR #65), so the Use cases card and the wizard link it like the AI SRE demo does.