### PR TITLE
AI SRE demo works against a hosted demo stack (TR-194)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Backend — install + tests
         run: |
           pip install -e .
-          for t in test_labels test_normalize test_auth test_api_keys test_pricing test_agents test_catalog_sync test_cli test_usage test_slack test_slack_verify test_slack_ask test_degraded; do
+          for t in test_labels test_normalize test_auth test_api_keys test_pricing test_agents test_catalog_sync test_cli test_usage test_slack test_slack_verify test_slack_ask test_degraded test_loki test_ai_sre_demo; do
             echo "== $t =="
             python "tests/$t.py"
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Backend — install + tests
         run: |
           pip install -e .
-          for t in test_labels test_normalize test_auth test_api_keys test_pricing test_agents test_catalog_sync test_cli test_usage test_slack test_slack_verify test_slack_ask test_degraded test_loki test_ai_sre_demo; do
+          for t in test_labels test_normalize test_auth test_api_keys test_pricing test_agents test_catalog_sync test_cli test_usage test_slack test_slack_verify test_slack_ask test_degraded test_loki test_ai_sre_demo test_seed; do
             echo "== $t =="
             python "tests/$t.py"
           done

--- a/tares/builtin_agents.py
+++ b/tares/builtin_agents.py
@@ -145,14 +145,16 @@ def prompt_hash(prompt: str) -> str:
 
 
 def resolve_key(store) -> tuple[str, str]:
-    """(key, where-it-came-from). The env `ANTHROPIC_API_KEY` (the standard SDK name most users
-    already have exported) wins over the console-stored value, so an operator's deployment config is
-    never silently overridden by something typed into a UI months earlier."""
-    val = os.getenv("ANTHROPIC_API_KEY", "").strip()
-    if val:
-        return val, "env:ANTHROPIC_API_KEY"
+    """(key, where-it-came-from). The console-stored key wins over the env `ANTHROPIC_API_KEY`:
+    the user's own key takes over from whatever the deployment shipped the moment they save one.
+    That order is load-bearing for hosted trials — an operator-provided key in the env must yield
+    to the customer's key instantly, so their spend lands on their key, not the trial's. Deleting
+    the stored key falls back to the env key (if the deployment still carries one)."""
     stored = (store.get_setting("anthropic_key") or "").strip()
-    return (stored, "console") if stored else ("", "")
+    if stored:
+        return stored, "console"
+    val = os.getenv("ANTHROPIC_API_KEY", "").strip()
+    return (val, "env:ANTHROPIC_API_KEY") if val else ("", "")
 
 
 class AgentRunner:
@@ -295,7 +297,7 @@ class AgentRunner:
                    run_id: str, dispatch_id: str | None = None) -> tuple[str, str | None]:
         started_at = now_utc()
         t0 = time.monotonic()
-        api_key, _ = resolve_key(self.store)
+        api_key, key_origin = resolve_key(self.store)
         if not api_key:
             msg = "no Anthropic key: set ANTHROPIC_API_KEY or add one in the console"
             self.store.finish_agent_run(run_id, "failed", error=msg)
@@ -326,7 +328,8 @@ class AgentRunner:
                 self.store.record_model_usage(
                     "agent", agent["name"], run_id, model, usage["calls"],
                     usage["input_tokens"], usage["output_tokens"],
-                    usage["cache_creation_input_tokens"], usage["cache_read_input_tokens"], cost)
+                    usage["cache_creation_input_tokens"], usage["cache_read_input_tokens"], cost,
+                    key_source=key_origin)
         if exhausted:
             # The round budget ran out before the model concluded. Keep whatever it said last as
             # a partial note (in `finding`, so it is visible) and say plainly what to do.

--- a/tares/connectors/__init__.py
+++ b/tares/connectors/__init__.py
@@ -15,6 +15,7 @@ from .base import UNIVERSAL_CONFIG
 from .claude_code import ClaudeCodeConnector
 from .docker_logs import DockerLogsConnector
 from .github import GithubConnector
+from .loki import LokiConnector
 from .memory import MemoryConnector
 from .otlp import OtlpConnector
 from .postgres import PostgresConnector
@@ -27,6 +28,7 @@ from .webhook import WebhookConnector
 REGISTRY = {
     "prometheus": PrometheusConnector,
     "docker_logs": DockerLogsConnector,
+    "loki": LokiConnector,
     "prometheus_alerts": PrometheusAlertsConnector,
     "alertmanager": AlertmanagerConnector,
     "reference": ReferenceConnector,
@@ -48,6 +50,10 @@ SPECS = {
     "docker_logs": {"label": "Docker logs", "mode": "poll", "discover": True,
                     "description": "Tails a running container's logs; all lines by default; "
                                    "optional match/drop regex filters."},
+    "loki": {"label": "Grafana Loki", "mode": "poll", "poll": "5s",
+             "description": "Polls a LogQL stream selector via query_range (cursor by "
+                            "timestamp); one event per log line, with the stream's labels. "
+                            "Works against any reachable Loki, including Grafana Cloud."},
     "prometheus_alerts": {"label": "Prometheus alerts", "mode": "poll", "discover": True, "poll": "30s",
                           "description": "Polls Prometheus's own /api/v1/alerts, the alerts its rules "
                                          "have fired, and emits one event per active alert (keyed by a "
@@ -102,7 +108,8 @@ SPECS = {
 # A source's signal type is a property of its connector, not something the user authors. Mostly
 # descriptive — EXCEPT "reference", which the read path treats specially (always surfaced, never
 # time-windowed; see store.read_view_window).
-_SOURCE_TYPES = {"docker_logs": "application_log", "memory": "agent_memory",
+_SOURCE_TYPES = {"docker_logs": "application_log", "loki": "application_log",
+                 "memory": "agent_memory",
                  "otlp": "application_log", "vercel": "application_log",
                  "claude_code": "agent_session", "reference": "reference",
                  "finding": "finding"}

--- a/tares/connectors/loki.py
+++ b/tares/connectors/loki.py
@@ -1,0 +1,130 @@
+"""Grafana Loki connector — polls a LogQL stream selector via query_range, one Envelope per line.
+
+The pull-based counterpart of docker_logs for logs that live in a Loki (or a Loki-compatible
+endpoint): the cell polls with a timestamp cursor instead of tailing a local container, so it
+works against any reachable Loki — a customer's own, Grafana Cloud, or a hosted demo stack.
+
+Ingests all matched lines by default (lossless; reads/triggers decide what's interesting).
+Optional match/drop regex filters narrow it, same semantics as docker_logs. Lines get the same
+format-agnostic derived fields (level, http method/status, JSON scalars) as docker_logs, so a
+view over either source sees the same shape.
+
+Cursor is the last-seen entry timestamp in nanoseconds (Loki's native unit); the next poll asks
+from cursor+1 so the boundary entry is never re-ingested.
+"""
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+
+import httpx
+
+from ..envelope import Envelope, now_utc
+from .base import Connector
+from .docker_logs import derive_fields
+
+# Cap how many lines one poll ingests: after downtime the range query can return a huge backlog;
+# take at most this many, advance the cursor to the last consumed entry, and drain over polls.
+MAX_PER_POLL = 5000
+# First poll looks back this far (mirrors docker_logs's "30s" initial --since).
+INITIAL_LOOKBACK_NS = 30 * 1_000_000_000
+
+
+def _client_kwargs(config: dict) -> dict:
+    """httpx client kwargs for the endpoint's auth: bearer and/or basic, plus Loki's tenant
+    header. Same shape as the prometheus connector so the two read identically."""
+    headers: dict = {}
+    if config.get("bearer_token"):
+        headers["Authorization"] = f"Bearer {config['bearer_token']}"
+    if config.get("tenant_id"):
+        headers["X-Scope-OrgID"] = str(config["tenant_id"])
+    kw: dict = {"headers": headers} if headers else {}
+    if config.get("username"):
+        kw["auth"] = (config["username"], config.get("password") or "")
+    return kw
+
+
+class LokiConnector(Connector):
+    CONFIG_SCHEMA = {
+        "url": {"type": "string", "required": True,
+                "help": "Loki base URL, e.g. http://localhost:3100"},
+        "query": {"type": "string", "required": True,
+                  "help": 'LogQL stream selector, e.g. {service="api-server"}'},
+        "bearer_token": {"type": "string", "secret": True,
+                         "help": "optional Authorization: Bearer token"},
+        "username": {"type": "string",
+                     "help": "optional HTTP basic-auth username (e.g. a Grafana Cloud user id)"},
+        "password": {"type": "string", "secret": True,
+                     "help": "optional basic-auth password / API token, paired with username"},
+        "tenant_id": {"type": "string",
+                      "help": "optional X-Scope-OrgID header for multi-tenant Loki"},
+        "match": {"type": "string",
+                  "help": "keep only lines matching this regex (default: all lines), e.g. ERROR|WARN"},
+        "drop": {"type": "string",
+                 "help": "skip lines matching this regex, e.g. 'HTTP/1.1\"' to drop access logs"},
+        "key": {"type": "string", "advanced": True,
+                "help": "legacy fixed key; prefer a primary label"},
+    }
+
+    def label_context(self, payload: dict | None) -> dict:
+        """A line's context from its stored payload: the stream's labels plus the same derived
+        fields docker_logs extracts. Used at ingest AND on retroactive relabel, so both see the
+        identical structure."""
+        p = payload or {}
+        stream = p.get("stream") if isinstance(p.get("stream"), dict) else {}
+        return {**(stream or {}), **derive_fields(str(p.get("raw", "")))}
+
+    async def poll(self):
+        c = self.cfg.config
+        base = c["url"].rstrip("/")
+        key_fallback = c.get("key", "unknown")
+        match_re = re.compile(c["match"], re.I) if c.get("match") else None
+        drop_re = re.compile(c["drop"], re.I) if c.get("drop") else None
+
+        cursor = self.store.get_cursor(self.cfg.name)
+        now_ns = int(now_utc().timestamp() * 1_000_000_000)
+        start_ns = int(cursor) + 1 if cursor else now_ns - INITIAL_LOOKBACK_NS
+
+        try:
+            async with httpx.AsyncClient(timeout=15, **_client_kwargs(c)) as cx:
+                r = await cx.get(f"{base}/loki/api/v1/query_range", params={
+                    "query": c["query"], "start": str(start_ns), "end": str(now_ns),
+                    "direction": "forward", "limit": MAX_PER_POLL,
+                })
+                streams = r.json().get("data", {}).get("result", [])
+        except Exception:
+            return []   # an unreachable Loki is a quiet poll, like every other poll connector
+
+        # Merge all streams' entries into one time-ordered pass: the cursor is global for the
+        # source, so it must only ever advance over lines actually consumed.
+        entries = []
+        for s in streams:
+            stream_labels = s.get("stream") or {}
+            for ts, line in s.get("values") or []:
+                entries.append((int(ts), str(line), stream_labels))
+        entries.sort(key=lambda e: e[0])
+
+        out = []
+        max_ts = None
+        for ts_ns, line, stream_labels in entries:
+            if ts_ns < start_ns:
+                continue
+            max_ts = ts_ns
+            msg = line.strip()
+            if match_re and not match_re.search(msg):
+                continue
+            if drop_re and drop_re.search(msg):
+                continue
+            event_time = datetime.fromtimestamp(ts_ns / 1_000_000_000, tz=timezone.utc)
+            ctx = {**stream_labels, **derive_fields(msg)}
+            labels, key = self.keyed(ctx, fallback=key_fallback)
+            out.append(Envelope(
+                source=self.cfg.name, source_type=self.cfg.type, key_value=key,
+                event_type="log", text=msg[:300], event_time=event_time,
+                payload={"raw": line, "stream": stream_labels}, labels=labels,
+            ))
+            if len(out) >= MAX_PER_POLL:
+                break   # leave the rest; cursor is at this entry
+        if max_ts is not None:
+            self.store.set_cursor(self.cfg.name, str(max_ts))
+        return out

--- a/tares/daemon.py
+++ b/tares/daemon.py
@@ -73,10 +73,17 @@ LOGIN_URL = os.getenv("TARES_LOGIN_URL", "").strip()
 # self-host: no link. Public, non-secret, surfaced on /health next to login_url.
 WORKSPACE_URL = os.getenv("TARES_WORKSPACE_URL", "").strip()
 # The Anthropic key for the in-app Ask agent (and Tares agents) is resolved at request time via
-# resolve_anthropic_key(store): env ANTHROPIC_API_KEY, else the console-stored key.
+# resolve_anthropic_key(store): the console-stored key, else env ANTHROPIC_API_KEY.
 # Never returned by any API — capabilities exposes only a boolean.
-# The Slack bot token behind the slack:// dispatch sink follows exactly the same rule via
-# resolve_slack_token(store): env TARES_SLACK_BOT_TOKEN, else the console-stored value.
+# The Slack bot token behind the slack:// dispatch sink keeps the OPPOSITE order via
+# resolve_slack_token(store): env TARES_SLACK_BOT_TOKEN wins over the console-stored value
+# (infrastructure wiring, not a metered credential — see the note on resolve_token).
+
+# Seed a use case on first boot (additive, env-gated): the named recipe is created once, so a
+# hosted cell is born with its demo already running instead of an empty system. A settings
+# marker makes it one-shot — deleting the use case never resurrects it. Meaningful for a
+# self-hoster building a golden image too; harmlessly unset otherwise.
+SEED_USECASE = os.getenv("TARES_SEED_USECASE", "").strip()
 
 
 def _is_ingest(path: str) -> bool:
@@ -333,6 +340,28 @@ class SlackSigningSecretIn(BaseModel):
     secret: str  # the signing secret behind POST /api/slack/events; same write-only contract
 
 
+def _seed_usecase(store, usecases) -> None:
+    """Create TARES_SEED_USECASE's use case once, on the first boot that carries the var. The
+    `seeded_usecase` settings marker is the one-shot record: it is written after the attempt
+    (success or failure), so a user who deletes the seeded use case never gets it back on a pod
+    restart. An unknown recipe key writes NO marker — a config typo stays fixable by fixing the
+    config. Never raises: a failed seed is a log line, not a dead cell."""
+    if not SEED_USECASE:
+        return
+    if store.get_setting("seeded_usecase"):
+        return
+    from .usecases.registry import list_recipes
+    if SEED_USECASE not in {r.key for r in list_recipes()}:
+        print(f"taresd: TARES_SEED_USECASE names unknown recipe {SEED_USECASE!r}; not seeded")
+        return
+    try:
+        inst = usecases.create(SEED_USECASE, params={})
+        print(f"taresd: seeded use case {SEED_USECASE!r} ({inst['id']})")
+    except Exception as e:
+        print(f"taresd: seeding use case {SEED_USECASE!r} failed: {type(e).__name__}: {e}")
+    store.set_setting("seeded_usecase", SEED_USECASE)
+
+
 def make_app() -> FastAPI:
     try:
         store = Store(DB_PATH)
@@ -363,6 +392,8 @@ def make_app() -> FastAPI:
     # webhook). In-process, so `tares up` closes the loop with nothing to deploy.
     dispatcher.agents = AgentRunner(store, runtime)
     dispatcher.runtime = runtime
+
+    _seed_usecase(store, usecases)
 
     def _otlp_source_for(header: str | None) -> str:
         """Resolve the OTLP source for an export (shared by the HTTP and gRPC receivers). Raises
@@ -1159,16 +1190,19 @@ def make_app() -> FastAPI:
         return {"sampled": sampled, "fields": fields, "labels": labels}
 
     # ── in-app agent (the Ask view) — server-side chat loop over the read API ──
-    def _record_ask_usage(model: str, usage: dict) -> None:
+    def _record_ask_usage(model: str, usage: dict, key_source: str = "") -> None:
         """One ledger row per Ask turn (console chat or Slack /ask), so the cell's spend meter
-        covers everything that talks to Anthropic, not just agent runs."""
+        covers everything that talks to Anthropic, not just agent runs. `key_source` is the
+        origin of the key that PAID for this turn, captured by the caller when it resolved the
+        key — never re-resolved here, the stored key could have changed mid-turn."""
         from .pricing import cost_usd
         store.record_model_usage(
             "ask", "", "", model, usage["calls"],
             usage["input_tokens"], usage["output_tokens"],
             usage["cache_creation_input_tokens"], usage["cache_read_input_tokens"],
             cost_usd(model, usage["input_tokens"], usage["output_tokens"],
-                     usage["cache_creation_input_tokens"], usage["cache_read_input_tokens"]))
+                     usage["cache_creation_input_tokens"], usage["cache_read_input_tokens"]),
+            key_source=key_source or None)
 
     @app.post("/api/agent/chat")
     async def agent_chat(request: Request):
@@ -1177,7 +1211,7 @@ def make_app() -> FastAPI:
         # `X-Anthropic-Key` header override, which the console filled from localStorage — so a key
         # added on the Ask page made Ask work while Slack and trigger-woken agents still reported
         # none configured, having no browser to read it from (NF-125).
-        key = resolve_anthropic_key(store)[0]
+        key, key_origin = resolve_anthropic_key(store)
         if not key:
             _err(ValueError("add your Anthropic API key to use the assistant"), 400)
         body = await request.json()
@@ -1186,7 +1220,7 @@ def make_app() -> FastAPI:
         return StreamingResponse(
             run_agent(key, body.get("messages") or [],
                       model=body.get("model"), self_headers=self_headers,
-                      on_usage=_record_ask_usage),
+                      on_usage=lambda m, u: _record_ask_usage(m, u, key_source=key_origin)),
             media_type="text/event-stream")
 
     # ── MCP connections — external tool servers a Tares agent can opt into ─────
@@ -1658,11 +1692,12 @@ def make_app() -> FastAPI:
             _err(KeyError(f"unknown agent {name!r}"), 404)
         return store.list_agent_runs(name, limit=min(limit, 200))
 
-    # ── the Anthropic key: env wins, console is the fallback ─────────────────
+    # ── the Anthropic key: a stored key wins, env is the fallback ────────────
     @app.get("/api/settings/anthropic-key")
     async def get_anthropic_key():
-        """Never returns the key — only whether one is resolvable and where it came from, so the
-        console can explain that an env-set key overrides what's stored."""
+        """Never returns the key — only whether one is resolvable and where it came from. A key
+        saved here takes over from the deployment's env key; `env_overrides` is kept for API
+        compatibility and can now only be true when no key is stored."""
         key, origin = resolve_anthropic_key(store)
         return {"configured": bool(key), "source": origin,
                 "stored": bool(store.get_setting("anthropic_key")),
@@ -1675,12 +1710,12 @@ def make_app() -> FastAPI:
             _err(ValueError("key is required (use DELETE to remove the stored key)"))
         store.set_setting("anthropic_key", key)
         _, origin = resolve_anthropic_key(store)
-        return {"ok": True, "source": origin,
-                **({"note": "an environment key takes precedence and is still in use"}
-                   if origin.startswith("env:") else {})}
+        return {"ok": True, "source": origin}
 
     @app.delete("/api/settings/anthropic-key")
     async def clear_anthropic_key():
+        """Removing the stored key falls back to the deployment's env key when one exists — on a
+        hosted trial cell that is the trial key, until its operator removes it too."""
         store.set_setting("anthropic_key", None)
         key, origin = resolve_anthropic_key(store)
         return {"ok": True, "configured": bool(key), "source": origin}
@@ -1799,13 +1834,14 @@ def make_app() -> FastAPI:
         from .agent import run_agent
         text, error = "", None
         try:
-            key = resolve_anthropic_key(store)[0]
+            key, key_origin = resolve_anthropic_key(store)
             self_headers = {"Authorization": f"Bearer {AUTH_TOKEN}"} if AUTH_TOKEN else {}
             async def _run():
                 nonlocal text, error
                 async for chunk in run_agent(key, [{"role": "user", "content": question}],
                                              self_headers=self_headers,
-                                             on_usage=_record_ask_usage):
+                                             on_usage=lambda m, u: _record_ask_usage(
+                                                 m, u, key_source=key_origin)):
                     for line in chunk.splitlines():
                         if not line.startswith("data: "):
                             continue

--- a/tares/slack.py
+++ b/tares/slack.py
@@ -48,9 +48,11 @@ _MAX_SECTION = 2800
 
 
 def resolve_token(store) -> tuple[str, str]:
-    """(token, where-it-came-from). Mirrors `resolve_key` for the Anthropic key: the environment
-    wins over the console-stored value, so an operator's deployment config is never silently
-    overridden by something typed into a UI months earlier."""
+    """(token, where-it-came-from). Environment wins over the console-stored value: an operator's
+    deployment config is never silently overridden by something typed into a UI months earlier.
+    Deliberately NOT the Anthropic key's order (resolve_key flipped to console-wins for hosted
+    trials); the Slack token is infrastructure wiring, not a metered credential, so env-wins
+    stays right here."""
     val = os.getenv(ENV_VAR, "").strip()
     if val:
         return val, f"env:{ENV_VAR}"

--- a/tares/store.py
+++ b/tares/store.py
@@ -160,7 +160,8 @@ CREATE TABLE IF NOT EXISTS model_usage (
   output_tokens BIGINT,
   cache_creation_input_tokens BIGINT,
   cache_read_input_tokens     BIGINT,
-  cost_usd DOUBLE
+  cost_usd DOUBLE,
+  key_source TEXT
 );
 CREATE INDEX IF NOT EXISTS ix_model_usage_ts ON model_usage(ts);
 CREATE TABLE IF NOT EXISTS settings (
@@ -292,6 +293,9 @@ _MIGRATIONS = [
     "ALTER TABLE agent_runs ADD COLUMN IF NOT EXISTS cache_creation_input_tokens BIGINT",
     "ALTER TABLE agent_runs ADD COLUMN IF NOT EXISTS cache_read_input_tokens BIGINT",
     "ALTER TABLE agent_runs ADD COLUMN IF NOT EXISTS cost_usd DOUBLE",
+    # Which key paid for a ledger row ("env:ANTHROPIC_API_KEY" | "console") — the boundary a
+    # hosted trial's enforcement counts against. Rows from before attribution stay NULL (unknown).
+    "ALTER TABLE model_usage ADD COLUMN IF NOT EXISTS key_source TEXT",
 ]
 
 _FILTER_COLS = {"event_type", "source", "text", "key_value"}
@@ -1031,15 +1035,17 @@ class Store:
                            input_tokens: int, output_tokens: int,
                            cache_creation_input_tokens: int = 0,
                            cache_read_input_tokens: int = 0,
-                           cost_usd: float | None = None) -> None:
+                           cost_usd: float | None = None,
+                           key_source: str | None = None) -> None:
         with self._lock:
             self.con.execute(
                 "INSERT INTO model_usage (id, ts, surface, agent, run_id, model, calls, "
                 "input_tokens, output_tokens, cache_creation_input_tokens, "
-                "cache_read_input_tokens, cost_usd) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                "cache_read_input_tokens, cost_usd, key_source) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 ["mu_" + uuid.uuid4().hex[:12], now_utc(), surface, agent, run_id, model,
                  calls, input_tokens, output_tokens, cache_creation_input_tokens,
-                 cache_read_input_tokens, cost_usd],
+                 cache_read_input_tokens, cost_usd, key_source or None],
             )
 
     def model_usage_summary(self, days: int = 30) -> dict:
@@ -1062,6 +1068,11 @@ class Store:
             total = self.con.execute(f"SELECT {agg} FROM model_usage").fetchone()
             surfaces = self.con.execute(
                 f"SELECT surface, {agg} FROM model_usage GROUP BY surface").fetchall()
+            # Which key paid: the boundary a hosted trial is enforced against ('unknown' holds
+            # rows from before attribution existed).
+            key_sources = self.con.execute(
+                f"SELECT coalesce(key_source, 'unknown'), {agg} FROM model_usage "
+                "GROUP BY 1").fetchall()
             daily = self.con.execute(
                 f"SELECT CAST(ts AS DATE) AS day, {agg} FROM model_usage "
                 f"WHERE ts > now() - INTERVAL {int(days)} DAY "
@@ -1069,6 +1080,7 @@ class Store:
         return {
             "total": shape(total),
             "by_surface": {r[0]: shape(r[1:]) for r in surfaces},
+            "by_key_source": {r[0]: shape(r[1:]) for r in key_sources},
             "days": [{"day": str(r[0]), **shape(r[1:])} for r in daily],
             "window_days": int(days),
         }

--- a/tares/usecases/ai_sre_demo.py
+++ b/tares/usecases/ai_sre_demo.py
@@ -8,8 +8,17 @@ duplicated.
 The demo stack itself (api-server, Prometheus, traffic) is Docker on the user's machine and stays
 outside Tares: SETUP shows the two commands, and the `inject` action calls the api-server's fault
 switch so an incident can be caused and cleared from the use case page.
+
+Hosted mode: when the instance is pointed at a hosted demo stack (TARES_DEMO_* env vars, set by
+whoever runs the instance — the cloud chart, or a self-hoster with their own stack), the same
+recipe adapts: URL defaults come from the env, logs come from the stack's Loki through the loki
+connector instead of a local Docker container, SETUP loses the docker steps, detect() probes the
+endpoints instead of shelling docker ps, and the actions say plainly that the stack is shared.
+The env vars are read per call, never at import, so one process can be tested in both modes.
 """
 from __future__ import annotations
+
+import os
 
 import httpx
 
@@ -17,6 +26,19 @@ from .base import PlannedObject, Recipe, UsecaseError
 from .registry import register
 
 SCENARIOS = ("error_spike", "latency", "dependency_outage", "clear")
+
+
+def _hosted() -> dict | None:
+    """The hosted demo stack this instance is pointed at, or None. Hosted mode needs all three
+    URLs (TARES_DEMO_PROMETHEUS_URL, TARES_DEMO_LOKI_URL, TARES_DEMO_API_SERVER_URL); the shared
+    read credential (TARES_DEMO_USERNAME / TARES_DEMO_PASSWORD) rides along when set."""
+    urls = {k: os.getenv(f"TARES_DEMO_{k.upper()}", "").strip().rstrip("/")
+            for k in ("prometheus_url", "loki_url", "api_server_url")}
+    if not all(urls.values()):
+        return None
+    return {**urls,
+            "username": os.getenv("TARES_DEMO_USERNAME", "").strip(),
+            "password": os.getenv("TARES_DEMO_PASSWORD", "").strip()}
 
 PROMPT = """You are an SRE taking the first look when Prometheus fires an alert on api-server. You are \
 handed the correlated timeline: the firing alert (HighErrorRate / HighLatency / DependencyDown) \
@@ -46,11 +68,29 @@ class AiSreDemo(Recipe):
                            "help": "the demo stack's Prometheus, as reachable from this Tares"},
         "api_server_url": {"type": "string", "default": "http://localhost:8080", "label": "api-server URL",
                            "help": "the demo api-server; used by the Cause an incident action"},
+        "loki_url": {"type": "string", "default": "", "label": "Loki URL",
+                     "help": "set to read the api-server's logs from a Loki instead of a local "
+                             "Docker container (a hosted demo stack sets this for you)"},
         "container": {"type": "string", "default": "tares-demo-api-server", "label": "Log container",
                       "help": "the api-server's Docker container name (fixed in docker-compose.yml)"},
         "model": {"type": "string", "default": "", "label": "Model",
                   "help": "model for the agent (empty = the instance default)"},
     }
+
+    def _params(self) -> dict:
+        """PARAMS with hosted defaults substituted, so the wizard's form and validate() both start
+        from the stack this instance is actually pointed at. Locally the Loki field is hidden
+        entirely — the local flow reads logs from the container and an extra URL field only
+        raises questions (pointing at your own Loki still works via the API/YAML)."""
+        h = _hosted()
+        if not h:
+            return {k: v for k, v in self.PARAMS.items() if k != "loki_url"}
+        # Hosted: no container field either — logs come from Loki, and a Docker container name
+        # is meaningless on a cell with no Docker.
+        out = {k: dict(v) for k, v in self.PARAMS.items() if k != "container"}
+        for k in ("prometheus_url", "loki_url", "api_server_url"):
+            out[k]["default"] = h[k]
+        return out
 
     SETUP = [
         {"title": "Start the demo stack", "check": "detect",
@@ -86,14 +126,78 @@ class AiSreDemo(Recipe):
          "help": "rolls the fault back; the alert resolves and a resolved event lands on the timeline"},
     ]
 
+    def _setup(self) -> list:
+        if not _hosted():
+            return list(self.SETUP)
+        # Hosted: nothing to install. One detect-checked step (the wizard marks it done when the
+        # stack answers) plus the key step, verbatim.
+        return [
+            {"title": "Shared demo environment", "check": "detect",
+             "text": "This instance is pointed at a hosted demo stack, shared by everyone trying "
+                     "the demo. Nothing to install; the form below fills itself once the stack "
+                     "answers."},
+            self.SETUP[-1],
+        ]
+
+    def _actions(self) -> list:
+        if not _hosted():
+            return list(self.ACTIONS)
+        acts = [dict(a) for a in self.ACTIONS]
+        acts[0]["intro"] = (
+            "Break the demo api-server on purpose and watch the AI SRE work: the fault shows up "
+            "in the metrics and logs, Prometheus fires an alert, the incident trigger wakes the "
+            "agent, and its incident note lands under Runs. The demo stack is shared by everyone "
+            "trying Tares: causing an incident shows up on every demo timeline, and it also "
+            "breaks itself every 30 minutes (cleared 5 minutes later), so you can simply wait "
+            "for one.")
+        acts[1]["help"] = ("rolls the fault back for everyone on the shared stack; the alert "
+                           "resolves and a resolved event lands on the timeline")
+        return acts
+
+    def _facts(self) -> dict:
+        """The card's you/Tares bullets, in the mode's own words (the console falls back to a
+        hardcoded copy for older daemons)."""
+        tares = [
+            "three sources keyed by service: Prometheus metrics, the api-server's logs, the alerts Prometheus fires",
+            "one timeline per service to explore",
+            "a trigger that wakes the agent when an alert fires",
+            "an agent that writes the first incident note back onto the timeline",
+        ]
+        if _hosted():
+            return {"you": ["give the agent an Anthropic key",
+                            "cause an incident from the use case page, or wait: the shared demo "
+                            "stack breaks itself every 30 minutes"],
+                    "tares": tares}
+        return {"you": ["start the demo stack with docker compose",
+                        "give the agent an Anthropic key",
+                        "cause an incident from the use case page"],
+                "tares": tares}
+
+    def describe(self) -> dict:
+        d = super().describe()
+        d["params"] = self._params()
+        d["setup"] = self._setup()
+        d["actions"] = self._actions()
+        d["facts"] = self._facts()
+        return d
+
     # ── params ───────────────────────────────────────────────────────────────
     def validate(self, params: dict) -> dict:
-        p = super().validate(params)
+        P = self._params()
+        p = dict(params or {})
+        for name, spec in P.items():
+            if name not in p and "default" in spec:
+                p[name] = spec["default"]
         for k in ("prometheus_url", "api_server_url"):
-            v = str(p.get(k) or self.PARAMS[k]["default"]).strip().rstrip("/")
+            v = str(p.get(k) or P[k]["default"]).strip().rstrip("/")
             if not v.startswith(("http://", "https://")):
                 raise UsecaseError(f"{k} must start with http:// or https://")
             p[k] = v
+        loki = str(p.get("loki_url") or "").strip().rstrip("/")
+        if loki and not loki.startswith(("http://", "https://")):
+            raise UsecaseError("loki_url must start with http:// or https://")
+        p["loki_url"] = loki
+        # the form may not have offered container (hosted mode); the stored default still applies
         p["container"] = str(p.get("container") or self.PARAMS["container"]["default"]).strip()
         p["model"] = str(p.get("model") or "").strip()
         return p
@@ -101,11 +205,27 @@ class AiSreDemo(Recipe):
     # ── plan: the demo catalog, verbatim ─────────────────────────────────────
     def plan(self, params: dict) -> list[PlannedObject]:
         prom = params["prometheus_url"]
+        # The shared read credential comes from the env, not the params: it belongs to the
+        # instance's wiring (like the stack URLs' defaults), and a secret must not live in the
+        # stored use-case params, which any console reader can see.
+        h = _hosted()
+        cred = ({"username": h["username"], "password": h["password"]}
+                if h and h["username"] else {})
+        if params.get("loki_url"):
+            logs = PlannedObject("source", "logs", {
+                "name": "demo_logs", "connector": "loki", "poll": "5s",
+                "config": {"url": params["loki_url"], "query": '{service="api-server"}', **cred,
+                           "labels": [{"name": "service", "const": "api-server", "primary": True}]}})
+        else:
+            logs = PlannedObject("source", "logs", {
+                "name": "demo_logs", "connector": "docker_logs", "poll": "5s",
+                "config": {"container": params["container"],
+                           "labels": [{"name": "service", "const": "api-server", "primary": True}]}})
         objs = [
             PlannedObject("source", "metrics", {
                 "name": "demo_metrics", "connector": "prometheus", "poll": "5s",
                 "config": {
-                    "url": prom,
+                    "url": prom, **cred,
                     "queries": [
                         {"promql": 'sum(rate(http_requests_total{status=~"5.."}[1m])) by (service)',
                          "event_type": "5xx_rate", "text": "5xx rate {service}={val}/s"},
@@ -119,13 +239,10 @@ class AiSreDemo(Recipe):
                     "labels": [{"name": "service", "const": "api-server", "primary": True},
                                {"name": "value", "field": "value", "type": "number"}],
                 }}),
-            PlannedObject("source", "logs", {
-                "name": "demo_logs", "connector": "docker_logs", "poll": "5s",
-                "config": {"container": params["container"],
-                           "labels": [{"name": "service", "const": "api-server", "primary": True}]}}),
+            logs,
             PlannedObject("source", "alerts", {
                 "name": "demo_alerts", "connector": "prometheus_alerts", "poll": "10s",
-                "config": {"url": prom,
+                "config": {"url": prom, **cred,
                            "labels": [{"name": "service", "field": "labels.service", "primary": True},
                                       {"name": "alertname", "field": "labels.alertname"},
                                       {"name": "severity", "field": "labels.severity"},
@@ -149,6 +266,9 @@ class AiSreDemo(Recipe):
 
     # ── detect: ask Docker what is running instead of assuming ports ─────────
     async def detect(self, store, runtime) -> dict:
+        h = _hosted()
+        if h:
+            return await self._detect_hosted(h)
         from ..discovery import _docker_ps, _published_port
         out = {"params": {}, "found": {}, "missing": {}, "notes": []}
         try:
@@ -184,6 +304,30 @@ class AiSreDemo(Recipe):
             out["notes"].append("Docker is running but no compose-managed containers were found")
         return out
 
+    async def _detect_hosted(self, h: dict) -> dict:
+        """Hosted mode: no Docker to ask. Probe the stack's three endpoints (with the shared
+        credential) and fill the URL params from the env; a down endpoint lands in `missing` with
+        the error, so the wizard says which half of the stack is unreachable."""
+        out = {"params": {}, "found": {}, "missing": {}, "notes": []}
+        auth = (h["username"], h["password"]) if h["username"] else None
+        probes = {
+            "prometheus_url": f"{h['prometheus_url']}/api/v1/query?query=up",
+            "loki_url": f"{h['loki_url']}/loki/api/v1/labels",
+            "api_server_url": f"{h['api_server_url']}/api/stats",
+        }
+        async with httpx.AsyncClient(timeout=10, auth=auth) as cx:
+            for param, probe in probes.items():
+                out["params"][param] = h[param]
+                try:
+                    r = await cx.get(probe)
+                    if r.status_code < 300:
+                        out["found"][param] = "hosted demo stack answered"
+                    else:
+                        out["missing"][param] = f"hosted demo stack answered HTTP {r.status_code}"
+                except Exception as e:
+                    out["missing"][param] = f"could not reach the hosted demo stack: {type(e).__name__}"
+        return out
+
     # ── actions ──────────────────────────────────────────────────────────────
     def run_action(self, instance: dict, action: str, args: dict, store, runtime) -> dict:
         params = self.validate(instance["params"])
@@ -196,8 +340,10 @@ class AiSreDemo(Recipe):
         else:
             raise UsecaseError(f"{self.key}: no action {action!r}")
         url = params["api_server_url"] + "/demo/inject"
+        h = _hosted()
+        auth = (h["username"], h["password"]) if h and h["username"] else None
         try:
-            r = httpx.post(url, json={"scenario": scenario}, timeout=10)
+            r = httpx.post(url, json={"scenario": scenario}, timeout=10, auth=auth)
         except Exception as e:
             raise UsecaseError(f"could not reach the demo api-server at {url}: {e}") from e
         if r.status_code >= 300:

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -102,6 +102,17 @@ async def main():
             ck("key reported configured from env", k["configured"] and k["source"].startswith("env:"), str(k))
             ck("key value is never returned", "sk-test" not in json.dumps(k), str(k))
 
+            # ── precedence: a stored key WINS over the env key (trial cells depend on it) ──
+            r = await cx.put(f"{B}/api/settings/anthropic-key", json={"key": "sk-user-own"})
+            ck("storing a key over an env key carries no takes-precedence note",
+               r.status_code == 200 and "note" not in r.json(), r.text[:200])
+            k = (await cx.get(f"{B}/api/settings/anthropic-key")).json()
+            ck("stored key takes over from the env key",
+               k["source"] == "console" and k["stored"] and not k["env_overrides"], str(k))
+            r = await cx.delete(f"{B}/api/settings/anthropic-key")
+            ck("deleting the stored key falls back to the env key",
+               r.status_code == 200 and r.json()["source"].startswith("env:"), r.text[:200])
+
             # ── create ───────────────────────────────────────────────────────
             r = await cx.post(f"{B}/api/agents/builtin", json={
                 "name": "first-look", "trigger": "incident", "prompt": "Take a first look."})
@@ -173,6 +184,9 @@ async def main():
             ck("usage meter attributes it to the agent surface",
                um["by_surface"].get("agent", {}).get("calls") == calls_made, str(um["by_surface"]))
             ck("usage meter has a per-day tail", len(um.get("days") or []) == 1, str(um.get("days")))
+            ck("usage attributed to the env key that paid",
+               um.get("by_key_source", {}).get("env:ANTHROPIC_API_KEY", {}).get("calls") == calls_made,
+               str(um.get("by_key_source")))
 
             # ── the firing counts the agent as a delivered subscriber ────────
             async def _delivered():

--- a/tests/test_ai_sre_demo.py
+++ b/tests/test_ai_sre_demo.py
@@ -30,6 +30,7 @@ def check(label, cond, detail=""):
 
 # a fake api-server that records what /demo/inject receives
 INJECTED = []
+AUTHS = []   # Authorization headers seen by the fake hosted stack
 
 
 class FakeApi(BaseHTTPRequestHandler):
@@ -37,6 +38,31 @@ class FakeApi(BaseHTTPRequestHandler):
         pass
 
     def do_POST(self):
+        n = int(self.headers.get("content-length") or 0)
+        body = json.loads(self.rfile.read(n) or b"{}")
+        if self.path == "/demo/inject":
+            INJECTED.append(body.get("scenario"))
+            self.send_response(200); self.end_headers(); self.wfile.write(b'{"ok":true}')
+        else:
+            self.send_response(404); self.end_headers()
+
+
+class FakeStack(BaseHTTPRequestHandler):
+    """The hosted demo stack in one handler: Prometheus, Loki and api-server probe endpoints,
+    plus /demo/inject, all recording the Authorization header they were called with."""
+
+    def log_message(self, *a):
+        pass
+
+    def do_GET(self):
+        AUTHS.append(self.headers.get("authorization"))
+        if self.path.startswith(("/api/v1/query", "/loki/api/v1/labels", "/api/stats")):
+            self.send_response(200); self.end_headers(); self.wfile.write(b'{"status":"ok"}')
+        else:
+            self.send_response(404); self.end_headers()
+
+    def do_POST(self):
+        AUTHS.append(self.headers.get("authorization"))
         n = int(self.headers.get("content-length") or 0)
         body = json.loads(self.rfile.read(n) or b"{}")
         if self.path == "/demo/inject":
@@ -139,6 +165,69 @@ async def main():
             check("demo sources gone", not ({"demo_metrics", "demo_logs", "demo_alerts"} & after), str(after))
 
     srv.shutdown()
+
+    # ── hosted mode: the same recipe against a hosted demo stack (TR-194) ────
+    print("== hosted mode ==")
+    stack = HTTPServer(("127.0.0.1", 0), FakeStack)
+    threading.Thread(target=stack.serve_forever, daemon=True).start()
+    base = f"http://127.0.0.1:{stack.server_port}"
+    os.environ.update({"TARES_DEMO_PROMETHEUS_URL": base, "TARES_DEMO_LOKI_URL": base,
+                       "TARES_DEMO_API_SERVER_URL": base,
+                       "TARES_DEMO_USERNAME": "demo", "TARES_DEMO_PASSWORD": "pw"})
+    try:
+        d = r.describe()
+        check("hosted defaults come from the env",
+              d["params"]["prometheus_url"]["default"] == base
+              and d["params"]["loki_url"]["default"] == base, json.dumps(d["params"])[:300])
+        check("hosted form hides the container field", "container" not in d["params"],
+              str(list(d["params"])))
+        check("hosted setup has no docker step and keeps the key step",
+              "docker" not in json.dumps(d["setup"]).lower()
+              and [s.get("check") for s in d["setup"]] == ["detect", "anthropic_key"],
+              json.dumps(d["setup"])[:300])
+        check("hosted facts say the stack is shared and nothing to install",
+              "shared" in json.dumps(d["facts"]) and "docker" not in json.dumps(d["facts"]),
+              json.dumps(d["facts"])[:300])
+        check("hosted inject action says it is shared",
+              "shared" in d["actions"][0]["intro"], d["actions"][0]["intro"][:200])
+
+        hp = r.validate({})
+        hplan = {o.key: o for o in r.plan(hp)}
+        check("hosted plan reads logs from Loki",
+              hplan["logs"].spec["connector"] == "loki"
+              and hplan["logs"].spec["config"]["query"] == '{service="api-server"}',
+              json.dumps(hplan["logs"].spec)[:300])
+        check("hosted sources carry the shared credential",
+              all(hplan[k].spec["config"].get("username") == "demo"
+                  and hplan[k].spec["config"].get("password") == "pw"
+                  for k in ("metrics", "logs", "alerts")), json.dumps(hplan["logs"].spec)[:300])
+
+        det = await r.detect(None, None)
+        check("hosted detect probes the stack, no docker",
+              set(det["found"]) == {"prometheus_url", "loki_url", "api_server_url"}
+              and not det["missing"], json.dumps(det)[:300])
+
+        AUTHS.clear(); INJECTED.clear()
+        out = r.run_action({"params": hp}, "inject", {"scenario": "error_spike"}, None, None)
+        check("hosted inject reaches the stack with the credential",
+              INJECTED == ["error_spike"] and AUTHS and AUTHS[-1] and AUTHS[-1].startswith("Basic "),
+              f"injected={INJECTED} auths={AUTHS[-1:]}")
+        check("inject message unchanged", "alert fires" in out["message"], out["message"])
+    finally:
+        for k in list(os.environ):
+            if k.startswith("TARES_DEMO_"):
+                del os.environ[k]
+        stack.shutdown()
+
+    # regression: with the env cleared, local mode is back untouched
+    d = r.describe()
+    check("local mode restored after env cleared",
+          d["params"]["prometheus_url"]["default"] == "http://localhost:9090"
+          and "docker compose" in json.dumps(d["setup"])
+          and r.plan(r.validate({}))[1].spec["connector"] == "docker_logs")
+    check("local form does not show the Loki field", "loki_url" not in d["params"],
+          str(list(d["params"])))
+
     print(f"\n{PASS} passed, {FAIL} failed")
     sys.exit(1 if FAIL else 0)
 

--- a/tests/test_loki.py
+++ b/tests/test_loki.py
@@ -1,0 +1,165 @@
+"""The loki connector: query_range polling, auth headers, envelope mapping, the nanosecond
+cursor, match/drop filters, and secret redaction.
+Run: .venv/bin/python tests/test_loki.py   (no Loki needed; a stub answers query_range)
+"""
+import asyncio
+import json
+import os
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import parse_qs, urlparse
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+DB = "/tmp/tares-loki-test.duckdb"
+os.environ["TARES_DB"] = DB
+
+PASS = FAIL = 0
+
+
+def check(label, cond, detail=""):
+    global PASS, FAIL
+    if cond:
+        PASS += 1; print(f"  ok   {label}")
+    else:
+        FAIL += 1; print(f"  FAIL {label}  {detail}")
+
+
+REQUESTS = []      # (params, headers) per query_range call
+RESPONSES = []     # queued response bodies; the last one repeats
+
+
+class FakeLoki(BaseHTTPRequestHandler):
+    def log_message(self, *a):
+        pass
+
+    def do_GET(self):
+        u = urlparse(self.path)
+        if u.path != "/loki/api/v1/query_range":
+            self.send_response(404); self.end_headers(); return
+        REQUESTS.append(({k: v[0] for k, v in parse_qs(u.query).items()}, dict(self.headers)))
+        body = json.dumps(RESPONSES.pop(0) if len(RESPONSES) > 1 else RESPONSES[0]).encode()
+        self.send_response(200)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+def loki_response(entries):
+    """entries: [(ts_ns, line, stream_labels)] -> a query_range body, one stream per label set."""
+    streams = {}
+    for ts, line, labels in entries:
+        streams.setdefault(json.dumps(labels, sort_keys=True), []).append([str(ts), line])
+    return {"status": "success", "data": {"resultType": "streams", "result": [
+        {"stream": json.loads(k), "values": v} for k, v in streams.items()]}}
+
+
+async def main():
+    for p in (DB, DB + ".wal"):
+        if os.path.exists(p):
+            os.remove(p)
+    srv = HTTPServer(("127.0.0.1", 0), FakeLoki)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    base = f"http://127.0.0.1:{srv.server_port}"
+
+    from tares.config import SourceCfg
+    from tares.connectors import build_connector, redact_config, source_type_for
+    from tares.store import Store
+    store = Store(DB)
+
+    def connector(config):
+        cfg = SourceCfg(name="demo_logs", type=source_type_for("loki"), connector="loki",
+                        poll_seconds=5.0, config=config)
+        return build_connector(cfg, store)
+
+    print("== request shape and auth ==")
+    import time
+    # entries must fall inside the first poll's 30s lookback, or a real Loki would not have
+    # returned them and the connector rightly skips them
+    T0 = int(time.time() * 1_000_000_000) - 10_000_000_000
+    RESPONSES[:] = [loki_response([
+        (T0 + 1, '2026-08-24T10:00:00Z INFO GET /api/orders "GET /api/orders HTTP/1.1" 200',
+         {"service": "api-server"}),
+        (T0 + 2, 'ERROR db timeout', {"service": "api-server"}),
+    ])]
+    # level/http_status are DERIVED context (derive_fields) — a label declared against them
+    # extracts, exactly like docker_logs; undeclared derived fields are candidates, not labels.
+    c = connector({"url": base, "query": '{service="api-server"}',
+                   "bearer_token": "tok", "tenant_id": "t1",
+                   "username": "demo", "password": "pw",
+                   "labels": [{"name": "service", "const": "api-server", "primary": True},
+                              {"name": "level", "field": "level"},
+                              {"name": "http_status", "field": "http_status"}]})
+    out = await c.poll()
+    params, headers = REQUESTS[-1]
+    check("query_range called with the selector", params.get("query") == '{service="api-server"}',
+          json.dumps(params))
+    check("forward direction with a limit", params.get("direction") == "forward"
+          and int(params.get("limit", 0)) > 0, json.dumps(params))
+    check("first poll starts in the recent past", int(params["start"]) < int(params["end"]),
+          json.dumps(params))
+    # bearer and basic auth share the Authorization header (use one or the other in practice);
+    # what matters is that configured auth reaches the wire at all, plus the tenant header.
+    check("tenant header sent", headers.get("X-Scope-OrgID") == "t1", str(headers))
+    check("an Authorization header was sent", bool(headers.get("Authorization")), str(headers))
+
+    print("== envelopes ==")
+    check("one envelope per line", len(out) == 2, str(len(out)))
+    e1, e2 = sorted(out, key=lambda e: e.event_time)
+    check("text is the line", "db timeout" in e2.text, e2.text)
+    check("event_type is log", e1.event_type == "log" and e2.event_type == "log")
+    check("keyed by the primary label", e1.key_value == "api-server", e1.key_value)
+    check("derived level from the line", e2.labels.get("level") == "ERROR", str(e2.labels))
+    check("http fields derived when present", e1.labels.get("http_status") == "200", str(e1.labels))
+    check("payload keeps raw + stream", e1.payload.get("stream") == {"service": "api-server"}
+          and "raw" in e1.payload, json.dumps(e1.payload)[:200])
+    check("event_time from the entry timestamp (ns)",
+          abs(e1.event_time.timestamp() - (T0 + 1) / 1e9) < 1, str(e1.event_time))
+
+    print("== cursor ==")
+    cur = store.get_cursor("demo_logs")
+    check("cursor advanced to the last entry", cur == str(T0 + 2), str(cur))
+    RESPONSES[:] = [loki_response([])]
+    REQUESTS.clear()
+    out = await c.poll()
+    params, _ = REQUESTS[-1]
+    check("second poll starts after the cursor", params["start"] == str(T0 + 3), json.dumps(params))
+    check("empty answer ingests nothing and keeps the cursor",
+          out == [] and store.get_cursor("demo_logs") == str(T0 + 2))
+
+    print("== filters ==")
+    store.set_cursor("demo_logs", str(T0))
+    RESPONSES[:] = [loki_response([
+        (T0 + 10, "ERROR boom", {"service": "api-server"}),
+        (T0 + 11, "INFO fine", {"service": "api-server"}),
+        (T0 + 12, 'GET /health "GET /health HTTP/1.1" 200', {"service": "api-server"}),
+    ])]
+    c2 = connector({"url": base, "query": '{service="api-server"}',
+                    "match": "ERROR|INFO", "drop": "fine",
+                    "labels": [{"name": "service", "const": "api-server", "primary": True}]})
+    out = await c2.poll()
+    check("match keeps, drop skips", [e.text for e in out] == ["ERROR boom"],
+          str([e.text for e in out]))
+    check("cursor still advances over filtered lines",
+          store.get_cursor("demo_logs") == str(T0 + 12), store.get_cursor("demo_logs"))
+
+    print("== failure is a quiet poll ==")
+    c3 = connector({"url": "http://127.0.0.1:1", "query": "{a=\"b\"}",
+                    "labels": [{"name": "service", "const": "x", "primary": True}]})
+    check("unreachable loki returns no events", await c3.poll() == [])
+
+    print("== secrets ==")
+    red = redact_config("loki", {"url": base, "query": "{}", "bearer_token": "tok",
+                                 "username": "u", "password": "pw"})
+    check("bearer and password redacted, username kept",
+          red["bearer_token"] != "tok" and red["password"] != "pw" and red["username"] == "u",
+          json.dumps(red))
+
+    store.con.close()
+    srv.shutdown()
+    print(f"\n{PASS} passed, {FAIL} failed")
+    sys.exit(1 if FAIL else 0)
+
+
+asyncio.run(main())

--- a/tests/test_seed.py
+++ b/tests/test_seed.py
@@ -1,0 +1,152 @@
+"""TARES_SEED_USECASE: a cell born with its use case already running.
+
+Boots real daemons (subprocess, like test_agents) against the hosted-demo stubs and checks the
+one-shot semantics: seeded on first boot, marker written, a user's deletion never resurrected,
+an unknown recipe fixable (no marker), and no seeding at all when the var is unset.
+"""
+import asyncio
+import json
+import os
+import signal
+import subprocess
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import httpx
+
+P = F = 0
+def ck(l, c, d=""):
+    global P, F; P += 1 if c else 0; F += 0 if c else 1
+    print(("  ok   " if c else "  FAIL ") + l + ("" if c else f"  {d}"))
+
+DB, PORT = "/tmp/tares-seed-test.duckdb", "8811"
+B = f"http://127.0.0.1:{PORT}"
+
+
+class FakeStack(BaseHTTPRequestHandler):
+    """Just enough of the hosted demo stack for the recipe's plan/detect to be happy."""
+    def log_message(self, *a):
+        pass
+
+    def do_GET(self):
+        self.send_response(200); self.end_headers(); self.wfile.write(b'{"status":"ok","data":{"result":[]}}')
+
+
+def daemon_env(stack_port: int, seed: str | None) -> dict:
+    base = f"http://127.0.0.1:{stack_port}"
+    env = {**os.environ, "TARES_DB": DB, "TARES_PORT": PORT, "TARES_OTLP_GRPC_PORT": "off",
+           "TARES_DEMO_PROMETHEUS_URL": base, "TARES_DEMO_LOKI_URL": base,
+           "TARES_DEMO_API_SERVER_URL": base}
+    env.pop("TARES_CATALOG", None)
+    env.pop("TARES_SEED_USECASE", None)
+    if seed is not None:
+        env["TARES_SEED_USECASE"] = seed
+    return env
+
+
+async def _wait(url, tries=80):
+    for _ in range(tries):
+        try:
+            async with httpx.AsyncClient() as cx:
+                if (await cx.get(url, timeout=1)).status_code == 200:
+                    return True
+        except Exception:
+            pass
+        await asyncio.sleep(0.25)
+    return False
+
+
+async def boot(env):
+    proc = subprocess.Popen([sys.executable, "-c", "from tares.cli import run_daemon; run_daemon()"],
+                            env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    ok = await _wait(f"{B}/health")
+    return proc, ok
+
+
+def stop(proc):
+    proc.send_signal(signal.SIGTERM)
+    try:
+        proc.wait(timeout=5)
+    except Exception:
+        proc.kill()
+
+
+async def usecases(cx):
+    return (await cx.get(f"{B}/api/usecases")).json()["usecases"]
+
+
+async def main():
+    for p in (DB, DB + ".wal"):
+        if os.path.exists(p):
+            os.remove(p)
+    stack = HTTPServer(("127.0.0.1", 0), FakeStack)
+    threading.Thread(target=stack.serve_forever, daemon=True).start()
+
+    # ── first boot with the var: seeded exactly once ─────────────────────────
+    proc, up = await boot(daemon_env(stack.server_port, "ai_sre_demo"))
+    try:
+        ck("daemon up", up)
+        async with httpx.AsyncClient(timeout=20) as cx:
+            uc = await usecases(cx)
+            ck("use case seeded on first boot", len(uc) == 1 and uc[0]["recipe"] == "ai_sre_demo",
+               json.dumps(uc)[:200])
+            uid = uc[0]["id"] if uc else ""
+            srcs = {s["name"] for s in (await cx.get(f"{B}/api/sources")).json()}
+            ck("seeded objects exist (loki logs source included)",
+               {"demo_metrics", "demo_logs", "demo_alerts"} <= srcs, str(srcs))
+            logs = next(s for s in (await cx.get(f"{B}/api/sources")).json() if s["name"] == "demo_logs")
+            ck("seeded in hosted mode", logs["connector"] == "loki", logs["connector"])
+            # a user deletes it on purpose
+            r = await cx.delete(f"{B}/api/usecases/{uid}")
+            ck("user can delete the seeded use case", r.status_code == 200, r.text[:200])
+    finally:
+        stop(proc)
+
+    # ── second boot, same var: the deletion sticks ───────────────────────────
+    proc, up = await boot(daemon_env(stack.server_port, "ai_sre_demo"))
+    try:
+        ck("daemon back up", up)
+        async with httpx.AsyncClient(timeout=20) as cx:
+            uc = await usecases(cx)
+            ck("deleted use case is NOT resurrected on restart", uc == [], json.dumps(uc)[:200])
+    finally:
+        stop(proc)
+
+    # ── unknown recipe: warns, no marker, so fixing the config still seeds ───
+    for p in (DB, DB + ".wal"):
+        os.path.exists(p) and os.remove(p)
+    proc, up = await boot(daemon_env(stack.server_port, "no_such_recipe"))
+    try:
+        ck("daemon healthy despite unknown seed recipe", up)
+        async with httpx.AsyncClient(timeout=20) as cx:
+            ck("nothing seeded for an unknown recipe", await usecases(cx) == [])
+    finally:
+        stop(proc)
+    proc, up = await boot(daemon_env(stack.server_port, "ai_sre_demo"))
+    try:
+        ck("daemon up after fixing the config", up)
+        async with httpx.AsyncClient(timeout=20) as cx:
+            uc = await usecases(cx)
+            ck("fixed config seeds on the next boot (typo wrote no marker)",
+               len(uc) == 1, json.dumps(uc)[:200])
+    finally:
+        stop(proc)
+
+    # ── var unset: nothing happens ───────────────────────────────────────────
+    for p in (DB, DB + ".wal"):
+        os.path.exists(p) and os.remove(p)
+    proc, up = await boot(daemon_env(stack.server_port, None))
+    try:
+        ck("daemon up without the var", up)
+        async with httpx.AsyncClient(timeout=20) as cx:
+            ck("no seeding without TARES_SEED_USECASE", await usecases(cx) == [])
+    finally:
+        stop(proc)
+
+    stack.shutdown()
+    print(f"\n{P} passed, {F} failed")
+    sys.exit(1 if F else 0)
+
+
+asyncio.run(main())

--- a/tests/test_slack_ask.py
+++ b/tests/test_slack_ask.py
@@ -303,6 +303,9 @@ async def main():
             want = (10 * 3.0 + 20 * 15.0) / 1e6
             ck("...costed at the sonnet rate", abs((ask.get("cost_usd") or 0) - want) < 1e-9,
                f"{ask.get('cost_usd')} vs {want}")
+            ck("...attributed to the env key that paid",
+               um.get("by_key_source", {}).get("env:ANTHROPIC_API_KEY", {}).get("calls") == 1,
+               str(um.get("by_key_source")))
 
             # ── in a thread, the answer belongs in that thread ───────────────
             REPLIES.clear()

--- a/ui/src/pages/Security.tsx
+++ b/ui/src/pages/Security.tsx
@@ -312,8 +312,9 @@ function AnthropicKeyPanel() {
       <h2 style={{ marginTop: 0 }}>Anthropic key</h2>
       <p className="help" style={{ marginTop: 0 }}>
         What <strong>Tares agents</strong> run on; their first look at an entity when a trigger
-        fires. Set <code>ANTHROPIC_API_KEY</code> in the daemon's environment, or store one here.
-        It is never returned by the API and never included in a catalog export.
+        fires. Store one here (it takes precedence), or set <code>ANTHROPIC_API_KEY</code> in the
+        daemon's environment. It is never returned by the API and never included in a catalog
+        export.
       </p>
 
       {err && <div className="alert error">{err}</div>}
@@ -328,11 +329,11 @@ function AnthropicKeyPanel() {
               : <><span className="badge error">not configured</span>{" "}
                   <span className="help">agents cannot be enabled until one is set</span></>}
           </p>
-          {st.env_overrides && st.stored && (
-            <div className="alert">
-              A key is set in the environment and takes precedence; the one stored here is not in
-              use. Remove the environment variable, or clear the stored key to avoid confusion.
-            </div>
+          {st.source.startsWith("env:") && (
+            <p className="help" style={{ margin: "0 0 10px" }}>
+              The deployment's environment key is in use. Saving a key here replaces it: your key
+              takes over immediately, and removing it falls back to the environment key.
+            </p>
           )}
           <div className="btnrow" style={{ alignItems: "center", maxWidth: 720 }}>
             <input type="password" className="mono" style={{ flex: 1 }} placeholder="sk-ant-…"

--- a/ui/src/pages/Usecases.tsx
+++ b/ui/src/pages/Usecases.tsx
@@ -24,8 +24,9 @@ export function usecaseKindCounts(u: Usecase) {
   return c;
 }
 
-// What each recipe wires up, in the user's words. Keyed by recipe so a new recipe without an
-// entry still gets a card, just without the "what it sets up" column.
+// What each recipe wires up, in the user's words. The daemon's describe() may carry mode-aware
+// facts (ai_sre_demo says different things against a hosted stack than against local docker);
+// this map is the fallback for recipes that don't, and for older daemons.
 const RECIPE_FACTS: Record<string, { you: string[]; tares: string[] }> = {
   ai_sre_demo: {
     you: ["start the demo stack with docker compose", "give the agent an Anthropic key", "cause an incident from the use case page"],
@@ -40,7 +41,7 @@ const RECIPE_FACTS: Record<string, { you: string[]; tares: string[] }> = {
 function RecipeCard({ r }: { r: Recipe }) {
   const navigate = useNavigate();
   const to = WIZARDS[r.key] ?? `/usecases/new/${encodeURIComponent(r.key)}`;
-  const facts = RECIPE_FACTS[r.key];
+  const facts = r.facts ?? RECIPE_FACTS[r.key];
   return (
     <div className="panel uc-card">
       <div className="uc-card-main">

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -437,6 +437,9 @@ export interface Recipe {
   guide?: { label: string; url: string } | null;
   setup?: RecipeSetupStep[];
   actions?: RecipeAction[];
+  // The card's you/Tares bullets, in the mode the daemon is running in (a hosted demo stack
+  // says different things than a local docker one). Absent on older daemons.
+  facts?: { you: string[]; tares: string[] };
 }
 export type UsecaseObjectKind = "source" | "view" | "trigger" | "agent" | "mcp_server";
 export interface UsecaseObject {


### PR DESCRIPTION
The AI SRE demo assumed a laptop: docker_logs tails a local container, detect() shells docker ps, defaults point at localhost. On a cloud cell all of that silently produces zero events. This makes the same use case work against a centrally hosted demo stack (TR-152's central-infra idea), while local mode stays byte-identical.

## New: loki connector
`tares/connectors/loki.py` polls a LogQL stream selector via `query_range` with a nanosecond cursor: one event per line, stream labels + the same derived fields as docker_logs (level, http status, JSON scalars), bearer/basic/tenant auth, match/drop filters, 5000-line backlog draining. A general log source (Grafana Cloud etc.), not demo-only.

## Recipe: hosted mode via env
When `TARES_DEMO_PROMETHEUS_URL` / `_LOKI_URL` / `_API_SERVER_URL` are set (the cloud chart will set them via extraEnv; a self-hoster can point them at their own stack; unset = nothing changes):
- URL defaults come from the env; the form drops the Log container field (no Docker on a cell) and shows a Loki URL instead
- `demo_logs` becomes a loki source; the shared read credential attaches to all three sources at plan time (env only, never stored in params)
- SETUP: the docker steps are replaced by one reachability-checked "Shared demo environment" step; the key step stays
- detect() probes the three endpoints with the credential instead of shelling docker ps
- The inject/clear actions say plainly the stack is shared and breaks itself every 30 minutes

Local mode (env unset): the card, wizard, plan objects and detection are unchanged, pinned by a regression check.

## UI
Card facts ("you / Tares sets up") now come from the daemon's describe(), which knows its mode; the hardcoded copy stays as fallback for other recipes and older daemons.

## Tests
New `tests/test_loki.py` (20 checks: request shape, auth headers, envelope mapping, cursor, filters, redaction) and a hosted-mode section in `test_ai_sre_demo.py` (35 total). Both added to CI along with test_ai_sre_demo, which was previously not in the CI list.

Cloud side (the actual hosted stack + provisioning extraEnv) is separate work in tares-cloud; release of this waits until that stack is verified.