### PR TITLE
Skill: fix the HTTP read fallback route

### DIFF
--- a/skills/tares/SKILL.md
+++ b/skills/tares/SKILL.md
@@ -183,7 +183,8 @@ the webhook `pipeline`). Show the user the result. If the client needs a restart
 servers are visible, say so and show the equivalent HTTP call instead:
 
 ```bash
-curl -sf "http://127.0.0.1:8787/api/read?service=<service name>&window=15m" | head -c 800
+curl -sf -X POST http://127.0.0.1:8787/read -H 'Content-Type: application/json' \
+  -d '{"selector": {"service": "<service name>"}, "window": "15m"}' | head -c 800
 ```
 
 ## 8. Report


### PR DESCRIPTION
Found by the fresh-machine run of TR-151: step 7's fallback used `GET /api/read?...`, which is not a route (it fell through to the console HTML with a 200). The real call is `POST /read` with a selector and window.