### PR TITLE
Tares install skill for coding agents (TR-151)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,64 @@
+# Working on Tares
+
+For contributors and coding agents working in this repository. The product docs live at
+https://docs.glassflow.ai/tares; this file is about the repo itself.
+
+## Layout
+
+- `tares/` the package: `daemon.py` (HTTP API + console), `cli.py` (`tares up`, `tares mcp`),
+  `store.py` (DuckDB), `connectors/`, `agent*.py` (Tares agents), `mcp*.py` (the MCP proxy).
+- `ui/` the console, a Vite + React app. The daemon serves `ui/dist` and the wheel bundles it.
+- `tests/` plain scripts. `demo/` the demo stack. `skills/` the install skill agents use.
+
+## Tests
+
+Tests are plain Python scripts, not pytest. Run one with `python tests/test_x.py`; it exits
+non-zero on failure. CI runs the list in `.github/workflows/ci.yml`; add a new test file to that
+list or it never runs.
+
+```bash
+uv venv && uv pip install -e ".[otlp-grpc]"
+python tests/test_cli.py
+```
+
+## Console
+
+```bash
+cd ui && npm ci && npx tsc --noEmit && npm run build   # produces ui/dist
+```
+
+Rebuild after any change under `ui/src`; the daemon serves whatever is in `ui/dist`.
+`TARES_UI_DIST` points the daemon at another build directory.
+
+## Environment contract
+
+Every knob is a `TARES_*` variable read at start. The ones you will meet most:
+
+| Variable | Meaning |
+|---|---|
+| `TARES_HOME` | data directory (default `~/.tares`); `--data-dir` overrides |
+| `TARES_HOST`, `TARES_PORT` | daemon bind address (127.0.0.1:8787) |
+| `TARES_MCP_HOST`, `TARES_MCP_PORT`, `TARES_MCP_TRANSPORT` | the MCP endpoint (127.0.0.1:8788, streamable-http) |
+| `TARESD_URL` | where `tares-mcp` finds the daemon |
+| `TARES_AUTH_TOKEN` | turns auth on; also the token `tares-mcp` presents |
+| `TARES_CATALOG` | a catalog file to import on first boot (only while the catalog is empty) |
+| `TARES_ANTHROPIC_KEY` | platform key for Tares agents and Ask; a key saved in the console wins |
+| `TARES_AGENT_MODEL` | model for Tares agents |
+| `TARES_MAX_DB_SIZE` | cap on the DuckDB file; `/api/usage` reports against it |
+| `TARES_SLACK_BOT_TOKEN`, `TARES_SLACK_SIGNING_SECRET` | the Slack surface |
+| `TARES_SEED_USECASE` | use case to seed on first boot |
+
+`grep -rhoE "TARES_[A-Z_]+" tares/*.py | sort -u` is the authoritative list.
+
+## Release
+
+`scripts/release.sh <version>` bumps `pyproject.toml`, commits and tags. Pushing the tag runs
+`release.yml` (PyPI) and `docker-publish.yml` (`ghcr.io/glassflow/tares:<version>`). Add a
+`CHANGELOG.md` entry first.
+
+## Writing rules
+
+- No em dashes in any rendered string: console copy, CLI output, docs, README. Use a comma, a
+  colon or a new sentence.
+- Plain language. Name the observable symptom, then the cause.
+- Keep commits short, no attribution trailers.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ uv tool install tares        # or: pipx install tares
 tares up                     # daemon + console on http://127.0.0.1:8787
 ```
 
+Or let your coding agent do it. In Claude Code, Codex or Cursor, paste:
+
+> Run `npx skills add glassflow/tares --skill tares` and use the tares skill to install Tares and connect it to this agent.
+
+The [skill](skills/tares/SKILL.md) installs Tares, starts it, adds a first source, connects the agent over MCP and shows one read.
+
 Docker images and server deployment (TLS, auth) are covered in the [server deployment guide](https://docs.glassflow.ai/tares/deployment).
 
 Prefer not to run it yourself? **[Tares Cloud](https://console.tares-glassflow.com/)** is the managed version: sign up, connect your sources, and get the same correlated timeline and MCP endpoint without operating anything.

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://skills.sh/schemas/skills.sh.schema.json",
+  "notGrouped": "bottom",
+  "groupings": [
+    {
+      "title": "Tares",
+      "description": "Skills for installing, connecting and operating Tares.",
+      "skills": ["tares"]
+    }
+  ]
+}

--- a/skills/tares/SKILL.md
+++ b/skills/tares/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: tares
+description: Installs Tares, the open-source platform for always-on AI agents, starts the daemon, adds a first source over the HTTP API, connects the agent it runs inside over MCP, and proves the connection with one read. Use when the user asks an agent to install or set up Tares, add a source, connect Claude Code, Codex or Cursor to Tares, or fix a local Tares install.
+---
+
+# Tares
+
+Install and connect **Tares** (docs: https://docs.glassflow.ai/tares). Tares puts every event
+from a user's systems on one timeline per thing, wakes an agent when a trigger fires, and keeps
+the finding for the next reader. This skill takes a machine from nothing to: daemon running, one
+source receiving, this agent connected over MCP, one successful `read`.
+
+## Operating rules
+
+- Act autonomously once the user asks for Tares to be installed. Ask only for what you cannot
+  infer: which source to add first, and its one or two parameters (see step 4).
+- Say what is about to run and that it may take a while. `uv tool install` can take a minute;
+  post a line of progress while it runs so the user does not kill it.
+- Print each command and its result. If a command fails, change something before retrying.
+- Never paste secrets into the console, the chat, or a file you show. Read them from environment
+  variables (`GITHUB_TOKEN`, `ANTHROPIC_API_KEY`). A variable exported only in your shell is not
+  seen by a `tares up` started elsewhere; start the daemon from the shell that has it, or tell
+  the user to set it where the daemon runs.
+- Do not create what already exists: `GET /api/sources` first, and skip a source whose name is
+  taken.
+- Everything below goes through the HTTP API at `http://127.0.0.1:8787`, not the console. The
+  console is for the user afterwards.
+
+## 1. Prerequisites
+
+```bash
+uv --version || pipx --version        # one of the two; stop and tell the user how to install uv if neither
+lsof -iTCP:8787 -sTCP:LISTEN -n -P    # empty = free; a listener here means a Tares is already running (step 3)
+lsof -iTCP:8788 -sTCP:LISTEN -n -P    # same, for the MCP endpoint
+docker info >/dev/null 2>&1 && echo docker-ok   # only matters if the user wants the demo stack
+```
+
+## 2. Install
+
+```bash
+tares --version 2>/dev/null && uv tool upgrade tares || uv tool install tares
+# pipx: pipx install tares   (or pipx upgrade tares)
+tares --version
+```
+
+If `tares` is not on PATH after installing, `uv tool update-shell` (or add `~/.local/bin` to PATH)
+and open a new shell.
+
+## 3. Start the daemon
+
+Pick a data directory (default `~/.tares`; use another one if the user wants an isolated
+install). Run detached so the session survives this conversation:
+
+```bash
+nohup tares up --data-dir ~/.tares > ~/.tares-up.log 2>&1 &
+for i in $(seq 1 30); do curl -sf http://127.0.0.1:8787/health && break; sleep 1; done
+```
+
+`/health` returns `{"status":"ok","auth_required":false,"sources":[...]}`. Print the console URL:
+`http://127.0.0.1:8787`. To stop later: `pkill -f "tares up"` (or `kill` the PID from
+`lsof -iTCP:8787`). To restart: the same `nohup` line.
+
+If port 8787 was already taken by a running Tares, skip this step and use it.
+
+## 4. Add the first source
+
+Ask the user which one, then `POST /api/sources` with the exact body below. `GET /api/sources`
+first; if the name exists, move on to step 5. Every body has the same shape:
+`{"name", "connector", "poll", "config"}`. Full config keys per connector:
+https://docs.glassflow.ai/tares/connectors. Do not invent keys.
+
+**Prometheus** (ask for the URL, one PromQL, and the label that names the service):
+
+```bash
+curl -sf -X POST http://127.0.0.1:8787/api/sources -H 'Content-Type: application/json' -d '{
+  "name": "metrics", "connector": "prometheus", "poll": "10s",
+  "config": {
+    "url": "http://localhost:9090",
+    "queries": [{"promql": "rate(http_requests_total[1m])", "by_name": true}],
+    "labels": [
+      {"name": "service", "field": "metric.service", "primary": true},
+      {"name": "value", "field": "value", "type": "number"}
+    ]
+  }}'
+```
+
+**OTLP** (nothing to ask; print the endpoint the collector should point at):
+
+```bash
+curl -sf -X POST http://127.0.0.1:8787/api/sources -H 'Content-Type: application/json' -d '{
+  "name": "otel", "connector": "otlp",
+  "config": {"labels": [{"name": "service", "field": "service", "primary": true}]}}'
+```
+
+Then tell the user: `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:8787` (OTLP/HTTP, paths
+`/v1/logs`, `/v1/traces`, `/v1/metrics`).
+
+**Docker logs** (ask for the container name; `docker ps` lists them):
+
+```bash
+curl -sf -X POST http://127.0.0.1:8787/api/sources -H 'Content-Type: application/json' -d '{
+  "name": "logs", "connector": "docker_logs", "poll": "5s",
+  "config": {
+    "container": "<container name>",
+    "labels": [{"name": "service", "const": "<service name>", "primary": true}]
+  }}'
+```
+
+**GitHub** (ask for `owner/repo`; the token comes from `GITHUB_TOKEN`, needed for private repos):
+
+```bash
+curl -sf -X POST http://127.0.0.1:8787/api/sources -H 'Content-Type: application/json' -d "{
+  \"name\": \"commits\", \"connector\": \"github\", \"poll\": \"30s\",
+  \"config\": {
+    \"repo\": \"<owner/repo>\",
+    \"token\": \"${GITHUB_TOKEN:-}\",
+    \"labels\": [{\"name\": \"repo\", \"field\": \"repo\", \"primary\": true},
+                 {\"name\": \"author\", \"field\": \"author\"}]
+  }}"
+```
+
+Drop the `token` line for a public repo without a token. Never echo the body with the token in it.
+
+**Webhook** (nothing to ask; create it and print the ingest URL):
+
+```bash
+curl -sf -X POST http://127.0.0.1:8787/api/sources -H 'Content-Type: application/json' -d '{
+  "name": "events", "connector": "webhook",
+  "config": {
+    "event_type_field": "action",
+    "text_template": "{action} by {sender}",
+    "labels": [{"name": "pipeline", "field": "pipeline", "primary": true}]
+  }}'
+```
+
+The response carries `ingest_key`. Print `POST http://127.0.0.1:8787/ingest/<ingest_key>` with a
+JSON body, and send one test event yourself:
+
+```bash
+curl -sf -X POST http://127.0.0.1:8787/ingest/<ingest_key> -H 'Content-Type: application/json' \
+  -d '{"action": "setup", "sender": "tares-skill", "pipeline": "setup"}'
+```
+
+## 5. Verify the source is receiving
+
+```bash
+for i in $(seq 1 30); do
+  n=$(curl -sf http://127.0.0.1:8787/api/sources/<name> | python3 -c 'import sys,json; h=json.load(sys.stdin).get("health") or {}; print(h.get("events_total") or 0)')
+  [ "$n" -gt 0 ] && break; sleep 2
+done
+curl -sf http://127.0.0.1:8787/api/sources/<name> | python3 -c 'import sys,json; h=json.load(sys.stdin).get("health") or {}; print("status", h.get("status"), "events", h.get("events_total"), "last_error", h.get("last_error"))'
+```
+
+Report what it saw: the event count, or the `last_error` if the count stayed 0 after 60 seconds
+(then fix the config and retry; see troubleshooting.md).
+
+## 6. Connect this agent over MCP
+
+Start the MCP endpoint, detached:
+
+```bash
+nohup tares mcp --transport streamable-http --port 8788 --taresd http://127.0.0.1:8787 > ~/.tares-mcp.log 2>&1 &
+sleep 2; lsof -iTCP:8788 -sTCP:LISTEN -n -P
+```
+
+Then register it with the client you are running inside:
+
+- **Claude Code**: `claude mcp add --transport http tares http://localhost:8788/mcp`
+- **Codex CLI**: `codex mcp add tares --url http://localhost:8788/mcp` (keep `--url`; a bare URL
+  registers a stdio server)
+- **Cursor**: write `~/.cursor/mcp.json` (or `.cursor/mcp.json` in the project):
+  `{"mcpServers": {"tares": {"url": "http://localhost:8788/mcp"}}}` and tell the user to approve
+  it under Settings > MCP
+- **Claude Desktop**: the same JSON in `claude_desktop_config.json`, then restart the app
+- **Anything else**: transport streamable HTTP, URL `http://localhost:8788/mcp`, no auth on a
+  local instance. Details: https://docs.glassflow.ai/tares/agents
+
+## 7. Prove it
+
+Call the `read` tool once for the entity the new source produced, for example
+`read(selector={"service": "<service name>"}, window="15m")` (for GitHub the key is `repo`, for
+the webhook `pipeline`). Show the user the result. If the client needs a restart before new MCP
+servers are visible, say so and show the equivalent HTTP call instead:
+
+```bash
+curl -sf "http://127.0.0.1:8787/api/read?service=<service name>&window=15m" | head -c 800
+```
+
+## 8. Report
+
+One short block: what was installed (version), the data dir, the console URL, how to stop and
+start, which source was added and how many events it has, which client is connected. End with
+exactly one next step:
+
+- one source so far: add a second one keyed by the same label so reads correlate
+  (https://docs.glassflow.ai/tares/connectors)
+- the user has Docker and no real source yet: run the demo stack and the AI SRE guide
+  (https://docs.glassflow.ai/tares/guides/ai-sre)
+- otherwise: "Ask me: what happened to <entity> in the last 15 minutes?"
+
+## Troubleshooting
+
+See [troubleshooting.md](troubleshooting.md).

--- a/skills/tares/troubleshooting.md
+++ b/skills/tares/troubleshooting.md
@@ -1,0 +1,44 @@
+# Tares troubleshooting
+
+Each entry: the symptom, the cause, the fix. Check the daemon log first: `~/.tares-up.log` (or
+wherever step 3 sent it).
+
+**`tares: command not found` after install.** uv's bin dir is not on PATH. `uv tool update-shell`,
+open a new shell, or call `~/.local/bin/tares` directly.
+
+**`/health` never returns 200.** The port is taken or the data dir is not writable. Check
+`lsof -iTCP:8787 -sTCP:LISTEN` and the log. A different port: `tares up --port 8797` (then use
+that port everywhere, including `--taresd` in step 6).
+
+**`POST /api/sources` returns 409.** The name exists. `GET /api/sources` and reuse it, or pick
+another name.
+
+**`POST /api/sources` returns 400.** A config key is wrong for that connector. The body of the
+response names it. Use only the keys shown in this skill or on
+https://docs.glassflow.ai/tares/connectors.
+
+**Source shows `events_total: 0` after 60 seconds.** Read `health.last_error` from
+`GET /api/sources/<name>`.
+- Prometheus: the URL is not reachable from the daemon's machine, or the PromQL matches no
+  series. Test with `curl '<url>/api/v1/query?query=<promql>'`.
+- Docker logs: wrong container name, or the container writes nothing. `docker logs <name>
+  --tail 5`.
+- GitHub: private repo without a token, or an expired token. The token is never returned by the
+  API; re-send the source with `PUT /api/sources/<name>` and a fresh `token`.
+- OTLP and webhook: nothing has been sent yet. Send one event yourself (step 4) to confirm the
+  path, then hand over to the user.
+
+**MCP client cannot connect.** `tares mcp` is not running (`lsof -iTCP:8788`), or it points at the
+wrong daemon (`--taresd`). The client must use transport `streamable-http` (or `http`) and the
+`/mcp` path.
+
+**`read` returns nothing.** The entity name is wrong or outside the window. The primary label of
+the source is the key: `service` for Prometheus, Docker and OTLP sources as configured above,
+`repo` for GitHub, `pipeline` for the webhook. Widen the window to `1h`.
+
+**Tares agents log "no key".** Built-in agents and Ask need an Anthropic key. Set
+`ANTHROPIC_API_KEY` in the shell that runs `tares up`, or add a key under Settings in the console.
+MCP reads need no key.
+
+**Demo stack does not start.** Docker is not running, or ports 8080 and 9090 are taken.
+`docker compose ps` and `lsof -iTCP:8080 -sTCP:LISTEN`.


### PR DESCRIPTION
`skills/tares/SKILL.md` and `troubleshooting.md`, discoverable with `npx skills add glassflow/tares --skill tares` (`skills.sh.json` at root, same layout as Kaelio/ktx).

The skill, in order: prerequisites (uv/pipx, ports 8787/8788, Docker only for the demo), install or upgrade, `tares up` detached with a health wait, first source over `POST /api/sources` with exact JSON bodies for prometheus, otlp, docker_logs, github (token from `GITHUB_TOKEN`, never echoed) and webhook (prints the ingest URL and sends a test event), verify via `GET /api/sources/<name>` health until events_total > 0, connect the detected client (Claude Code, Codex, Cursor, Claude Desktop, generic), prove with one `read`, report with a single next step.

Rules stated: announce long steps and post progress, secrets from env only with the "different shell" caveat, print each command, change something before retrying, GET before POST.

Also: `AGENTS.md` for contributors (plain-script tests, console rebuild, `TARES_*` contract, release, no em dashes) with `CLAUDE.md` including it, and the one-line prompt in the README Get running section.

The `skills` CLI only sees the skill once this is on main, so the fresh-machine end-to-end run is after merge.