### PR TITLE
tares status: readiness checklist and next step after tares up (TR-154)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Backend — install + tests
         run: |
           pip install -e .
-          for t in test_labels test_normalize test_auth test_api_keys test_pricing test_agents test_catalog_sync test_cli test_usage test_slack test_slack_verify test_slack_ask test_degraded test_loki test_ai_sre_demo test_seed; do
+          for t in test_labels test_normalize test_auth test_api_keys test_pricing test_agents test_catalog_sync test_cli test_status test_usage test_slack test_slack_verify test_slack_ask test_degraded test_loki test_ai_sre_demo test_seed; do
             echo "== $t =="
             python "tests/$t.py"
           done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 Notable changes to Tares (formerly NavFlow). Format follows [Keep a Changelog](https://keepachangelog.com/);
 the project follows [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+- **`tares status`**: a readiness checklist for a running instance (daemon, auth, sources
+  receiving, views, triggers, Tares agents and whether a key is set, MCP endpoint, which agent
+  clients on this machine have Tares registered, Slack) that ends with the one next step.
+  `--json` for scripts; exit 1 when nothing answers. `tares up` prints the same "Next:" line
+  right under the console URL once the daemon is up. `/health` now carries `version` and
+  `uptime_seconds`.
+
+### Changed
+- An agent run without a key, and the banners on the Agents pages, now say what to do: set
+  `ANTHROPIC_API_KEY` before `tares up`, or add a key under Settings (linked).
+
 ## [1.10.0] - 2026-08-25
 
 ### Changed

--- a/tares/builtin_agents.py
+++ b/tares/builtin_agents.py
@@ -299,7 +299,7 @@ class AgentRunner:
         t0 = time.monotonic()
         api_key, key_origin = resolve_key(self.store)
         if not api_key:
-            msg = "no Anthropic key: set ANTHROPIC_API_KEY or add one in the console"
+            msg = "no Anthropic key: set ANTHROPIC_API_KEY before `tares up`, or add a key under Settings"
             self.store.finish_agent_run(run_id, "failed", error=msg)
             return "failed", msg
         # Count the runs BEFORE this one (its row is already inserted), so the cap fires at exactly

--- a/tares/cli.py
+++ b/tares/cli.py
@@ -118,7 +118,45 @@ def _up(args: argparse.Namespace):
         import webbrowser
         open_url = f"{url}/?token={root_token}" if root_token else url
         threading.Timer(1.2, lambda: webbrowser.open(open_url)).start()
+    _print_next_step_when_up(url, root_token, str(home))
     run_daemon()
+
+
+def _print_next_step_when_up(url: str, token: str | None, data_dir: str) -> None:
+    """Once /health answers, print the same "Next:" line `tares status` ends with, so a first-run
+    user sees what to do right under the console URL. A daemon thread: it must never hold the
+    process open or fail the start."""
+    import threading
+    import time
+
+    def wait():
+        from .status import collect, next_step
+        for _ in range(60):
+            time.sleep(0.5)
+            st = collect(url, token, data_dir=data_dir)
+            if st["daemon"]["running"]:
+                print(f"tares: {next_step(st)}", flush=True)
+                return
+
+    threading.Thread(target=wait, daemon=True).start()
+
+
+def _status(args: argparse.Namespace):
+    """Readiness checklist against a running daemon. Read-only."""
+    import json
+    from .status import collect, render
+    home = Path(args.data_dir).expanduser()
+    base = args.taresd or f"http://127.0.0.1:{os.getenv('TARES_PORT', '8787')}"
+    token = os.getenv("TARES_AUTH_TOKEN", "").strip() or None
+    if not token and (home / "root_token").exists():
+        token = (home / "root_token").read_text().strip() or None
+    mcp = f"http://{os.getenv('TARES_MCP_HOST', '127.0.0.1')}:{os.getenv('TARES_MCP_PORT', '8788')}/mcp"
+    st = collect(base, token, mcp_url=mcp, data_dir=str(home))
+    if args.json:
+        print(json.dumps(st, indent=2, default=str))
+    else:
+        print(render(st))
+    raise SystemExit(0 if st["daemon"]["running"] else 1)
 
 
 def _mcp(args: argparse.Namespace):
@@ -163,6 +201,13 @@ def main():
     m.add_argument("--taresd", default=os.getenv("TARESD_URL", ""),
                    help="taresd base URL to proxy to (default http://127.0.0.1:8787)")
     m.set_defaults(func=_mcp)
+
+    st = sub.add_parser("status", help="readiness checklist for a running instance, and the next step")
+    st.add_argument("--taresd", default=os.getenv("TARESD_URL", ""),
+                    help="daemon URL (default http://127.0.0.1:$TARES_PORT or 8787)")
+    st.add_argument("--data-dir", default=str(DEFAULT_HOME), help="where the root token lives when auth is on")
+    st.add_argument("--json", action="store_true", help="machine-readable output")
+    st.set_defaults(func=_status)
 
     args = p.parse_args()
     if not getattr(args, "func", None):

--- a/tares/daemon.py
+++ b/tares/daemon.py
@@ -11,6 +11,7 @@ import asyncio
 import hashlib
 import json
 import os
+import time
 import re
 import secrets
 import shutil
@@ -84,6 +85,17 @@ WORKSPACE_URL = os.getenv("TARES_WORKSPACE_URL", "").strip()
 # marker makes it one-shot — deleting the use case never resurrects it. Meaningful for a
 # self-hoster building a golden image too; harmlessly unset otherwise.
 SEED_USECASE = os.getenv("TARES_SEED_USECASE", "").strip()
+
+
+_STARTED_MONO = time.monotonic()
+
+
+def _installed_version() -> str | None:
+    from importlib.metadata import version as _v
+    try:
+        return _v("tares")
+    except Exception:
+        return None
 
 
 def _is_ingest(path: str) -> bool:
@@ -531,7 +543,8 @@ def make_app() -> FastAPI:
                 detail = f"storage {pct}% full ({MAX_DB_SIZE} byte limit)"
         body = {"status": status, "auth_required": bool(AUTH_TOKEN),
                 "sources": [] if AUTH_TOKEN else list(runtime.catalog.sources),
-                "pct_used": pct}
+                "pct_used": pct, "version": _installed_version(),
+                "uptime_seconds": int(time.monotonic() - _STARTED_MONO)}
         if detail:
             body["detail"] = detail
         if LOGIN_URL:

--- a/tares/status.py
+++ b/tares/status.py
@@ -1,0 +1,284 @@
+"""`tares status`: a readiness checklist for a running instance, and the one next step.
+
+Everything comes from the daemon's existing HTTP API plus a read-only look at the agent clients'
+config files on this machine. Pure functions where it matters: `next_step` and `render` take the
+collected dict, so they are testable without a daemon and reusable by `tares up`.
+"""
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+DOCS = "docs.glassflow.ai/tares"
+_TIMEOUT = 3.0
+
+
+# ── collection ────────────────────────────────────────────────────────────────────────────────
+
+def _get(base: str, path: str, token: str | None) -> dict | list | None:
+    req = urllib.request.Request(base.rstrip("/") + path)
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    try:
+        with urllib.request.urlopen(req, timeout=_TIMEOUT) as r:
+            return json.loads(r.read().decode())
+    except (urllib.error.URLError, urllib.error.HTTPError, ValueError, OSError):
+        return None
+
+
+def _probe(url: str) -> bool:
+    """Is anything listening? Any HTTP answer counts (an MCP endpoint answers GET with 4xx)."""
+    try:
+        urllib.request.urlopen(urllib.request.Request(url), timeout=1.5)
+        return True
+    except urllib.error.HTTPError:
+        return True
+    except (urllib.error.URLError, OSError):
+        return False
+
+
+def _ago(ts: str | None) -> str | None:
+    if not ts:
+        return None
+    try:
+        t = datetime.fromisoformat(str(ts).replace("Z", "+00:00"))
+        if t.tzinfo is None:
+            t = t.replace(tzinfo=timezone.utc)
+        s = int((datetime.now(timezone.utc) - t).total_seconds())
+    except ValueError:
+        return None
+    if s < 60:
+        return f"{s}s ago"
+    if s < 3600:
+        return f"{s // 60}m ago"
+    if s < 86400:
+        return f"{s // 3600}h ago"
+    return f"{s // 86400}d ago"
+
+
+def _fmt_bytes(n: int | None) -> str:
+    if n is None:
+        return "?"
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if n < 1024 or unit == "TB":
+            return f"{n:.0f} {unit}" if unit == "B" else f"{n:.1f} {unit}".replace(".0 ", " ")
+        n /= 1024
+    return f"{n:.1f} TB"
+
+
+def detect_clients(home: Path | None = None, cwd: Path | None = None) -> dict:
+    """Which local agent clients have a Tares MCP server registered. Best-effort, read-only:
+    unreadable or malformed files read as 'unknown', a missing file as not connected."""
+    home = home or Path.home()
+    cwd = cwd or Path.cwd()
+    out: dict[str, str] = {}
+
+    def has_tares(servers) -> bool:
+        return isinstance(servers, dict) and any("tares" in k.lower() for k in servers)
+
+    # Claude Code: global mcpServers plus per-project entries in ~/.claude.json, and .mcp.json
+    p = home / ".claude.json"
+    if p.exists():
+        try:
+            d = json.loads(p.read_text())
+            found = has_tares(d.get("mcpServers"))
+            for proj in (d.get("projects") or {}).values():
+                found = found or has_tares((proj or {}).get("mcpServers"))
+            if not found and (cwd / ".mcp.json").exists():
+                found = has_tares(json.loads((cwd / ".mcp.json").read_text()).get("mcpServers"))
+            out["Claude Code"] = "connected" if found else "not connected"
+        except (OSError, ValueError):
+            out["Claude Code"] = "unknown"
+    # Cursor: global or per-project mcp.json
+    for p in (home / ".cursor" / "mcp.json", cwd / ".cursor" / "mcp.json"):
+        if p.exists():
+            try:
+                if has_tares(json.loads(p.read_text()).get("mcpServers")):
+                    out["Cursor"] = "connected"
+                    break
+                out.setdefault("Cursor", "not connected")
+            except (OSError, ValueError):
+                out["Cursor"] = "unknown"
+    # Codex: TOML; a substring check is enough and avoids a parser dependency
+    p = home / ".codex" / "config.toml"
+    if p.exists():
+        try:
+            out["Codex"] = "connected" if "[mcp_servers.tares" in p.read_text() else "not connected"
+        except OSError:
+            out["Codex"] = "unknown"
+    return out
+
+
+def collect(base: str, token: str | None = None, mcp_url: str | None = None,
+            data_dir: str | None = None) -> dict:
+    """One dict with everything the checklist prints. `daemon.running` false means nothing else
+    could be read; every other field is present (possibly null) so `--json` is stable."""
+    health = _get(base, "/health", token)
+    st: dict = {
+        "url": base, "data_dir": data_dir, "version": None,
+        "daemon": {"running": health is not None, "status": None, "uptime_seconds": None,
+                   "detail": None},
+        "auth": {"on": None},
+        "storage": {"used_bytes": None, "max_bytes": None},
+        "sources": {"configured": 0, "receiving": 0, "last_event_at": None, "silent": []},
+        "views": {"count": 0, "names": []},
+        "triggers": {"enabled": 0, "last_fired_at": None},
+        "agents": {"enabled": 0, "configured": 0, "model": None, "key_configured": None},
+        "mcp": {"url": mcp_url, "running": None},
+        "clients": detect_clients(),
+        "slack": {"configured": None},
+        "entities": [],
+    }
+    if health is None:
+        return st
+    st["daemon"].update({"status": health.get("status"), "detail": health.get("detail"),
+                         "uptime_seconds": health.get("uptime_seconds")})
+    st["version"] = health.get("version")
+    st["auth"]["on"] = bool(health.get("auth_required"))
+
+    usage = _get(base, "/api/usage", token)
+    if isinstance(usage, dict):
+        st["storage"] = {"used_bytes": (usage.get("db_bytes") or 0) + (usage.get("wal_bytes") or 0),
+                         "max_bytes": usage.get("max_bytes")}
+
+    sources = _get(base, "/api/sources", token)
+    if isinstance(sources, list):
+        last = None
+        for s in sources:
+            h = s.get("health") or {}
+            st["sources"]["configured"] += 1
+            if (h.get("events_total") or 0) > 0:
+                st["sources"]["receiving"] += 1
+            else:
+                st["sources"]["silent"].append({"name": s.get("name"), "error": h.get("last_error")})
+            li = h.get("last_ingest")
+            if li and (last is None or str(li) > str(last)):
+                last = li
+        st["sources"]["last_event_at"] = last
+
+    views = _get(base, "/api/views", token)
+    if isinstance(views, list):
+        st["views"] = {"count": len(views), "names": [v.get("name") for v in views]}
+
+    triggers = _get(base, "/api/triggers", token)
+    if isinstance(triggers, list):
+        st["triggers"]["enabled"] = sum(1 for t in triggers if not t.get("paused"))
+    dispatches = _get(base, "/api/activity/dispatches?limit=1", token)
+    if isinstance(dispatches, list) and dispatches:
+        st["triggers"]["last_fired_at"] = dispatches[0].get("fired_at")
+
+    agents = _get(base, "/api/agents/builtin", token)
+    if isinstance(agents, dict):
+        rows = agents.get("agents") or []
+        enabled = [a for a in rows if a.get("enabled")]
+        st["agents"] = {"configured": len(rows), "enabled": len(enabled),
+                        "model": next((a.get("model") for a in enabled if a.get("model")), None)
+                        or agents.get("default_model"),
+                        "key_configured": bool(agents.get("key_configured"))}
+        st["slack"]["configured"] = bool(agents.get("slack_workspace"))
+
+    if mcp_url:
+        st["mcp"]["running"] = _probe(mcp_url)
+
+    # one entity name for the "ask your agent" line: the first source's most recent event key
+    if isinstance(sources, list) and sources:
+        ev = _get(base, f"/api/sources/{sources[0]['name']}/events?limit=1", token)
+        if isinstance(ev, list) and ev and isinstance(ev[0], dict):
+            k = ev[0].get("key") or ev[0].get("key_value")
+            if k:
+                st["entities"] = [k]
+    return st
+
+
+# ── the decision table ────────────────────────────────────────────────────────────────────────
+
+def next_step(st: dict) -> str:
+    """Exactly one line, in this order of precedence."""
+    if not st["daemon"]["running"]:
+        return f"Next: start Tares with `tares up`. Docs: {DOCS}/quickstart"
+    src = st["sources"]
+    if src["configured"] == 0:
+        return (f"Next: add a source (Sources > Add source, or POST /api/sources), or run the demo "
+                f"stack. Docs: {DOCS}/connectors")
+    if src["receiving"] == 0:
+        s = src["silent"][0]
+        why = f" ({s['error']})" if s.get("error") else ""
+        return f"Next: source `{s['name']}` has not received anything yet{why}. Docs: {DOCS}/connectors"
+    if src["configured"] == 1:
+        return (f"Next: add a second source keyed by the same label so reads correlate. "
+                f"Docs: {DOCS}/connectors")
+    if not any(v == "connected" for v in st["clients"].values()):
+        mcp = st["mcp"].get("url") or "http://127.0.0.1:8788/mcp"
+        return (f"Next: connect an agent: `tares mcp` then "
+                f"`claude mcp add --transport http tares {mcp}`. Docs: {DOCS}/agents")
+    ag = st["agents"]
+    if ag["enabled"] > 0 and ag["key_configured"] is False:
+        return ("Next: set ANTHROPIC_API_KEY before `tares up`, or add a key under Settings, "
+                "so the enabled agents can run.")
+    ent = st["entities"][0] if st["entities"] else "<entity>"
+    return f"Ready. Ask your agent: what happened to {ent} in the last 15 minutes?"
+
+
+# ── rendering ─────────────────────────────────────────────────────────────────────────────────
+
+def render(st: dict) -> str:
+    L = []
+    ver = st.get("version") or "?"
+    store = ""
+    if st["storage"]["used_bytes"] is not None:
+        cap = st["storage"]["max_bytes"]
+        store = f"   data dir {st['data_dir'] or '?'} ({_fmt_bytes(st['storage']['used_bytes'])}"
+        store += f" of {_fmt_bytes(cap)})" if cap else ")"
+    L.append(f"Tares {ver} at {st['url']}{store}")
+    d = st["daemon"]
+    if not d["running"]:
+        L.append(f"{'Daemon:':<19}not running (nothing answered at {st['url']})")
+        L.append("")
+        L.append(next_step(st))
+        return "\n".join(L)
+    up = d.get("uptime_seconds")
+    up_s = f" (uptime {up // 3600}h {(up % 3600) // 60}m)" if isinstance(up, (int, float)) else ""
+    status = d["status"] or "running"
+    L.append(f"{'Daemon:':<19}{'running' if status == 'ok' else status}{up_s}"
+             + (f"   {d['detail']}" if d.get("detail") else ""))
+    L.append(f"{'Auth:':<19}{'on' if st['auth']['on'] else 'off (open local instance)'}")
+    s = st["sources"]
+    if s["configured"] == 0:
+        L.append(f"{'Sources:':<19}none yet")
+    else:
+        last = _ago(s["last_event_at"])
+        L.append(f"{'Sources:':<19}{s['configured']} configured, {s['receiving']} receiving"
+                 + (f" (last event {last})" if last else ""))
+    v = st["views"]
+    L.append(f"{'Views:':<19}{v['count']}" + (f" ({', '.join(v['names'][:3])})" if v["names"] else ""))
+    t = st["triggers"]
+    fired = _ago(t["last_fired_at"])
+    L.append(f"{'Triggers:':<19}{t['enabled']} enabled" + (f", last fired {fired}" if fired else ""))
+    a = st["agents"]
+    if a["configured"] == 0:
+        L.append(f"{'Tares agents:':<19}none")
+    else:
+        key = "set" if a["key_configured"] else "missing"
+        L.append(f"{'Tares agents:':<19}{a['enabled']} enabled"
+                 + (f", model {a['model']}" if a.get("model") else "") + f", Anthropic key: {key}")
+    m = st["mcp"]
+    if m["running"] is None:
+        L.append(f"{'MCP endpoint:':<19}not checked")
+    elif m["running"]:
+        L.append(f"{'MCP endpoint:':<19}running at {m['url']}")
+    else:
+        L.append(f"{'MCP endpoint:':<19}not running (start with `tares mcp`)")
+    c = st["clients"]
+    if c:
+        L.append(f"{'Agent clients:':<19}" + ", ".join(f"{k}: {v}" for k, v in c.items()))
+    else:
+        L.append(f"{'Agent clients:':<19}none detected")
+    sl = st["slack"]["configured"]
+    L.append(f"{'Slack:':<19}{'configured' if sl else 'not configured'}")
+    L.append("")
+    L.append(next_step(st))
+    return "\n".join(L)

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1,0 +1,67 @@
+"""`tares status` (tares/status.py): the decision table, the rendering, and client detection.
+No daemon: collect() is exercised in test_cli-style integration by hand; here the pure parts."""
+import json, os, tempfile
+from pathlib import Path
+
+from tares.status import detect_clients, next_step, render
+
+P = F = 0
+def ck(l, c, d=""):
+    global P, F; P += 1 if c else 0; F += 0 if c else 1
+    print(("  ok   " if c else "  FAIL ") + l + ("" if c else f"  {d}"))
+
+
+def base(**over):
+    st = {"url": "http://127.0.0.1:8787", "data_dir": "/x", "version": "1.11.0",
+          "daemon": {"running": True, "status": "ok", "uptime_seconds": 3700, "detail": None},
+          "auth": {"on": False}, "storage": {"used_bytes": 12_000_000, "max_bytes": None},
+          "sources": {"configured": 0, "receiving": 0, "last_event_at": None, "silent": []},
+          "views": {"count": 0, "names": []}, "triggers": {"enabled": 0, "last_fired_at": None},
+          "agents": {"enabled": 0, "configured": 0, "model": None, "key_configured": False},
+          "mcp": {"url": "http://127.0.0.1:8788/mcp", "running": False},
+          "clients": {}, "slack": {"configured": False}, "entities": []}
+    for k, v in over.items():
+        st[k] = {**st[k], **v} if isinstance(v, dict) else v
+    return st
+
+
+# decision table, in order
+ck("down -> start", "tares up" in next_step(base(daemon={"running": False})))
+ck("no sources -> add or demo", "add a source" in next_step(base()))
+s = base(sources={"configured": 1, "receiving": 0, "silent": [{"name": "logs", "error": "no such container"}]})
+n = next_step(s)
+ck("silent source named with its error", "`logs`" in n and "no such container" in n, n)
+ck("one source -> second keyed the same", "second source" in next_step(base(sources={"configured": 1, "receiving": 1})))
+two = base(sources={"configured": 2, "receiving": 2})
+ck("no client -> claude mcp add", "claude mcp add" in next_step(two))
+conn = base(sources={"configured": 2, "receiving": 2}, clients={"Claude Code": "connected"},
+            agents={"enabled": 1, "configured": 1, "key_configured": False})
+ck("agent enabled, no key -> where to set it", "ANTHROPIC_API_KEY" in next_step(conn))
+ready = base(sources={"configured": 2, "receiving": 2}, clients={"Cursor": "connected"},
+             agents={"enabled": 1, "configured": 1, "key_configured": True}, entities=["api-server"])
+ck("otherwise ready with the first entity", next_step(ready) == "Ready. Ask your agent: what happened to api-server in the last 15 minutes?", next_step(ready))
+
+# rendering
+out = render(ready)
+ck("header has version and url", out.startswith("Tares 1.11.0 at http://127.0.0.1:8787"), out.splitlines()[0])
+ck("uptime rendered", "uptime 1h 1m" in out)
+ck("auth off wording", "off (open local instance)" in out)
+ck("key set", "Anthropic key: set" in out)
+ck("ends with the next line", out.rstrip().splitlines()[-1].startswith("Ready."))
+ck("no em dash anywhere", "—" not in out)
+down = render(base(daemon={"running": False}))
+ck("down is short and says so", "not running" in down and "Next:" in down)
+
+# client detection, read-only over a temp home
+with tempfile.TemporaryDirectory() as d:
+    h = Path(d); cwd = h / "proj"; cwd.mkdir()
+    ck("nothing -> empty", detect_clients(h, cwd) == {})
+    (h / ".claude.json").write_text(json.dumps({"mcpServers": {}, "projects": {"/p": {"mcpServers": {"tares": {}}}}}))
+    ck("claude code per-project entry", detect_clients(h, cwd)["Claude Code"] == "connected")
+    (h / ".cursor").mkdir(); (h / ".cursor" / "mcp.json").write_text("{not json")
+    ck("unreadable cursor config -> unknown", detect_clients(h, cwd)["Cursor"] == "unknown")
+    (h / ".codex").mkdir(); (h / ".codex" / "config.toml").write_text("[mcp_servers.tares]\nurl='x'\n")
+    ck("codex toml", detect_clients(h, cwd)["Codex"] == "connected")
+
+print(f"\n{P} passed, {F} failed")
+raise SystemExit(1 if F else 0)

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -140,7 +140,7 @@ export default function AgentDetail() {
                   <td>
                     {agent.enabled ? <span className="badge ok">enabled</span> : <span className="badge">disabled</span>}
                     {!data.key_configured
-                      ? <span className="help"> · no Anthropic key: set one under <Link to="/settings?tab=anthropic">Settings</Link> to run</span>
+                      ? <span className="help"> · no Anthropic key: set ANTHROPIC_API_KEY before <span className="mono">tares up</span>, or add a key under <Link to="/settings?tab=anthropic">Settings</Link></span>
                       : <span className="help"> · key from <span className="mono">{data.key_source}</span></span>}
                   </td>
                 </tr>
@@ -366,7 +366,10 @@ function RunRow({ r, open, focused, onToggle }: {
                   </div>
                 : !exhaustedNote && (
                     <p className="help" style={{ margin: 0, whiteSpace: "normal" }}>
-                      {r.status === "running" ? "investigating…" : (r.error ?? "no finding")}
+                      {r.status === "running" ? "investigating…"
+                        : r.error?.startsWith("no Anthropic key")
+                          ? <>{r.error} (<Link to="/settings?tab=anthropic">Settings</Link>)</>
+                          : (r.error ?? "no finding")}
                     </p>
                   )}
             </div>

--- a/ui/src/pages/Agents.tsx
+++ b/ui/src/pages/Agents.tsx
@@ -35,8 +35,8 @@ export default function Agents() {
 
       {data && !data.key_configured && (
         <div className="alert">
-          No Anthropic key configured; agents can be created but not enabled. Set one under{" "}
-          <Link to="/settings">Settings</Link>.
+          No Anthropic key: set ANTHROPIC_API_KEY before <span className="mono">tares up</span>, or add a
+          key under <Link to="/settings?tab=anthropic">Settings</Link>. Agents can be created but not enabled until then.
         </div>
       )}
 


### PR DESCRIPTION
- `tares status` (tares/status.py + cli): daemon, auth, sources configured/receiving with last event, views, triggers with last fired, Tares agents with model and key set/missing, MCP endpoint, agent clients detected read-only from `~/.claude.json` (global and per-project), `~/.cursor/mcp.json`, `~/.codex/config.toml`, Slack. Ends with one `Next:` line from the decision table in the ticket order. `--json` for scripts, exit 1 when nothing answers. Reads the root token from the data dir when auth is on.
- `tares up` prints the same `Next:` line under the console URL once `/health` answers (daemon thread, never blocks the start).
- `/health` gains `version` and `uptime_seconds`.
- No-key wording: the agent run error, the Agents banner and the agent page now say "set ANTHROPIC_API_KEY before `tares up`, or add a key under Settings", linked; the run row links to Settings when the error is a missing key.
- tests/test_status.py (decision table, rendering, client detection over a temp home), added to the CI list. CHANGELOG under Unreleased.

Verified live: fresh instance (Next: add a source), the demo catalog (3 sources, 2 receiving, 1 agent enabled, key missing -> Next: set the key), `--json` keys stable, a down daemon (exit 1).