### PR TITLE
Agent cost tracking + first-class agents page (TR-189)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Backend — install + tests
         run: |
           pip install -e .
-          for t in test_labels test_normalize test_auth test_api_keys test_agents test_catalog_sync test_cli test_usage test_slack test_slack_verify test_slack_ask test_degraded; do
+          for t in test_labels test_normalize test_auth test_api_keys test_pricing test_agents test_catalog_sync test_cli test_usage test_slack test_slack_verify test_slack_ask test_degraded; do
             echo "== $t =="
             python "tests/$t.py"
           done

--- a/tares/agent.py
+++ b/tares/agent.py
@@ -292,8 +292,13 @@ def _sse(obj: dict) -> str:
 
 
 async def run_agent(api_key: str, messages: list,
-                    model: str | None = None, self_headers: dict | None = None):
-    """Async generator of SSE lines: the agent loop, streaming assistant text and tool activity."""
+                    model: str | None = None, self_headers: dict | None = None,
+                    on_usage=None):
+    """Async generator of SSE lines: the agent loop, streaming assistant text and tool activity.
+
+    `on_usage(model, usage_dict)` is called once per turn (after the loop, including on an error
+    mid-turn) with the summed token usage of every model call the turn made, so the caller can
+    meter Ask's Anthropic spend. Never called when no model call completed."""
     try:
         import anthropic
     except ImportError:
@@ -304,6 +309,9 @@ async def run_agent(api_key: str, messages: list,
     client = anthropic.AsyncAnthropic(api_key=api_key)
     convo = list(messages)
     headers = self_headers or {}
+    used_model = model or DEFAULT_MODEL
+    usage = {"calls": 0, "input_tokens": 0, "output_tokens": 0,
+             "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0}
     try:
         for _ in range(MAX_ROUNDS):
             async with client.messages.stream(
@@ -315,6 +323,11 @@ async def run_agent(api_key: str, messages: list,
                         yield _sse({"type": "text", "text": event.delta.text})
                 final = await stream.get_final_message()
 
+            usage["calls"] += 1
+            for field in ("input_tokens", "output_tokens",
+                          "cache_creation_input_tokens", "cache_read_input_tokens"):
+                usage[field] += int(getattr(final.usage, field, 0) or 0)
+            used_model = final.model or used_model
             convo.append({"role": "assistant", "content": final.content})
             tool_uses = [b for b in final.content if b.type == "tool_use"]
             if not tool_uses:
@@ -356,3 +369,9 @@ async def run_agent(api_key: str, messages: list,
         yield _sse({"type": "done"})
     except Exception as e:  # noqa: BLE001 — surface auth/rate/other errors to the chat
         yield _sse({"type": "error", "detail": f"{type(e).__name__}: {e}"})
+    finally:
+        if usage["calls"] and on_usage is not None:
+            try:
+                on_usage(used_model, usage)
+            except Exception as e:  # metering must never break the chat
+                print(f"ask: usage record failed: {type(e).__name__}: {e}")

--- a/tares/builtin_agents.py
+++ b/tares/builtin_agents.py
@@ -30,6 +30,7 @@ import httpx
 
 from .config import FINDINGS_SOURCE, agent_url
 from .envelope import now_utc
+from .pricing import cost_usd
 from .slack import deep_link as _slack_deep_link
 from .views import resolve_query_full, resolve_read
 
@@ -306,8 +307,26 @@ class AgentRunner:
             self.store.finish_agent_run(run_id, "capped", error=msg)
             return "capped", msg
 
-        finding, rounds, tool_calls, external_used, exhausted, partial = await self._loop(
-            agent, trigger_name, key, payload, api_key)
+        # Usage accumulates in a mutable dict rather than the loop's return value, so a run that
+        # dies mid-loop still records the tokens it already paid for (the finally below).
+        model = agent.get("model") or MODEL
+        usage = {"calls": 0, "input_tokens": 0, "output_tokens": 0,
+                 "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0}
+        try:
+            finding, rounds, tool_calls, external_used, exhausted, partial = await self._loop(
+                agent, trigger_name, key, payload, api_key, usage)
+        finally:
+            if usage["calls"]:
+                cost = cost_usd(model, usage["input_tokens"], usage["output_tokens"],
+                                usage["cache_creation_input_tokens"],
+                                usage["cache_read_input_tokens"])
+                self.store.record_run_usage(
+                    run_id, model, usage["input_tokens"], usage["output_tokens"],
+                    usage["cache_creation_input_tokens"], usage["cache_read_input_tokens"], cost)
+                self.store.record_model_usage(
+                    "agent", agent["name"], run_id, model, usage["calls"],
+                    usage["input_tokens"], usage["output_tokens"],
+                    usage["cache_creation_input_tokens"], usage["cache_read_input_tokens"], cost)
         if exhausted:
             # The round budget ran out before the model concluded. Keep whatever it said last as
             # a partial note (in `finding`, so it is visible) and say plainly what to do.
@@ -332,8 +351,12 @@ class AgentRunner:
                 "agent": agent["name"], "trigger": trigger_name, "key": key,
                 "finding": finding,
                 "run_id": run_id, "dispatch_id": dispatch_id,
-                "model": agent.get("model") or MODEL,
+                "model": model,
                 "rounds": rounds, "tool_calls": tool_calls,
+                "usage": {k: v for k, v in usage.items() if k != "calls"},
+                "cost_usd": cost_usd(model, usage["input_tokens"], usage["output_tokens"],
+                                     usage["cache_creation_input_tokens"],
+                                     usage["cache_read_input_tokens"]),
                 "started_at": started_at.isoformat(), "finished_at": now_utc().isoformat(),
                 "duration_s": round(time.monotonic() - t0, 2),
                 "prompt_hash": prompt_hash(agent["prompt"]),
@@ -342,7 +365,7 @@ class AgentRunner:
 
     # ── the bounded model loop ────────────────────────────────────────────────
     async def _loop(self, agent: dict, trigger_name: str, key: str, payload: str,
-                    api_key: str) -> tuple[str, int, int, list[str], bool, str]:
+                    api_key: str, usage: dict) -> tuple[str, int, int, list[str], bool, str]:
         # External tools: the agent's selected MCP servers, connected for the duration of this
         # run. A server that fails to connect is skipped (recorded below) — losing a tool server
         # must not lose the run.
@@ -353,10 +376,12 @@ class AgentRunner:
         async with RemoteToolbox(servers) as toolbox:
             for failure in toolbox.failures:
                 print(f"[agent {agent['name']}] mcp connect failed; {failure}")
-            return await self._loop_with(agent, trigger_name, key, payload, api_key, toolbox)
+            return await self._loop_with(agent, trigger_name, key, payload, api_key, toolbox,
+                                         usage)
 
     async def _loop_with(self, agent: dict, trigger_name: str, key: str, payload: str,
-                         api_key: str, toolbox) -> tuple[str, int, int, list[str], bool, str]:
+                         api_key: str, toolbox,
+                         usage: dict) -> tuple[str, int, int, list[str], bool, str]:
         """Returns (finding, rounds, tool_calls, external_tools_used, exhausted, partial_text)."""
         tools = TOOL_DEFS + toolbox.tool_defs
         max_rounds = effective_max_rounds(agent)
@@ -386,7 +411,14 @@ class AgentRunner:
                     json=body)
                 if r.status_code >= 400:
                     raise RuntimeError(f"anthropic {r.status_code}: {r.text[:300]}")
-                return r.json()
+                msg = r.json()
+                # Defensive get: stubs (tests) may answer without a usage block.
+                u = msg.get("usage") or {}
+                usage["calls"] += 1
+                for field in ("input_tokens", "output_tokens",
+                              "cache_creation_input_tokens", "cache_read_input_tokens"):
+                    usage[field] += int(u.get(field) or 0)
+                return msg
 
             for rounds in range(1, max_rounds + 1):
                 msg = await call(True)

--- a/tares/daemon.py
+++ b/tares/daemon.py
@@ -1159,6 +1159,17 @@ def make_app() -> FastAPI:
         return {"sampled": sampled, "fields": fields, "labels": labels}
 
     # ── in-app agent (the Ask view) — server-side chat loop over the read API ──
+    def _record_ask_usage(model: str, usage: dict) -> None:
+        """One ledger row per Ask turn (console chat or Slack /ask), so the cell's spend meter
+        covers everything that talks to Anthropic, not just agent runs."""
+        from .pricing import cost_usd
+        store.record_model_usage(
+            "ask", "", "", model, usage["calls"],
+            usage["input_tokens"], usage["output_tokens"],
+            usage["cache_creation_input_tokens"], usage["cache_read_input_tokens"],
+            cost_usd(model, usage["input_tokens"], usage["output_tokens"],
+                     usage["cache_creation_input_tokens"], usage["cache_read_input_tokens"]))
+
     @app.post("/api/agent/chat")
     async def agent_chat(request: Request):
         from .agent import run_agent
@@ -1174,7 +1185,8 @@ def make_app() -> FastAPI:
         self_headers = {"Authorization": f"Bearer {AUTH_TOKEN}"} if AUTH_TOKEN else {}
         return StreamingResponse(
             run_agent(key, body.get("messages") or [],
-                      model=body.get("model"), self_headers=self_headers),
+                      model=body.get("model"), self_headers=self_headers,
+                      on_usage=_record_ask_usage),
             media_type="text/event-stream")
 
     # ── MCP connections — external tool servers a Tares agent can opt into ─────
@@ -1538,10 +1550,14 @@ def make_app() -> FastAPI:
         no key configured is the common case on a fresh install and looks identical to "disabled"
         without this."""
         key, origin = resolve_anthropic_key(store)
+        stats = store.agent_stats()
+        zero = {"runs": 0, "ok": 0, "finished": 0, "avg_duration_ms": None,
+                "cost_usd": None, "input_tokens": 0, "output_tokens": 0, "uncosted_runs": 0}
         rows = []
         for a in store.list_catalog_agents():
             runs = store.list_agent_runs(a["name"], limit=1)
             rows.append({"name": a["name"], "trigger": a["trigger"], "prompt": a["prompt"],
+                         "stats": stats.get(a["name"]) or zero,
                          "slack_configured": bool(a.get("slack_webhook")),
                          "model": a.get("model") or "",
                          "slack_channel": a.get("slack_channel") or "",
@@ -1788,7 +1804,8 @@ def make_app() -> FastAPI:
             async def _run():
                 nonlocal text, error
                 async for chunk in run_agent(key, [{"role": "user", "content": question}],
-                                             self_headers=self_headers):
+                                             self_headers=self_headers,
+                                             on_usage=_record_ask_usage):
                     for line in chunk.splitlines():
                         if not line.startswith("data: "):
                             continue
@@ -2137,6 +2154,15 @@ def make_app() -> FastAPI:
         return {**u, "disk_total": disk_total, "disk_free": disk_free,
                 "max_bytes": MAX_DB_SIZE,
                 "pct_used": round(100 * used / MAX_DB_SIZE, 2) if MAX_DB_SIZE else None}
+
+    @app.get("/api/usage/model")
+    async def usage_model(days: int = 30):
+        """The cell's Anthropic spend meter: all-time totals plus a per-day tail, split by surface
+        (agent runs vs Ask). Generic data only — a hosted control plane polls this to enforce
+        credits, a self-hoster reads their own bill coming; the cell attaches no meaning to it.
+        `cost_usd` is a floor: `uncosted_calls` counts rows whose model had no known price, and
+        runs from before metering existed are absent entirely."""
+        return store.model_usage_summary(days=max(1, min(int(days), 366)))
 
     # ── console UI (built SPA; catch-all registered last so API routes win) ──
     @app.get("/{path:path}", include_in_schema=False)

--- a/tares/pricing.py
+++ b/tares/pricing.py
@@ -1,0 +1,43 @@
+"""Anthropic model pricing, for turning per-call token usage into a stored USD cost.
+
+Cost is computed at write time and stored with the run, never recomputed later: prices change,
+and the history must keep the cost that was true when the tokens were bought. Model ids are
+matched by family prefix (first match wins) so dated snapshots like claude-haiku-4-5-20251001
+price the same as their family; anything unmatched costs None — the caller records the tokens
+and leaves cost NULL rather than guess.
+"""
+from __future__ import annotations
+
+# (model id prefix, USD per Mtok input, USD per Mtok output); first match wins.
+MODEL_PRICING = [
+    ("claude-fable-5", 10.0, 50.0),
+    ("claude-opus-", 5.0, 25.0),
+    ("claude-sonnet-", 3.0, 15.0),
+    ("claude-haiku-", 1.0, 5.0),
+]
+# Cache write bills at 1.25x the input rate, cache read at 0.10x. `input_tokens` in the API's
+# usage block already excludes cached tokens, so the three input buckets are additive.
+CACHE_WRITE_MULT = 1.25
+CACHE_READ_MULT = 0.10
+
+
+def price_for(model: str) -> tuple[float, float] | None:
+    """(usd_per_mtok_in, usd_per_mtok_out) for a model id, or None when unknown."""
+    for prefix, p_in, p_out in MODEL_PRICING:
+        if (model or "").startswith(prefix):
+            return p_in, p_out
+    return None
+
+
+def cost_usd(model: str, input_tokens: int, output_tokens: int,
+             cache_creation_input_tokens: int = 0,
+             cache_read_input_tokens: int = 0) -> float | None:
+    """USD cost of one or more calls' summed usage, or None when the model is unpriced."""
+    p = price_for(model)
+    if p is None:
+        return None
+    p_in, p_out = p
+    return (input_tokens * p_in
+            + output_tokens * p_out
+            + cache_creation_input_tokens * p_in * CACHE_WRITE_MULT
+            + cache_read_input_tokens * p_in * CACHE_READ_MULT) / 1e6

--- a/tares/store.py
+++ b/tares/store.py
@@ -10,6 +10,7 @@ import os
 import re
 import secrets
 import threading
+import uuid
 from datetime import datetime
 
 import duckdb
@@ -141,6 +142,27 @@ CREATE TABLE IF NOT EXISTS agent_runs (
   error       TEXT
 );
 CREATE INDEX IF NOT EXISTS ix_agent_runs_agent ON agent_runs(agent);
+-- Model-usage ledger: one row per model interaction (an agent run's whole loop, an Ask turn),
+-- with token counts straight from the API's usage block and the USD cost priced at write time
+-- (tares/pricing.py). This is the cell's own meter for what it spends on Anthropic. A hosted
+-- control plane reads the aggregate over /api/usage/model to enforce credits, but the cell
+-- attaches no meaning to the total. cost_usd is NULL when the model has no known price.
+-- (No semicolons in these comments: _SCHEMA is split on them.)
+CREATE TABLE IF NOT EXISTS model_usage (
+  id       TEXT PRIMARY KEY,
+  ts       TIMESTAMPTZ,
+  surface  TEXT,
+  agent    TEXT,
+  run_id   TEXT,
+  model    TEXT,
+  calls    INTEGER,
+  input_tokens  BIGINT,
+  output_tokens BIGINT,
+  cache_creation_input_tokens BIGINT,
+  cache_read_input_tokens     BIGINT,
+  cost_usd DOUBLE
+);
+CREATE INDEX IF NOT EXISTS ix_model_usage_ts ON model_usage(ts);
 CREATE TABLE IF NOT EXISTS settings (
   key        TEXT PRIMARY KEY,
   value      TEXT,
@@ -262,6 +284,14 @@ _MIGRATIONS = [
     "ALTER TABLE catalog_agents ADD COLUMN IF NOT EXISTS customized BOOLEAN",
     "ALTER TABLE mcp_servers ADD COLUMN IF NOT EXISTS owned_by TEXT",
     "ALTER TABLE mcp_servers ADD COLUMN IF NOT EXISTS customized BOOLEAN",
+    # Per-run model usage (tokens from the API's usage block, cost priced at write time). Runs
+    # from before these columns keep NULL everywhere — their cost is unknown, never backfilled.
+    "ALTER TABLE agent_runs ADD COLUMN IF NOT EXISTS model TEXT",
+    "ALTER TABLE agent_runs ADD COLUMN IF NOT EXISTS input_tokens BIGINT",
+    "ALTER TABLE agent_runs ADD COLUMN IF NOT EXISTS output_tokens BIGINT",
+    "ALTER TABLE agent_runs ADD COLUMN IF NOT EXISTS cache_creation_input_tokens BIGINT",
+    "ALTER TABLE agent_runs ADD COLUMN IF NOT EXISTS cache_read_input_tokens BIGINT",
+    "ALTER TABLE agent_runs ADD COLUMN IF NOT EXISTS cost_usd DOUBLE",
 ]
 
 _FILTER_COLS = {"event_type", "source", "text", "key_value"}
@@ -928,9 +958,27 @@ class Store:
                  json.dumps(external_tools or []), now_utc(), now_utc(), run_id],
             )
 
+    def record_run_usage(self, run_id: str, model: str, input_tokens: int, output_tokens: int,
+                         cache_creation_input_tokens: int = 0,
+                         cache_read_input_tokens: int = 0,
+                         cost_usd: float | None = None) -> None:
+        """Stamp a run with what its model loop consumed. Separate from finish_agent_run on
+        purpose: usage exists for every outcome (ok, empty, exhausted, and failed after burning
+        tokens), so it is written by the loop's finally rather than each outcome path."""
+        with self._lock:
+            self.con.execute(
+                "UPDATE agent_runs SET model = ?, input_tokens = ?, output_tokens = ?, "
+                "cache_creation_input_tokens = ?, cache_read_input_tokens = ?, cost_usd = ? "
+                "WHERE id = ?",
+                [model, input_tokens, output_tokens, cache_creation_input_tokens,
+                 cache_read_input_tokens, cost_usd, run_id],
+            )
+
     def list_agent_runs(self, agent: str | None = None, limit: int = 50) -> list[dict]:
         sql = ("SELECT id, agent, trigger, dispatch_id, key_value, status, rounds, tool_calls, "
-               "started_at, duration_ms, finding, error, external_tools, max_rounds "
+               "started_at, duration_ms, finding, error, external_tools, max_rounds, "
+               "model, input_tokens, output_tokens, cache_creation_input_tokens, "
+               "cache_read_input_tokens, cost_usd "
                "FROM agent_runs ")
         params: list = []
         if agent:
@@ -944,9 +992,86 @@ class Store:
             {"id": r[0], "agent": r[1], "trigger": r[2], "dispatch_id": r[3], "key": r[4],
              "status": r[5], "rounds": r[6], "tool_calls": r[7], "started_at": r[8],
              "duration_ms": r[9], "finding": r[10], "error": r[11],
-             "external_tools": json.loads(r[12]) if r[12] else [], "max_rounds": r[13]}
+             "external_tools": json.loads(r[12]) if r[12] else [], "max_rounds": r[13],
+             "model": r[14], "input_tokens": r[15], "output_tokens": r[16],
+             "cache_creation_input_tokens": r[17], "cache_read_input_tokens": r[18],
+             "cost_usd": r[19]}
             for r in rows
         ]
+
+    def agent_stats(self) -> dict[str, dict]:
+        """Per-agent lifetime aggregates for the console, one grouped query. `finished` excludes
+        `running` and `capped` (a capped run made no model call), so the success rate reflects
+        runs that actually concluded or tried to. Cost sums skip NULL rows (historical runs and
+        unpriced models); `uncosted_runs` says how many finished runs the sum could not see, so
+        a total reads as a floor rather than a fact."""
+        with self._lock:
+            rows = self.con.execute(
+                "SELECT agent, count(*), "
+                "count(*) FILTER (WHERE status = 'ok'), "
+                "count(*) FILTER (WHERE status IN ('ok', 'empty', 'failed', 'exhausted')), "
+                "avg(duration_ms) FILTER (WHERE status IN ('ok', 'empty', 'failed', 'exhausted')), "
+                "sum(cost_usd), sum(input_tokens), sum(output_tokens), "
+                "count(*) FILTER (WHERE status IN ('ok', 'empty', 'failed', 'exhausted') "
+                "                 AND cost_usd IS NULL) "
+                "FROM agent_runs GROUP BY agent"
+            ).fetchall()
+        return {
+            r[0]: {"runs": int(r[1]), "ok": int(r[2]), "finished": int(r[3]),
+                   "avg_duration_ms": int(r[4]) if r[4] is not None else None,
+                   "cost_usd": float(r[5]) if r[5] is not None else None,
+                   "input_tokens": int(r[6]) if r[6] is not None else 0,
+                   "output_tokens": int(r[7]) if r[7] is not None else 0,
+                   "uncosted_runs": int(r[8])}
+            for r in rows
+        }
+
+    # ── model-usage ledger (the cell's Anthropic spend meter) ─────────────────
+    def record_model_usage(self, surface: str, agent: str, run_id: str, model: str, calls: int,
+                           input_tokens: int, output_tokens: int,
+                           cache_creation_input_tokens: int = 0,
+                           cache_read_input_tokens: int = 0,
+                           cost_usd: float | None = None) -> None:
+        with self._lock:
+            self.con.execute(
+                "INSERT INTO model_usage (id, ts, surface, agent, run_id, model, calls, "
+                "input_tokens, output_tokens, cache_creation_input_tokens, "
+                "cache_read_input_tokens, cost_usd) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                ["mu_" + uuid.uuid4().hex[:12], now_utc(), surface, agent, run_id, model,
+                 calls, input_tokens, output_tokens, cache_creation_input_tokens,
+                 cache_read_input_tokens, cost_usd],
+            )
+
+    def model_usage_summary(self, days: int = 30) -> dict:
+        """All-time totals plus a per-day tail over the ledger. The shape a credits poller needs:
+        totals to enforce against, days to draw a burn-down. `uncosted_calls` counts rows whose
+        model had no known price, so the cost total is understood as a floor."""
+        agg = ("coalesce(sum(calls), 0), coalesce(sum(input_tokens), 0), "
+               "coalesce(sum(output_tokens), 0), coalesce(sum(cache_creation_input_tokens), 0), "
+               "coalesce(sum(cache_read_input_tokens), 0), sum(cost_usd), "
+               "coalesce(sum(calls) FILTER (WHERE cost_usd IS NULL), 0)")
+
+        def shape(r) -> dict:
+            return {"calls": int(r[0]), "input_tokens": int(r[1]), "output_tokens": int(r[2]),
+                    "cache_creation_input_tokens": int(r[3]),
+                    "cache_read_input_tokens": int(r[4]),
+                    "cost_usd": float(r[5]) if r[5] is not None else None,
+                    "uncosted_calls": int(r[6])}
+
+        with self._lock:
+            total = self.con.execute(f"SELECT {agg} FROM model_usage").fetchone()
+            surfaces = self.con.execute(
+                f"SELECT surface, {agg} FROM model_usage GROUP BY surface").fetchall()
+            daily = self.con.execute(
+                f"SELECT CAST(ts AS DATE) AS day, {agg} FROM model_usage "
+                f"WHERE ts > now() - INTERVAL {int(days)} DAY "
+                "GROUP BY day ORDER BY day").fetchall()
+        return {
+            "total": shape(total),
+            "by_surface": {r[0]: shape(r[1:]) for r in surfaces},
+            "days": [{"day": str(r[0]), **shape(r[1:])} for r in daily],
+            "window_days": int(days),
+        }
 
     def agent_runs_today(self, agent: str, exclude_run_id: str | None = None) -> int:
         """Runs started in the last 24h — the cost ceiling's counter. `exclude_run_id` leaves out the

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -45,7 +45,8 @@ class Stub(BaseHTTPRequestHandler):
                         "input": {"selector": {"service": "checkout"}, "window": "1h"}}]
         else:
             content = [{"type": "text", "text": FINDING}]
-        out = json.dumps({"content": content, "model": body.get("model")}).encode()
+        out = json.dumps({"content": content, "model": body.get("model"),
+                          "usage": {"input_tokens": 100, "output_tokens": 50}}).encode()
         self.send_response(200)
         self.send_header("content-type", "application/json")
         self.send_header("content-length", str(len(out)))
@@ -147,6 +148,31 @@ async def main():
             ck("run records the entity", run.get("key") == "checkout", str(run.get("key")))
             ck("run counted the tool call", (run.get("tool_calls") or 0) >= 1, str(run))
             ck("run is tied to a dispatch", bool(run.get("dispatch_id")), str(run.get("dispatch_id")))
+
+            # ── model usage: tokens from the stub's usage block, cost priced at write time ──
+            calls_made = run.get("rounds") or 0   # the stub concludes without the +1 call
+            ck("run records the model", run.get("model") == "claude-sonnet-4-6", str(run.get("model")))
+            ck("run sums input tokens over its calls",
+               run.get("input_tokens") == 100 * calls_made, str(run))
+            ck("run sums output tokens over its calls",
+               run.get("output_tokens") == 50 * calls_made, str(run))
+            want_cost = (100 * calls_made * 3.0 + 50 * calls_made * 15.0) / 1e6
+            ck("run cost matches the sonnet rate", abs((run.get("cost_usd") or 0) - want_cost) < 1e-9,
+               f"{run.get('cost_usd')} vs {want_cost}")
+
+            lst = (await cx.get(f"{B}/api/agents/builtin")).json()
+            me = next(a for a in lst["agents"] if a["name"] == "first-look")
+            ck("agent list carries stats", me.get("stats", {}).get("runs") == 1, str(me.get("stats")))
+            ck("stats sum the cost", abs((me["stats"].get("cost_usd") or 0) - want_cost) < 1e-9,
+               str(me["stats"]))
+
+            um = (await cx.get(f"{B}/api/usage/model")).json()
+            ck("usage meter totals the run's tokens",
+               um["total"]["input_tokens"] == 100 * calls_made
+               and um["total"]["output_tokens"] == 50 * calls_made, str(um["total"]))
+            ck("usage meter attributes it to the agent surface",
+               um["by_surface"].get("agent", {}).get("calls") == calls_made, str(um["by_surface"]))
+            ck("usage meter has a per-day tail", len(um.get("days") or []) == 1, str(um.get("days")))
 
             # ── the firing counts the agent as a delivered subscriber ────────
             async def _delivered():

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -1,0 +1,41 @@
+"""Model pricing — family-prefix matching and the cost formula.
+
+The cost stored with a run must be right at write time, and an unknown model must yield None
+(recorded as tokens without a cost), never a guessed number.
+"""
+import sys
+
+from tares.pricing import CACHE_READ_MULT, CACHE_WRITE_MULT, cost_usd, price_for
+
+P = F = 0
+def ck(l, c, d=""):
+    global P, F; P += 1 if c else 0; F += 0 if c else 1
+    print(("  ok   " if c else "  FAIL ") + l + ("" if c else f"  {d}"))
+
+# ── family-prefix resolution ─────────────────────────────────────────────────
+ck("bare family id resolves", price_for("claude-sonnet-5") == (3.0, 15.0))
+ck("dated snapshot resolves to its family", price_for("claude-haiku-4-5-20251001") == (1.0, 5.0))
+ck("older sonnet resolves the same", price_for("claude-sonnet-4-6") == (3.0, 15.0))
+ck("opus resolves", price_for("claude-opus-5") == (5.0, 25.0))
+ck("fable resolves", price_for("claude-fable-5") == (10.0, 50.0))
+ck("unknown claude model is unpriced", price_for("claude-mystery-9") is None)
+ck("non-claude model is unpriced", price_for("gpt-4") is None)
+ck("empty model is unpriced", price_for("") is None)
+
+# ── the formula ──────────────────────────────────────────────────────────────
+ck("input-only cost", abs(cost_usd("claude-sonnet-5", 1_000_000, 0) - 3.0) < 1e-9)
+ck("output-only cost", abs(cost_usd("claude-sonnet-5", 0, 1_000_000) - 15.0) < 1e-9)
+ck("cache write bills at 1.25x input",
+   abs(cost_usd("claude-opus-5", 0, 0, cache_creation_input_tokens=1_000_000)
+       - 5.0 * CACHE_WRITE_MULT) < 1e-9)
+ck("cache read bills at 0.10x input",
+   abs(cost_usd("claude-opus-5", 0, 0, cache_read_input_tokens=1_000_000)
+       - 5.0 * CACHE_READ_MULT) < 1e-9)
+ck("buckets are additive",
+   abs(cost_usd("claude-haiku-4-5-20251001", 100_000, 10_000, 20_000, 50_000)
+       - (100_000 * 1.0 + 10_000 * 5.0 + 20_000 * 1.0 * 1.25 + 50_000 * 1.0 * 0.10) / 1e6) < 1e-12)
+ck("unknown model costs None, not zero", cost_usd("claude-mystery-9", 1000, 1000) is None)
+ck("zero usage on a known model is 0.0", cost_usd("claude-sonnet-5", 0, 0) == 0.0)
+
+print(f"\n{P} passed, {F} failed")
+sys.exit(1 if F else 0)

--- a/tests/test_slack_ask.py
+++ b/tests/test_slack_ask.py
@@ -294,6 +294,16 @@ async def main():
                "checkout-svc" in json.dumps(MODEL_CALLS[0].get("messages", [])),
                str(MODEL_CALLS[:1])[:300])
 
+            # ── the turn is metered: tokens from the stream's usage, priced at write time ──
+            um = (await cx.get(f"{B}/api/usage/model")).json()
+            ask = um.get("by_surface", {}).get("ask", {})
+            ck("the ask turn landed on the usage meter", ask.get("calls") == 1, str(um))
+            ck("...with the stream's final usage (input 10, output 20)",
+               ask.get("input_tokens") == 10 and ask.get("output_tokens") == 20, str(ask))
+            want = (10 * 3.0 + 20 * 15.0) / 1e6
+            ck("...costed at the sonnet rate", abs((ask.get("cost_usd") or 0) - want) < 1e-9,
+               f"{ask.get('cost_usd')} vs {want}")
+
             # ── in a thread, the answer belongs in that thread ───────────────
             REPLIES.clear()
             r = await slash(cx, "ask what happened to checkout-svc", thread_ts="1700000000.000100")

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -4,7 +4,7 @@ import type {
   CatalogDescribe, CatalogList, ConnectorSpec, DiscoverProposal, DispatchDetail, DispatchLogEntry, Entity, EnvScan,
   AgentPreset, AgentRun, BuiltinAgent,
   GithubCredential,
-  LabelFacet, QueryLogEntry,
+  LabelFacet, ModelUsage, QueryLogEntry,
   Recipe, Usecase, UsecaseSummary, UsecaseUpdateReport,
   Source, SourceEvent, SourceFieldsProfile, Subscription, TestResult, Usage,
   TimelineEventRow, Trigger, View,
@@ -167,6 +167,8 @@ export const api = {
   disableBuiltinAgent: (name: string) => request(`/api/agents/builtin/${name}/disable`, { method: "POST" }),
   builtinAgentRuns: (name: string, limit = 20) =>
     request<AgentRun[]>(`/api/agents/builtin/${name}/runs?limit=${limit}`),
+  // The cell's Anthropic spend meter: totals + per-day, split agent runs vs Ask.
+  modelUsage: (days = 30) => request<ModelUsage>(`/api/usage/model?days=${days}`),
 
   // The Anthropic key Tares agents run on. Never returned — only whether one resolves and where.
   anthropicKeyStatus: () =>

--- a/ui/src/components/bits.tsx
+++ b/ui/src/components/bits.tsx
@@ -84,6 +84,22 @@ export function formatBytes(n: number | null | undefined): string {
   return `${v >= 10 ? Math.round(v) : v.toFixed(1)} ${units[i]}`;
 }
 
+/** USD cost for display. Null/undefined is *unknown*, not free — historical runs and unpriced
+ *  models have no cost, and "$0.00" would claim they were. Four decimals below a dollar: agent
+ *  runs cost fractions of a cent, and two decimals would flatten them all to "$0.00". */
+export function fmtCost(v: number | null | undefined): string {
+  if (v == null || !Number.isFinite(v)) return "—";
+  return v >= 1 ? `$${v.toFixed(2)}` : `$${v.toFixed(4)}`;
+}
+
+/** Token counts, compact ("12.4k", "1.2M"). Null/undefined renders as unknown. */
+export function fmtTokens(n: number | null | undefined): string {
+  if (n == null || !Number.isFinite(n)) return "—";
+  if (n < 1000) return String(Math.round(n));
+  if (n < 1_000_000) return `${(n / 1000).toFixed(n < 10_000 ? 1 : 0)}k`;
+  return `${(n / 1_000_000).toFixed(1)}M`;
+}
+
 /** How a label rewrites its values, in as few characters as fit a table cell. "" when it passes
  *  values straight through. One implementation so the editor and the read-only tables can never
  *  describe the same rule differently. */

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -7,12 +7,15 @@ import { api } from "../api";
 import AgentForm from "../components/AgentForm";
 import ConfirmDialog from "../components/ConfirmDialog";
 import UsecaseBadge from "../components/UsecaseBadge";
-import { ErrorState, TimeAgo, usePolling } from "../components/bits";
-import type { AgentRun } from "../types";
+import { ErrorState, TimeAgo, fmtCost, fmtTokens, usePolling } from "../components/bits";
+import type { AgentRun, BuiltinAgent } from "../types";
 
-// Everything about one Tares agent: its prompt, wiring, and — the part that doesn't belong on the
-// trigger page — its output. Each run shows when it was woken, which firing woke it, and the finding
-// rendered as markdown. External (connected) agents are not managed here; they live in the roster.
+// Everything about one Tares agent, run like an operational surface rather than a config sheet:
+// what it has cost and how it has performed (the stat cards), what it produced (Runs), and how it
+// is wired (Configuration). External (connected) agents are not managed here; they live in the
+// roster under Deliveries.
+
+type Tab = "overview" | "runs" | "configuration";
 
 function statusBadge(r: AgentRun) {
   if (r.status === "ok") return <span className="badge ok">ok</span>;
@@ -24,20 +27,25 @@ function statusBadge(r: AgentRun) {
 }
 
 export default function AgentDetail() {
-  // A dispatch page links here as ?dispatch=<id>: that run opens, highlights, and scrolls into
-  // view, so "what did the agent do with this firing" is one click.
+  // A dispatch page links here as ?dispatch=<id> (and a use case as ?run=<id>): the Runs tab
+  // opens with that run expanded, highlighted, and scrolled into view.
 
   const { name = "" } = useParams();
-  const [search] = useSearchParams();
+  const [search, setSearch] = useSearchParams();
   const focusDispatch = search.get("dispatch") ?? undefined;
   const focusRun = search.get("run") ?? undefined;
+  const tabParam = search.get("tab");
+  const tab: Tab = focusDispatch || focusRun
+    ? "runs"
+    : tabParam === "runs" || tabParam === "configuration" ? tabParam : "overview";
   const nav = useNavigate();
   const [editing, setEditing] = useState(false);
   const [confirmDel, setConfirmDel] = useState(false);
+  const [openRun, setOpenRun] = useState<string>();
   const [err, setErr] = useState<string>();
 
   const { data, error, reload } = usePolling(() => api.builtinAgents(), 10000);
-  const { data: runs, error: runsError } = usePolling(() => api.builtinAgentRuns(name, 20), 10000);
+  const { data: runs, error: runsError } = usePolling(() => api.builtinAgentRuns(name, 50), 10000);
   const { data: triggers } = usePolling(() => api.triggers(), 30000);
 
   if (error) return <div className="alert error">{error}</div>;
@@ -53,6 +61,14 @@ export default function AgentDetail() {
     );
   }
 
+  const setTab = (t: Tab) => {
+    // Switching tabs drops the run/dispatch focus params, or they would pin the Runs tab forever.
+    const next = new URLSearchParams();
+    if (t !== "overview") next.set("tab", t);
+    setSearch(next, { replace: true });
+    if (t !== "configuration") setEditing(false);
+  };
+
   const toggle = async () => {
     setErr(undefined);
     try {
@@ -62,7 +78,10 @@ export default function AgentDetail() {
     } catch (e) { setErr(String((e as Error).message ?? e)); }
   };
 
+  const stats = agent.stats;
+  const success = stats && stats.finished > 0 ? Math.round((100 * stats.ok) / stats.finished) : null;
   const lastRun = runs?.[0];
+  const latestFinding = runs?.find((r) => r.finding && r.status === "ok");
 
   return (
     <>
@@ -77,7 +96,7 @@ export default function AgentDetail() {
         {!editing && (
           <span className="btnrow">
             <button className="primary" onClick={toggle}>{agent.enabled ? "Disable" : "Enable"}</button>
-            <button onClick={() => setEditing(true)}>Edit</button>
+            <button onClick={() => { setTab("configuration"); setEditing(true); }}>Edit</button>
             <button className="danger" onClick={() => setConfirmDel(true)}>Delete</button>
           </span>
         )}
@@ -85,21 +104,33 @@ export default function AgentDetail() {
 
       {err && <div className="alert error">{err}</div>}
 
-      {editing ? (
-        <AgentForm
-          initial={agent}
-          triggers={(triggers ?? []).map((t) => t.name)}
-          presets={data.presets}
-          models={data.models}
-          defaultModel={data.default_model}
-          slackWorkspace={data.slack_workspace}
-          defaultMaxRounds={data.default_max_rounds}
-          defaultMaxRoundsWithMcp={data.default_max_rounds_with_mcp}
-          maxRoundsLimit={data.max_rounds_limit}
-          onSaved={() => { setEditing(false); reload(); }}
-          onCancel={() => setEditing(false)}
-        />
-      ) : (
+      <div className="cards">
+        <div className="card">
+          <div className="k">total cost</div>
+          <div className="v">{fmtCost(stats?.cost_usd)}
+            {!!stats?.uncosted_runs && <small title="runs from before cost tracking, or on a model without a known price">+{stats.uncosted_runs} uncosted</small>}
+          </div>
+        </div>
+        <div className="card"><div className="k">runs</div><div className="v">{stats?.runs ?? 0}</div></div>
+        <div className="card">
+          <div className="k">success</div>
+          <div className="v">{success != null ? `${success}%` : "—"}
+            {stats && stats.finished > 0 && <small>{stats.ok} of {stats.finished} concluded</small>}
+          </div>
+        </div>
+        <div className="card">
+          <div className="k">avg duration</div>
+          <div className="v">{stats?.avg_duration_ms != null ? `${(stats.avg_duration_ms / 1000).toFixed(1)}s` : "—"}</div>
+        </div>
+      </div>
+
+      <div className="tabs" style={{ marginTop: 16 }}>
+        <button className={tab === "overview" ? "active" : ""} onClick={() => setTab("overview")}>Overview</button>
+        <button className={tab === "runs" ? "active" : ""} onClick={() => setTab("runs")}>Runs</button>
+        <button className={tab === "configuration" ? "active" : ""} onClick={() => setTab("configuration")}>Configuration</button>
+      </div>
+
+      {tab === "overview" && (
         <>
           <div className="panel">
             <table>
@@ -127,9 +158,75 @@ export default function AgentDetail() {
                 <tr><td className="help">model</td>
                     <td><span className="mono">{agent.model || data.default_model}</span>
                         {!agent.model && <span className="help"> · instance default</span>}</td></tr>
+                <tr><td className="help">tokens used</td>
+                    <td>{stats && (stats.input_tokens || stats.output_tokens)
+                      ? <><span className="mono">{fmtTokens(stats.input_tokens)}</span> in
+                          {" · "}<span className="mono">{fmtTokens(stats.output_tokens)}</span> out</>
+                      : <span className="dim">—</span>}</td></tr>
+                <tr><td className="help">Slack</td>
+                    <td>{agent.slack_channel
+                      ? <><span className="badge ok">channel</span> <span className="help">posted by the workspace bot</span></>
+                      : agent.slack_configured
+                        ? <><span className="badge ok">webhook</span> <span className="help">legacy per-agent webhook</span></>
+                        : <span className="dim">—</span>}</td></tr>
+              </tbody>
+            </table>
+          </div>
+
+          {latestFinding && (
+            <>
+              <h2>Latest finding</h2>
+              <div className="panel">
+                <p className="help" style={{ margin: "0 0 8px" }}>
+                  for <span className="mono">{latestFinding.key}</span> · <TimeAgo ts={latestFinding.started_at} />
+                  {" · "}<a onClick={(e) => { e.preventDefault(); setTab("runs"); }} href="?tab=runs">all runs</a>
+                </p>
+                <div className="md">
+                  <ReactMarkdown remarkPlugins={[remarkGfm]}>{latestFinding.finding!}</ReactMarkdown>
+                </div>
+              </div>
+            </>
+          )}
+        </>
+      )}
+
+      {tab === "runs" && (
+        <RunsTable runs={runs} runsError={runsError} agent={agent}
+                   focusDispatch={focusDispatch} focusRun={focusRun}
+                   openRun={openRun} setOpenRun={setOpenRun} />
+      )}
+
+      {tab === "configuration" && (
+        editing ? (
+          <AgentForm
+            initial={agent}
+            triggers={(triggers ?? []).map((t) => t.name)}
+            presets={data.presets}
+            models={data.models}
+            defaultModel={data.default_model}
+            slackWorkspace={data.slack_workspace}
+            defaultMaxRounds={data.default_max_rounds}
+            defaultMaxRoundsWithMcp={data.default_max_rounds_with_mcp}
+            maxRoundsLimit={data.max_rounds_limit}
+            onSaved={() => { setEditing(false); reload(); }}
+            onCancel={() => setEditing(false)}
+          />
+        ) : (
+          <div className="panel">
+            <table>
+              <tbody>
+                <tr><td className="help" style={{ width: 150 }}>trigger</td>
+                    <td><Link to={`/triggers/${encodeURIComponent(agent.trigger)}`} className="mono">{agent.trigger}</Link></td></tr>
+                <tr><td className="help">model</td>
+                    <td><span className="mono">{agent.model || data.default_model}</span>
+                        {!agent.model && <span className="help"> · instance default</span>}</td></tr>
                 <tr><td className="help">max rounds</td>
                     <td><span className="mono">{agent.effective_max_rounds}</span>
                         {!agent.max_rounds && <span className="help"> · default{agent.mcp_servers.length ? " for an agent with external MCP servers" : ""}</span>}</td></tr>
+                <tr><td className="help">external tools</td>
+                    <td>{agent.mcp_servers.length
+                      ? agent.mcp_servers.map((m) => <span key={m} className="chip mono" style={{ marginRight: 4 }}>{m}</span>)
+                      : <span className="dim">—</span>}</td></tr>
                 <tr><td className="help">Slack</td>
                     <td>{agent.slack_channel
                       ? <><span className="badge ok">channel</span> <span className="help">posted by the workspace bot</span></>
@@ -147,59 +244,9 @@ export default function AgentDetail() {
                     <td><pre className="mono" style={{ whiteSpace: "pre-wrap", margin: 0 }}>{agent.prompt}</pre></td></tr>
               </tbody>
             </table>
+            <button style={{ marginTop: 10 }} onClick={() => setEditing(true)}>Edit</button>
           </div>
-
-          <h2>Runs &amp; findings</h2>
-          {runsError && <ErrorState error={runsError} what="this agent’s runs" />}
-          {!runsError && !runs?.length && <p className="help">none yet; this agent runs when <span className="mono">{agent.trigger}</span> fires</p>}
-          {runs?.map((r, i) => {
-            const header = (
-              <>
-                {statusBadge(r)}{" "}
-                <span className="mono">{r.key}</span>{" "}
-                <span className="help">
-                  · <TimeAgo ts={r.started_at} />
-                  {r.dispatch_id && <> · <Link to={`/dispatches/${encodeURIComponent(r.dispatch_id)}`}>firing</Link></>}
-                  {r.rounds ? ` · ${r.rounds}${r.max_rounds ? `/${r.max_rounds}` : ""} round${r.rounds === 1 && !r.max_rounds ? "" : "s"}` : ""}
-                  {r.duration_ms != null ? ` · ${(r.duration_ms / 1000).toFixed(1)}s` : ""}
-                </span>
-                {(r.external_tools ?? []).length > 0 && (
-                  <span style={{ marginLeft: 8 }}>
-                    {[...new Set(r.external_tools)].map((t) => (
-                      <span key={t} className="chip mono" title="external MCP tool this run called"
-                            style={{ marginRight: 4 }}>{t}</span>
-                    ))}
-                  </span>
-                )}
-              </>
-            );
-            const exhaustedNote = r.status === "exhausted" && (
-              <p className="help" style={{ margin: "8px 0 0" }}>
-                ran out of rounds before concluding ({r.rounds}{r.max_rounds ? `/${r.max_rounds}` : ""});
-                raise max rounds under Edit, Advanced.
-                {r.finding ? " What it had so far:" : ""}
-              </p>
-            );
-            const body = r.finding
-              ? <>{exhaustedNote}<div className="md" style={{ marginTop: 8 }}>
-                  <ReactMarkdown remarkPlugins={[remarkGfm]}>{r.finding}</ReactMarkdown>
-                </div></>
-              : exhaustedNote || <p className="help" style={{ margin: "8px 0 0" }}>
-                  {r.status === "running" ? "investigating…" : (r.error ?? "no finding")}
-                </p>;
-            // Newest run expanded by default; older ones collapse so the page stays readable as
-            // runs accumulate. <details> keeps it dependency-free and keyboard-accessible.
-            const focused = (!!focusDispatch && r.dispatch_id === focusDispatch) || (!!focusRun && r.id === focusRun);
-            return (
-              <details className="panel" key={r.id} open={i === 0 || focused}
-                       style={focused ? { outline: "2px solid var(--accent)" } : undefined}
-                       ref={(el) => { if (el && focused) el.scrollIntoView({ block: "center" }); }}>
-                <summary style={{ cursor: "pointer", listStyle: "revert" }}>{header}</summary>
-                {body}
-              </details>
-            );
-          })}
-        </>
+        )
       )}
 
       {confirmDel && (
@@ -214,6 +261,117 @@ export default function AgentDetail() {
             catch (e) { setErr(String((e as Error).message ?? e)); setConfirmDel(false); }
           }}
         />
+      )}
+    </>
+  );
+}
+
+function RunsTable({ runs, runsError, agent, focusDispatch, focusRun, openRun, setOpenRun }: {
+  runs: AgentRun[] | undefined;
+  runsError: string | undefined;
+  agent: BuiltinAgent;
+  focusDispatch?: string;
+  focusRun?: string;
+  openRun: string | undefined;
+  setOpenRun: (id: string | undefined) => void;
+}) {
+  if (runsError) return <ErrorState error={runsError} what="this agent’s runs" />;
+  if (!runs?.length) {
+    return <p className="help">none yet; this agent runs when <span className="mono">{agent.trigger}</span> fires</p>;
+  }
+  const isFocused = (r: AgentRun) =>
+    (!!focusDispatch && r.dispatch_id === focusDispatch) || (!!focusRun && r.id === focusRun);
+  return (
+    <table>
+      <thead>
+        <tr>
+          <th>status</th><th>when</th><th>entity</th><th>model</th>
+          <th className="num">rounds</th><th className="num">tokens</th>
+          <th className="num">cost</th><th className="num">duration</th><th />
+        </tr>
+      </thead>
+      <tbody>
+        {runs.map((r) => {
+          const focused = isFocused(r);
+          // A deep-linked run starts open; clicking any row toggles it like the roster table.
+          const open = openRun !== undefined ? openRun === r.id : focused;
+          return (
+            <RunRow key={r.id} r={r} open={open} focused={focused}
+                    onToggle={() => setOpenRun(open ? "" : r.id)} />
+          );
+        })}
+      </tbody>
+    </table>
+  );
+}
+
+function RunRow({ r, open, focused, onToggle }: {
+  r: AgentRun; open: boolean; focused: boolean; onToggle: () => void;
+}) {
+  // A dash on an old run means unknown, not zero: usage was not recorded before cost tracking.
+  const hasTokens = r.input_tokens != null || r.output_tokens != null;
+  const cache = (r.cache_creation_input_tokens ?? 0) + (r.cache_read_input_tokens ?? 0);
+  const exhaustedNote = r.status === "exhausted" && (
+    <p className="help" style={{ margin: "0 0 8px", whiteSpace: "normal" }}>
+      ran out of rounds before concluding ({r.rounds}{r.max_rounds ? `/${r.max_rounds}` : ""});
+      raise max rounds under Configuration, Advanced.
+      {r.finding ? " What it had so far:" : ""}
+    </p>
+  );
+  return (
+    <>
+      <tr className="clickable" onClick={onToggle}
+          style={focused ? { outline: "2px solid var(--accent)", outlineOffset: -2 } : undefined}
+          ref={(el) => { if (el && focused) el.scrollIntoView({ block: "center" }); }}>
+        <td>{statusBadge(r)}</td>
+        <td style={{ whiteSpace: "nowrap" }}><TimeAgo ts={r.started_at} /></td>
+        <td className="mono">{r.key}</td>
+        <td className="mono">{r.model ?? <span className="dim">—</span>}</td>
+        <td className="num">{r.rounds}{r.max_rounds ? <span className="dim">/{r.max_rounds}</span> : null}</td>
+        <td className="num" style={{ whiteSpace: "nowrap" }}
+            title={hasTokens ? `${(r.input_tokens ?? 0).toLocaleString()} in · ${(r.output_tokens ?? 0).toLocaleString()} out` : "this run predates usage tracking"}>
+          {hasTokens
+            ? <>{fmtTokens(r.input_tokens)} <span className="dim">in</span> {fmtTokens(r.output_tokens)} <span className="dim">out</span></>
+            : <span className="dim">—</span>}
+        </td>
+        <td className="num">{fmtCost(r.cost_usd)}</td>
+        <td className="num" style={{ whiteSpace: "nowrap" }}>
+          {r.duration_ms != null ? `${(r.duration_ms / 1000).toFixed(1)}s` : "—"}
+        </td>
+        <td className="dim">{open ? "▾" : "▸"}</td>
+      </tr>
+      {open && (
+        <tr>
+          <td colSpan={9} style={{ background: "var(--wash, transparent)" }}>
+            <div style={{ padding: "8px 4px" }}>
+              <p className="help" style={{ margin: "0 0 8px", whiteSpace: "normal" }}>
+                {r.dispatch_id
+                  ? <><Link to={`/dispatches/${encodeURIComponent(r.dispatch_id)}`}>the firing</Link> that woke it</>
+                  : "run without a firing (manual or bootstrap)"}
+                {r.tool_calls ? <> · {r.tool_calls} tool call{r.tool_calls === 1 ? "" : "s"}</> : null}
+                {cache > 0 && <> · cache: {fmtTokens(r.cache_creation_input_tokens)} written, {fmtTokens(r.cache_read_input_tokens)} read</>}
+              </p>
+              {(r.external_tools ?? []).length > 0 && (
+                <p style={{ margin: "0 0 8px" }}>
+                  {[...new Set(r.external_tools)].map((t) => (
+                    <span key={t} className="chip mono" title="external MCP tool this run called"
+                          style={{ marginRight: 4 }}>{t}</span>
+                  ))}
+                </p>
+              )}
+              {exhaustedNote}
+              {r.finding
+                ? <div className="md">
+                    <ReactMarkdown remarkPlugins={[remarkGfm]}>{r.finding}</ReactMarkdown>
+                  </div>
+                : !exhaustedNote && (
+                    <p className="help" style={{ margin: 0, whiteSpace: "normal" }}>
+                      {r.status === "running" ? "investigating…" : (r.error ?? "no finding")}
+                    </p>
+                  )}
+            </div>
+          </td>
+        </tr>
       )}
     </>
   );

--- a/ui/src/pages/Agents.tsx
+++ b/ui/src/pages/Agents.tsx
@@ -1,7 +1,7 @@
 import { Link, useNavigate } from "react-router-dom";
 
 import { api } from "../api";
-import { TimeAgo, usePolling } from "../components/bits";
+import { TimeAgo, fmtCost, usePolling } from "../components/bits";
 import type { AgentRun } from "../types";
 
 // Tares agents: the prompts you author that run in-process when a trigger fires. Subscribers
@@ -52,7 +52,8 @@ export default function Agents() {
           </div>
         ) : (
           <table>
-            <thead><tr><th>agent</th><th>trigger</th><th>status</th><th>last run</th><th>finding</th></tr></thead>
+            <thead><tr><th>agent</th><th>trigger</th><th>status</th><th>last run</th>
+              <th className="num">runs</th><th className="num">cost</th><th>finding</th></tr></thead>
             <tbody>
               {data.agents.map((a) => (
                 <tr key={a.name} className="clickable"
@@ -62,6 +63,11 @@ export default function Agents() {
                   <td>{a.enabled ? <span className="badge ok">enabled</span> : <span className="badge">disabled</span>}</td>
                   <td style={{ whiteSpace: "nowrap" }}>
                     {runBadge(a.last_run)}{a.last_run && <> <TimeAgo ts={a.last_run.started_at} /></>}
+                  </td>
+                  <td className="num">{a.stats?.runs ?? 0}</td>
+                  <td className="num"
+                      title={a.stats?.uncosted_runs ? `plus ${a.stats.uncosted_runs} run(s) with no recorded cost` : undefined}>
+                    {fmtCost(a.stats?.cost_usd)}
                   </td>
                   <td style={{ maxWidth: 360, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
                     {a.last_run?.finding ?? <span className="dim">—</span>}

--- a/ui/src/pages/Home.tsx
+++ b/ui/src/pages/Home.tsx
@@ -2,8 +2,8 @@ import { useEffect } from "react";
 import { Link, useNavigate } from "react-router-dom";
 
 import { api } from "../api";
-import { ErrorState, TimeAgo, formatBytes, usePolling } from "../components/bits";
-import type { Usage, Usecase } from "../types";
+import { ErrorState, TimeAgo, fmtCost, fmtTokens, formatBytes, usePolling } from "../components/bits";
+import type { ModelUsage, Usage, Usecase } from "../types";
 
 // The instance at a glance. This exists because the numbers that describe the WHOLE instance —
 // how full the disk is, how much has been ingested, how hard the agents are working — were living
@@ -28,6 +28,7 @@ export default function Home() {
   const { data: u, error: usageError, reload: reloadUsage } = usePolling(() => api.usage(), 30000);
   const { data: sources, error: sourcesError } = usePolling(() => api.sources(), 30000);
   const { data: uc } = usePolling(() => api.usecases(), 30000);
+  const { data: mu, error: muError, reload: reloadMu } = usePolling(() => api.modelUsage(30), 30000);
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -89,6 +90,8 @@ export default function Home() {
 
       {uc && uc.usecases.length > 0 && <UsecasesPanel usecases={uc.usecases} />}
 
+      <ModelSpendPanel usage={mu} error={muError} reload={reloadMu} />
+
       <StoragePanel
         usage={u}
         error={usageError}
@@ -104,6 +107,66 @@ export default function Home() {
         </div>
       )}
     </>
+  );
+}
+
+// What has this instance spent on its Anthropic key? — the whole-instance counterpart of the
+// per-agent cost cards. Covers everything that burns the key inside the cell (Tares agent runs
+// and Ask); external agents run on their own keys and are deliberately absent. The total is a
+// floor: runs from before cost tracking, and models without a known price, carry no cost —
+// said out loud via the uncosted note rather than silently folded into $0.
+function ModelSpendPanel({ usage, error, reload }: {
+  usage: ModelUsage | undefined;
+  error?: string;
+  reload: () => void;
+}) {
+  const m = usage;
+  const today = m?.days.length ? m.days[m.days.length - 1] : null;
+  const windowCost = m?.days.reduce((s, d) => s + (d.cost_usd ?? 0), 0) ?? 0;
+  const agent = m?.by_surface.agent;
+  const ask = m?.by_surface.ask;
+  const uncosted = m?.total.uncosted_calls ?? 0;
+  return (
+    <div className="panel">
+      <h2 style={{ marginTop: 0 }}>Model spend</h2>
+      <p className="help" style={{ marginTop: 0 }}>
+        What this instance has spent on its Anthropic key; Tares agent runs plus Ask. External
+        agents run on their own keys and are not counted here.
+      </p>
+
+      {error && <ErrorState error={error} what="model spend" onRetry={reload} />}
+      {!m && !error && <div className="muted">loading…</div>}
+
+      {m && (m.total.calls === 0 ? (
+        <p className="help" style={{ marginBottom: 0 }}>
+          Nothing spent yet; the meter starts counting with the first agent run or Ask question.
+        </p>
+      ) : (
+        <>
+          <div className="cards" style={{ marginBottom: 8 }}>
+            <div className="card">
+              <div className="k">all time</div>
+              <div className="v">{fmtCost(m.total.cost_usd)}</div>
+            </div>
+            <div className="card">
+              <div className="k">last {m.window_days} days</div>
+              <div className="v">{fmtCost(windowCost)}</div>
+            </div>
+            <div className="card">
+              <div className="k">today</div>
+              <div className="v">{today ? fmtCost(today.cost_usd ?? 0) : fmtCost(0)}</div>
+            </div>
+          </div>
+          <p className="help" style={{ marginBottom: 0 }}>
+            {agent && <>agents {fmtCost(agent.cost_usd)} over {agent.calls.toLocaleString()} model call{agent.calls === 1 ? "" : "s"}</>}
+            {agent && ask && " · "}
+            {ask && <>Ask {fmtCost(ask.cost_usd)} over {ask.calls.toLocaleString()} call{ask.calls === 1 ? "" : "s"}</>}
+            {" · "}{fmtTokens(m.total.input_tokens)} tokens in, {fmtTokens(m.total.output_tokens)} out
+            {uncosted > 0 && <> · {uncosted} call{uncosted === 1 ? "" : "s"} on an unpriced model, not in the total</>}
+          </p>
+        </>
+      ))}
+    </div>
   );
 }
 

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -250,6 +250,20 @@ export interface BuiltinAgent {
   last_run?: AgentRun | null;
   owned_by?: string | null;
   customized?: boolean;
+  stats?: AgentStats;
+}
+
+// Lifetime aggregates over an agent's runs. cost_usd is a floor: runs from before usage tracking
+// and runs on unpriced models carry no cost (uncosted_runs counts those).
+export interface AgentStats {
+  runs: number;
+  ok: number;
+  finished: number;            // runs that concluded or tried to (excludes running and capped)
+  avg_duration_ms: number | null;
+  cost_usd: number | null;
+  input_tokens: number;
+  output_tokens: number;
+  uncosted_runs: number;
 }
 
 export interface AgentRun {
@@ -267,6 +281,32 @@ export interface AgentRun {
   duration_ms: number | null;
   finding: string | null;
   error: string | null;
+  // Model usage; null on runs from before cost tracking (unknown, not zero).
+  model?: string | null;
+  input_tokens?: number | null;
+  output_tokens?: number | null;
+  cache_creation_input_tokens?: number | null;
+  cache_read_input_tokens?: number | null;
+  cost_usd?: number | null;
+}
+
+// The cell's Anthropic spend meter (/api/usage/model): all-time totals plus a per-day tail,
+// split by surface (agent runs vs Ask).
+export interface ModelUsageBucket {
+  calls: number;
+  input_tokens: number;
+  output_tokens: number;
+  cache_creation_input_tokens: number;
+  cache_read_input_tokens: number;
+  cost_usd: number | null;
+  uncosted_calls: number;
+}
+
+export interface ModelUsage {
+  total: ModelUsageBucket;
+  by_surface: Record<string, ModelUsageBucket>;
+  days: ({ day: string } & ModelUsageBucket)[];
+  window_days: number;
 }
 
 export interface AgentPreset {


### PR DESCRIPTION
Tares agents never got the treatment they deserve: the agents page showed config plus stacked run panels, with nothing about models, runs, or cost. And the upcoming $10 cloud credits need each cell to meter its own Anthropic spend.

## Cost tracking
- `tares/pricing.py`: family-prefix pricing (fable 10/50, opus 5/25, sonnet 3/15, haiku 1/5 USD per Mtok; cache write 1.25x, read 0.10x). Unknown model = cost null, never guessed.
- Agent runs: every model call's `usage` block is accumulated (incl. the tools-off call) and stamped on the run via try/finally, so failed runs still record tokens burned. Webhook write-back body carries `usage` + `cost_usd`.
- Ask: `run_agent` gained an `on_usage` callback; console chat and Slack `/tares ask` both record through it.
- Store: 6 nullable columns on `agent_runs` + a `model_usage` ledger both surfaces append to. Historical runs stay NULL (cost is a floor; `uncosted` counters make that visible).
- New `GET /api/usage/model`: all-time totals + per-day tail, split agent/ask. This is what the control plane will poll for credits; no credit logic in the cell (no-fork rule).

## Agents UI
- Agent detail rebuilt: stat cards (cost, runs, success, avg duration), Overview / Runs / Configuration tabs, runs as an expandable-row table with model, rounds, tokens in/out, cost, duration. `?run=` / `?dispatch=` deep links still work and force the Runs tab.
- Agents list: runs + cost columns.
- Overview: Model spend panel (all time / last 30 days / today, agent vs Ask split, uncosted note).

## Tests
- New `tests/test_pricing.py` (added to CI).
- Agents stub now emits usage; assertions check per-run tokens/cost against the sonnet math, list stats, and `/api/usage/model`.
- Slack-ask test asserts the ask surface lands on the meter with the stream's final usage.
- Full CI suite passes locally; verified end-to-end with a real key (4-round run, 7,015 in / 948 out, $0.0353 recorded consistently on run, stats, and meter).