### PR TITLE
Triggers: debounce catch-up so a second source's key still fires

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 Notable changes to Tares (formerly NavFlow). Format follows [Keep a Changelog](https://keepachangelog.com/);
 the project follows [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- **A trigger no longer misses a key whose source ingested right after another.** Trigger
+  evaluation is debounced to once per 10 seconds per trigger; a second source of the same view
+  that ingested inside that interval was left unevaluated until the next ingest, by which time a
+  short detection window could have slid past its events (two repos polled a second apart: the
+  first fired, the second never did). A skipped evaluation is now re-run once the interval ends.
+- **Shared code context**: the `every_commit` trigger's detection window is 5 minutes (was 2),
+  matching the 60-second source poll.
+
 ## [1.8.1] - 2026-08-19
 
 ### Fixed

--- a/tares/daemon.py
+++ b/tares/daemon.py
@@ -362,6 +362,7 @@ def make_app() -> FastAPI:
     # Tares agents are the second kind of subscriber to a firing (the first is an external agent's
     # webhook). In-process, so `tares up` closes the loop with nothing to deploy.
     dispatcher.agents = AgentRunner(store, runtime)
+    dispatcher.runtime = runtime
 
     def _otlp_source_for(header: str | None) -> str:
         """Resolve the OTLP source for an export (shared by the HTTP and gRPC receivers). Raises

--- a/tares/dispatch.py
+++ b/tares/dispatch.py
@@ -28,6 +28,9 @@ class Dispatcher:
         # Set by the daemon once the runtime exists — the in-process executor for Tares-agent
         # subscriptions. External-only deployments can leave it None.
         self.agents = None
+        # Set by the daemon too: the live runtime, so a deferred trigger evaluation can read the
+        # current catalog instead of the one captured when it was scheduled.
+        self.runtime = None
 
     async def fire(self, trigger, key: str, payload: str) -> None:
         subs = self.store.list_subscriptions(trigger.name)

--- a/tares/runtime.py
+++ b/tares/runtime.py
@@ -48,6 +48,8 @@ class Runtime:
             self._start(cfg)
 
     def shutdown(self) -> None:
+        from .triggers import cancel_catchups
+        cancel_catchups()
         for rt in self.sources.values():
             if rt.task:
                 rt.task.cancel()

--- a/tares/triggers.py
+++ b/tares/triggers.py
@@ -41,17 +41,29 @@ def _aware(dt):
 _catchups: dict = {}   # trigger name -> pending asyncio task for a debounced re-evaluation
 
 
+def cancel_catchups() -> None:
+    """Drop pending catch-up evaluations (daemon shutdown)."""
+    for t in list(_catchups.values()):
+        t.cancel()
+    _catchups.clear()
+
+
 def _schedule_catchup(name: str, delay: float, store, catalog, dispatcher, eval_state) -> None:
     """Re-evaluate `name` once the debounce interval has passed, unless a catch-up is already
-    pending. Evaluates without an affected-source filter so every key of the view is considered."""
+    pending. Evaluates without an affected-source filter so every key of the view is considered.
+    The catalog is re-read at fire time through `dispatcher.runtime` when available, so a trigger
+    edited or a use case created inside the interval is evaluated as it is then, not as it was."""
     if name in _catchups and not _catchups[name].done():
         return
 
     async def _later():
         try:
             await asyncio.sleep(max(delay, 0.05))
-            await eval_triggers(store, catalog, dispatcher, affected_sources=None,
+            live = getattr(getattr(dispatcher, "runtime", None), "catalog", None) or catalog
+            await eval_triggers(store, live, dispatcher, affected_sources=None,
                                 eval_state=eval_state, only=name)
+        except asyncio.CancelledError:
+            raise
         except Exception:
             pass
         finally:

--- a/tares/triggers.py
+++ b/tares/triggers.py
@@ -7,6 +7,7 @@ and evaluate on the in-flight batch to decouple latency from the poll interval.
 """
 from __future__ import annotations
 
+import asyncio
 import operator
 import os
 from datetime import timezone
@@ -37,15 +38,43 @@ def _aware(dt):
     return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
 
 
+_catchups: dict = {}   # trigger name -> pending asyncio task for a debounced re-evaluation
+
+
+def _schedule_catchup(name: str, delay: float, store, catalog, dispatcher, eval_state) -> None:
+    """Re-evaluate `name` once the debounce interval has passed, unless a catch-up is already
+    pending. Evaluates without an affected-source filter so every key of the view is considered."""
+    if name in _catchups and not _catchups[name].done():
+        return
+
+    async def _later():
+        try:
+            await asyncio.sleep(max(delay, 0.05))
+            await eval_triggers(store, catalog, dispatcher, affected_sources=None,
+                                eval_state=eval_state, only=name)
+        except Exception:
+            pass
+        finally:
+            _catchups.pop(name, None)
+
+    try:
+        _catchups[name] = asyncio.get_running_loop().create_task(_later())
+    except RuntimeError:   # no running loop (tests calling synchronously): evaluate next time
+        pass
+
+
 async def eval_triggers(store, catalog: Catalog, dispatcher, affected_sources=None,
-                        eval_state: dict | None = None) -> list:
+                        eval_state: dict | None = None, only: str | None = None) -> list:
     """Evaluate every trigger whose view touches an affected source. Returns [(trigger, key)] fired.
+    `only` restricts the pass to one trigger (the debounce catch-up).
 
     `eval_state` is a caller-owned {trigger_name: last_eval_datetime} map for debouncing across ticks;
     pass None (tests) to evaluate on every call."""
     fired = []
     now = now_utc()
     for trig in catalog.triggers:
+        if only is not None and trig.name != only:
+            continue
         # A paused trigger is inert: not evaluated, never fires, until resumed.
         if getattr(trig, "paused", False):
             continue
@@ -55,11 +84,16 @@ async def eval_triggers(store, catalog: Catalog, dispatcher, affected_sources=No
 
         c = trig.condition
         # Debounce: skip if this trigger was evaluated within min(window, _DEBOUNCE_SECONDS) ago.
-        # The first evaluation of a trigger always runs (no prior state).
+        # The first evaluation of a trigger always runs (no prior state). A skipped evaluation is
+        # not dropped: it is re-run once the interval is over (see _schedule_catchup), otherwise
+        # two sources of the same view that ingest within one interval leave the second one
+        # unevaluated until the next ingest, by which time a short window has slid past its events.
         if eval_state is not None:
             interval = min(parse_window(c.window).total_seconds(), _DEBOUNCE_SECONDS)
             last_eval = eval_state.get(trig.name)
             if last_eval is not None and (now - last_eval).total_seconds() < interval:
+                _schedule_catchup(trig.name, interval - (now - last_eval).total_seconds(),
+                                  store, catalog, dispatcher, eval_state)
                 continue
             eval_state[trig.name] = now
 

--- a/tares/usecases/shared_code_context.py
+++ b/tares/usecases/shared_code_context.py
@@ -27,7 +27,7 @@ TRIGGERS = {
     # only this one is offered today; "every merged PR" needs the github_webhook connector and
     # "daily" needs scheduled triggers, so both stay out of PARAMS until they exist
     "every_commit": {"label": "every commit to the branch (batched per repo)",
-                     "window": "2m", "cooldown": "5m"},
+                     "window": "5m", "cooldown": "5m"},
 }
 WRITE_MODES = ("pull_request", "commit_to_branch")
 LAYOUTS = ("existing", "per_repo")

--- a/tests/test_shared_code_context.py
+++ b/tests/test_shared_code_context.py
@@ -169,7 +169,7 @@ async def main():
           and src["config"]["labels"][0] == {"name": "repo", "field": "repo", "primary": True}, json.dumps(src))
     trig = next(o for o in plan1 if o.kind == "trigger").spec
     check("trigger counts commits per repo with 5m cooldown and 30m context",
-          trig["condition"] == {"aggregate": "count", "predicate": "> 0", "window": "2m", "group_by": ["key_value"]}
+          trig["condition"] == {"aggregate": "count", "predicate": "> 0", "window": "5m", "group_by": ["key_value"]}
           and trig["cooldown"] == "5m" and trig["emit"]["attach_view"] is True
           and trig["emit"]["context_window"] == "30m", json.dumps(trig))
     mcp = next(o for o in plan1 if o.kind == "mcp_server").spec

--- a/tests/test_trigger_debounce.py
+++ b/tests/test_trigger_debounce.py
@@ -1,0 +1,90 @@
+"""Two sources of one view ingesting within the trigger debounce interval must both fire (per key).
+Regression for the shared code context cookbook: billing fired, orders (ingested one second later)
+never did, because the debounced evaluation was dropped and the 2m window slid past the commits.
+Run: .venv/bin/python tests/test_trigger_debounce.py
+"""
+import asyncio
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+DB = "/tmp/tares-trigger-debounce-test.duckdb"
+CATALOG = "/tmp/tares-trigger-debounce-test.catalog.yaml"
+os.environ["TARES_DB"] = DB
+os.environ["TARES_CATALOG"] = CATALOG
+os.environ["TARES_TRIGGER_DEBOUNCE_SECONDS"] = "3"
+
+import httpx
+
+PASS = FAIL = 0
+
+
+def check(label, cond, detail=""):
+    global PASS, FAIL
+    if cond:
+        PASS += 1; print(f"  ok   {label}")
+    else:
+        FAIL += 1; print(f"  FAIL {label}  {detail}")
+
+
+CATALOG_YAML = """
+sources:
+  - name: a_repo
+    connector: webhook
+    config:
+      event_type: commit
+      labels: [{name: repo, field: repo, primary: true}]
+  - name: b_repo
+    connector: webhook
+    config:
+      event_type: commit
+      labels: [{name: repo, field: repo, primary: true}]
+views:
+  - name: repos
+    key_field: repo
+    sources: [a_repo, b_repo]
+triggers:
+  - name: changes
+    view: repos
+    condition: {aggregate: count, predicate: "> 0", window: 2m, group_by: [key_value]}
+    emit: {kind: change, attach_view: true, context_window: 15m}
+    cooldown: 5m
+"""
+
+
+async def main():
+    for p in (DB, DB + ".wal"):
+        if os.path.exists(p):
+            os.remove(p)
+    open(CATALOG, "w").write(CATALOG_YAML)
+    from tares.daemon import make_app
+    app = make_app()
+    async with app.router.lifespan_context(app):
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as cx:
+            srcs = (await cx.get("/api/sources")).json()
+            paths = {s["name"]: f"/ingest/{s.get('ingest_key') or s['name']}" for s in srcs}
+            r1 = await cx.post(paths["a_repo"], json={"repo": "org/a", "sha": "1"})
+            check("a ingested", r1.status_code == 202, r1.text[:200])
+            await asyncio.sleep(0.5)          # inside the 3s debounce
+            r2 = await cx.post(paths["b_repo"], json={"repo": "org/b", "sha": "2"})
+            check("b ingested one second later", r2.status_code == 202, r2.text[:200])
+
+            async def fired_keys():
+                rows = (await cx.get("/api/activity/dispatches")).json()
+                return sorted({str(x.get("key")) for x in rows if x.get("trigger") == "changes"})
+
+            k = await fired_keys()
+            check("first key fired immediately", "org/a" in k, str(k))
+            # the second key must fire once the debounce interval passes, not never
+            for _ in range(20):
+                k = await fired_keys()
+                if "org/b" in k:
+                    break
+                await asyncio.sleep(0.5)
+            check("second key fires after the debounce catch-up", "org/b" in k, str(k))
+    print(f"\n{PASS} passed, {FAIL} failed")
+    sys.exit(1 if FAIL else 0)
+
+
+asyncio.run(main())


### PR DESCRIPTION
Found running cookbook 02: billing fired, orders (ingested one second later) never did. Trigger evaluation is debounced per trigger to once per 10s; the second source's ingest inside that interval was dropped and by the next ingest the 2m window had slid past the commits. A skipped evaluation is now scheduled once as a catch-up at the end of the interval (evaluated over every key of the view). Regression test tests/test_trigger_debounce.py fails on main, passes here. Also widens the shared code context every_commit window to 5m (60s polls). Full loop: only the two known-failing scripts.