### PR TITLE
Challenger workflow: Tares side and plugin (TR-195 to TR-200)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Backend — install + tests
         run: |
           pip install -e .
-          for t in test_labels test_normalize test_auth test_api_keys test_pricing test_agents test_catalog_sync test_cli test_status test_usage test_slack test_slack_verify test_slack_ask test_degraded test_loki test_ai_sre_demo test_seed test_session_flow test_challenger_workflow; do
+          for t in test_labels test_normalize test_auth test_api_keys test_pricing test_agents test_catalog_sync test_cli test_status test_usage test_slack test_slack_verify test_slack_ask test_degraded test_loki test_ai_sre_demo test_seed test_session_flow test_challenger_workflow test_plugin_challenger; do
             echo "== $t =="
             python "tests/$t.py"
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Backend — install + tests
         run: |
           pip install -e .
-          for t in test_labels test_normalize test_auth test_api_keys test_pricing test_agents test_catalog_sync test_cli test_status test_usage test_slack test_slack_verify test_slack_ask test_degraded test_loki test_ai_sre_demo test_seed; do
+          for t in test_labels test_normalize test_auth test_api_keys test_pricing test_agents test_catalog_sync test_cli test_status test_usage test_slack test_slack_verify test_slack_ask test_degraded test_loki test_ai_sre_demo test_seed test_session_flow; do
             echo "== $t =="
             python "tests/$t.py"
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Backend — install + tests
         run: |
           pip install -e .
-          for t in test_labels test_normalize test_auth test_api_keys test_pricing test_agents test_catalog_sync test_cli test_status test_usage test_slack test_slack_verify test_slack_ask test_degraded test_loki test_ai_sre_demo test_seed test_session_flow; do
+          for t in test_labels test_normalize test_auth test_api_keys test_pricing test_agents test_catalog_sync test_cli test_status test_usage test_slack test_slack_verify test_slack_ask test_degraded test_loki test_ai_sre_demo test_seed test_session_flow test_challenger_workflow; do
             echo "== $t =="
             python "tests/$t.py"
           done

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "tares",
   "displayName": "Tares",
-  "version": "0.1.1",
-  "description": "Connect Claude Code to Tares \u2014 query your data plane over MCP, and stream this session into Tares's claude_code source.",
+  "version": "0.2.0",
+  "description": "Connect Claude Code to Tares: query your data plane over MCP, stream this session into Tares, and run challenger sessions where Codex challenges the plan and every commit.",
   "author": {
     "name": "GlassFlow",
     "url": "https://glassflow.dev"
@@ -25,7 +25,7 @@
     "access_token": {
       "type": "string",
       "title": "API key / token (optional)",
-      "description": "Only if your Tares requires auth. Recommended: an API key with the read + ingest scopes (console -> Security -> API keys) \u2014 streams sessions and enables MCP read-back without admin rights. The root auth token also works.",
+      "description": "Only if your Tares requires auth. Recommended: an API key with the read + ingest scopes (console -> Security -> API keys) — streams sessions and enables MCP read-back without admin rights. The root auth token also works.",
       "sensitive": true,
       "default": ""
     },
@@ -34,6 +34,24 @@
       "title": "Stream this session into Tares",
       "description": "When on, this session's transcript is shipped to Tares's claude_code source as it progresses.",
       "default": true
+    },
+    "challenger_mode": {
+      "type": "string",
+      "title": "Challenger mode for commits",
+      "description": "strict: P1/P2 findings from the Codex review block Claude until fixed (default). advise: findings come back as context only. Plans are always advisory.",
+      "default": "strict"
+    },
+    "codex_bin": {
+      "type": "string",
+      "title": "Codex CLI path (optional)",
+      "description": "Leave empty to use `codex` from PATH.",
+      "default": ""
+    },
+    "codex_sandbox": {
+      "type": "string",
+      "title": "Codex sandbox (optional)",
+      "description": "Empty = Codex's --full-auto sandbox. workspace-write or danger-full-access when the default sandbox fails inside an already sandboxed session.",
+      "default": ""
     }
   }
 }

--- a/claude-plugin/README.md
+++ b/claude-plugin/README.md
@@ -9,7 +9,8 @@ One install wires Claude Code to Tares in **both directions**:
   `{tares_url}/ingest/claude_code`.
 
 Both wires are configured once on install (`tares_url`, optional auth `access_token`, and a
-`stream_sessions` toggle).
+`stream_sessions` toggle). Challenger sessions (below) add `challenger_mode`, `codex_bin` and
+`codex_sandbox`.
 
 ## Prerequisites
 
@@ -42,6 +43,35 @@ dir), then users run:
 ```
 
 They're prompted for `tares_url` + token on install; the token is stored in the OS keychain.
+
+## Challenger sessions
+
+Say "make this a challenger session" (or type `/tares:challenger`) at the start of a session.
+Claude calls the `set_session_flow` MCP tool; the shipper sees that call in the transcript, marks
+the session locally and on Tares, and from then on:
+
+- when Claude leaves plan mode, the OpenAI Codex CLI on your laptop critiques the plan and Claude
+  gets the findings before you see the plan (advisory);
+- after every `git commit` Claude makes, Codex reviews the commit. `[P1]`/`[P2]` findings block
+  Claude until it fixes and amends (strict, the default) or come back as context (`challenger_mode`
+  = `advise`). Errors, timeouts and inconclusive reviews never block. Consecutive failed rounds are
+  capped at 8 and the fix loop at 5 turn ends;
+- every review lands on the session's timeline in Tares next to the transcript, and when the
+  session ends Tares's challenger use case writes the session summary with memory proposals.
+  Accepted memory is handed to Claude at the next session start on that project.
+
+`/tares:challenger off` turns it off mid-session. `/tares:challenger-waive [n|all]` suppresses a
+disputed finding. `touch .git/tares-challenger-skip` disables the hooks for a repository. State and
+history live under `.git/` (`tares-challenger-*`), never in the working tree.
+
+Needs `codex` on PATH (`npm install -g @openai/codex && codex login`) or the `codex_bin` option;
+reviews are billed to your OpenAI account and Tares never calls Codex. If reviews come back
+INCONCLUSIVE inside an already sandboxed session, set `codex_sandbox` to `danger-full-access`.
+
+The mechanism follows [andreidavid/codex-review](https://github.com/andreidavid/codex-review)
+(MIT): post-commit review, priority-tagged findings, the blocking fix loop, plan critique, state in
+`.git/`. This plugin reimplements it in Python, gates it on the session mark, and records the
+exchange in Tares.
 
 ## How capture works
 

--- a/claude-plugin/commands/challenger-waive.md
+++ b/claude-plugin/commands/challenger-waive.md
@@ -1,0 +1,15 @@
+---
+description: Waive a disputed finding from the last failed Codex review so it stops blocking the commit.
+argument-hint: "[n|all]"
+allowed-tools: [Bash]
+---
+
+The user invoked /tares:challenger-waive with: $ARGUMENTS
+
+Run, from the repository root:
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/challenger.py" waive $ARGUMENTS
+```
+
+Show the user its output verbatim. If it lists the blocking findings and asks which one, ask the user and run it again with the number. Do not edit the waiver file yourself and do not re-run the review.

--- a/claude-plugin/commands/challenger.md
+++ b/claude-plugin/commands/challenger.md
@@ -1,0 +1,12 @@
+---
+description: Make this a challenger session (Codex challenges the plan and every commit; Tares keeps the record). "off" turns it off.
+argument-hint: "[off]"
+---
+
+The user invoked /tares:challenger with: $ARGUMENTS
+
+If the argument is `off`: call the `set_session_flow` tool of the tares MCP server with `flow` set to an empty string, then tell the user the challenger is off for this session.
+
+Otherwise: call the `set_session_flow` tool of the tares MCP server with `flow` = `challenger`. Then tell the user, in two sentences, that this is now a challenger session: Codex on this laptop will challenge the plan when you leave plan mode and every commit you make, and Tares records the exchange and writes a session summary with memory proposals when the session ends.
+
+Do nothing else. Do not run Codex yourself; the plugin's hooks run it.

--- a/claude-plugin/hooks/hooks.json
+++ b/claude-plugin/hooks/hooks.json
@@ -1,13 +1,18 @@
 {
   "hooks": {
     "SessionStart": [
-      { "hooks": [{ "type": "command", "command": "python3", "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/ship.py"], "async": true }] }
+      { "hooks": [{ "type": "command", "command": "python3", "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/ship.py"], "timeout": 10 }] }
     ],
     "UserPromptSubmit": [
       { "hooks": [{ "type": "command", "command": "python3", "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/ship.py"], "async": true }] }
     ],
     "PostToolUse": [
-      { "hooks": [{ "type": "command", "command": "python3", "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/ship.py"], "async": true }] }
+      { "hooks": [{ "type": "command", "command": "python3", "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/ship.py"], "async": true }] },
+      { "matcher": "Bash|ExitPlanMode",
+        "hooks": [{ "type": "command", "command": "python3", "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/challenger.py"], "timeout": 900 }] }
+    ],
+    "Stop": [
+      { "hooks": [{ "type": "command", "command": "python3", "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/challenger.py"], "timeout": 10 }] }
     ],
     "SessionEnd": [
       { "hooks": [{ "type": "command", "command": "python3", "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/ship.py"] }] }

--- a/claude-plugin/marketplace.example.json
+++ b/claude-plugin/marketplace.example.json
@@ -1,13 +1,16 @@
 {
   "name": "tares",
-  "owner": { "name": "GlassFlow", "url": "https://glassflow.dev" },
+  "owner": {
+    "name": "GlassFlow",
+    "url": "https://glassflow.dev"
+  },
   "description": "Tares — data plane for AI agents. Query Tares from Claude Code and stream sessions back in.",
   "plugins": [
     {
       "name": "tares",
       "source": "./claude-plugin",
-      "description": "Connect Claude Code to Tares (MCP read-back + session capture).",
-      "version": "0.1.0"
+      "description": "Connect Claude Code to Tares (MCP read-back, session capture, challenger sessions).",
+      "version": "0.2.0"
     }
   ]
 }

--- a/claude-plugin/scripts/challenger.py
+++ b/claude-plugin/scripts/challenger.py
@@ -1,0 +1,555 @@
+#!/usr/bin/env python3
+"""The challenger hooks: a second model (OpenAI Codex CLI, on this laptop) challenges Claude's plan
+and every commit in a session the user marked as a challenger session.
+
+Runs as three Claude Code hooks, all gated on the per-session marker the shipper writes when Claude
+calls the `set_session_flow` MCP tool (see ship.py). Nothing here ever asks Tares whether to run.
+
+- PostToolUse(ExitPlanMode): Codex critiques the plan. Findings come back to Claude as context so
+  it can revise before the user sees the plan. Never blocks: the user approves the plan anyway.
+- PostToolUse(Bash) after a successful `git commit`: `codex exec review --json --commit HEAD`.
+  P1/P2 findings block Claude with the review (strict mode, the default) or come back as context
+  (advise mode). Errors, timeouts and inconclusive reviews never block.
+- Stop: while the last review of this session's commit is FAIL, keep Claude in the fix loop
+  (amend while unpushed), capped at MAX_LOOPS turn ends and MAX_ROUNDS review rounds.
+
+Every review is appended to .git/tares-challenger-reviews.jsonl and shipped to Tares as a
+challenge_plan / challenge_commit line on the session timeline (best effort; a failed POST never
+changes the verdict). State lives under .git/, never in the working tree.
+
+The mechanism (post-commit review, priority-tagged findings, blocking fix loop, plan critique,
+state in .git) follows andreidavid/codex-review (MIT); this is a rewrite in Python that adds the
+session gate and the Tares record.
+
+`challenger.py waive [n|all]` (the /tares:challenger-waive command) suppresses a disputed finding.
+"""
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from ship import CHALLENGER, _opt, config, read_flow, ship_lines, synthetic_line  # noqa: E402
+
+MAX_LOOPS = int(os.environ.get("TARES_CHALLENGER_MAX_LOOPS", "5"))      # Stop-hook continuations
+MAX_ROUNDS = int(os.environ.get("TARES_CHALLENGER_MAX_ROUNDS", "8"))    # consecutive FAIL reviews
+TIMEOUT = min(int(os.environ.get("TARES_CHALLENGER_TIMEOUT", "600")), 880)
+MAX_OUTPUT = 8000
+FAIL_MAX_AGE = 3600
+RUNNING_MAX_AGE = 16 * 60
+STATE = "tares-challenger-state"
+LOOPS = "tares-challenger-loop-count"
+ROUNDS = "tares-challenger-round-count"
+HISTORY = "tares-challenger-reviews.jsonl"
+WAIVED = "tares-challenger-waived"
+SKIP = "tares-challenger-skip"
+
+_COMMIT_RE = re.compile(r"(^|[^\w])git(\s[^;&|]*)?\scommit([^\w]|$)")
+_FINDING_RE = re.compile(r"^\s*(?:[-*>]\s+)?\[(P[123])\]\s+(\S.*?)\s*$")
+
+PLAN_PROMPT = (
+    "Review the implementation plan at {path}. Read it fully, then critique from these angles: "
+    "missing steps or gaps; design flaws or wrong-architecture choices; scope creep or "
+    "under-scoping; risks and unhandled edge cases; verification that is insufficient or missing. "
+    "Format findings one per line using priorities: [P1] = critical (the plan will fail or produce "
+    "wrong outcomes as written), [P2] = important (will cause rework), [P3] = advisory. If nothing "
+    "material is wrong, say so explicitly."
+)
+
+
+def out(obj: dict) -> None:
+    print(json.dumps(obj))
+
+
+def context(event: str, text: str) -> dict:
+    return {"hookSpecificOutput": {"hookEventName": event, "additionalContext": text[:MAX_OUTPUT]}}
+
+
+def block(reason: str) -> dict:
+    return {"decision": "block", "reason": reason[:MAX_OUTPUT]}
+
+
+def codex_bin() -> str:
+    return (_opt("codex_bin") or os.environ.get("CODEX_BIN") or shutil.which("codex") or "").strip()
+
+
+def sandbox_args() -> list:
+    mode = (_opt("codex_sandbox") or "").strip()
+    return {"workspace-write": ["--sandbox", "workspace-write"],
+            "danger-full-access": ["--sandbox", "danger-full-access"]}.get(mode, ["--full-auto"])
+
+
+# ── Codex ────────────────────────────────────────────────────────────────────
+
+def run_codex(args: list, cwd: str) -> dict:
+    """Run the Codex CLI; return {prose, findings, verdict, exit, duration_seconds, activity}.
+    Parses the JSONL event stream (`--json`); falls back to the raw text of older CLIs."""
+    started = time.time()
+    try:
+        p = subprocess.run([codex_bin(), *args], cwd=cwd, capture_output=True, text=True,
+                           timeout=TIMEOUT)
+        exit_code, stdout, stderr = p.returncode, p.stdout, p.stderr
+    except subprocess.TimeoutExpired:
+        return {"prose": f"(review timed out after {TIMEOUT}s)", "findings": [], "verdict": "TIMEOUT",
+                "exit": 124, "duration_seconds": round(time.time() - started, 1), "activity": False}
+    except Exception as e:
+        return {"prose": f"(could not run codex: {type(e).__name__}: {e})", "findings": [],
+                "verdict": "ERROR", "exit": 1, "duration_seconds": round(time.time() - started, 1),
+                "activity": False}
+    duration = round(time.time() - started, 1)
+    prose, activity, jsonl = "", False, False
+    for line in stdout.splitlines():
+        try:
+            ev = json.loads(line)
+        except Exception:
+            continue
+        if not isinstance(ev, dict) or "type" not in ev:
+            continue
+        jsonl = True
+        item = ev.get("item") if isinstance(ev.get("item"), dict) else {}
+        if ev.get("type") == "item.completed":
+            if item.get("type") == "agent_message" and item.get("text"):
+                prose = str(item["text"])
+            if (item.get("type") == "command_execution" and item.get("exit_code", 1) == 0) or \
+               (item.get("type") == "mcp_tool_call" and item.get("status") == "completed"):
+                activity = True
+    if not jsonl:
+        text = re.sub(r"\x1b\[[0-9;]*m", "", stdout)
+        m = re.search(r"^codex$", text, re.M)
+        prose = text[m.end():].strip() if m else text.strip()
+        activity = True   # the legacy text path cannot tell; do not call it inconclusive
+    if exit_code != 0 and not prose:
+        return {"prose": f"(codex exited {exit_code}; stderr: {stderr.strip()[:1500] or '<empty>'})",
+                "findings": [], "verdict": "ERROR", "exit": exit_code,
+                "duration_seconds": duration, "activity": activity}
+    if not prose:
+        prose = f"(Codex produced no message; stderr: {stderr.strip()[:1500] or '<empty>'})"
+    findings = [{"priority": m.group(1), "title": m.group(2)}
+                for m in (_FINDING_RE.match(l) for l in prose.splitlines()) if m]
+    return {"prose": prose, "findings": findings, "verdict": "", "exit": exit_code,
+            "duration_seconds": duration, "activity": activity}
+
+
+def waive_key(title: str) -> str:
+    return re.sub(r"\s+", " ", re.sub(r"(:|line)\s*\d+", "", title)).strip().lower()
+
+
+def apply_waivers(gitdir: str, findings: list) -> None:
+    try:
+        keys = {l.strip() for l in open(os.path.join(gitdir, WAIVED)) if l.strip() and not l.startswith("#")}
+    except OSError:
+        keys = set()
+    for f in findings:
+        f["waive_key"] = waive_key(f["title"])
+        f["waived"] = f["waive_key"] in keys
+
+
+def counts(findings: list) -> tuple:
+    blocking = sum(1 for f in findings if f["priority"] in ("P1", "P2") and not f.get("waived"))
+    waived = sum(1 for f in findings if f.get("waived"))
+    return len(findings), blocking, waived
+
+
+# ── repo and state ───────────────────────────────────────────────────────────
+
+def repo_root(cwd: str, command: str) -> str:
+    """The repo the commit landed in: honours `git -C <dir>` and a leading `cd <dir>`."""
+    cands = []
+    m = re.search(r"git\s+(?:-C|--git-dir)\s+([\"']?)([^\s\"']+)\1", command)
+    if m:
+        cands.append(os.path.join(cwd, m.group(2)))
+    for seg in re.split(r"\s*(?:&&|\|\||;|\|)\s*", command):
+        m = re.match(r"\s*cd\s+([\"']?)([^\s\"']+)\1", seg)
+        if m:
+            cands.append(os.path.join(cwd, os.path.expanduser(m.group(2))))
+    cands.append(cwd)
+    for c in cands:
+        try:
+            p = subprocess.run(["git", "-C", c, "rev-parse", "--show-toplevel"], capture_output=True,
+                               text=True, timeout=5)
+            if p.returncode == 0 and p.stdout.strip():
+                return p.stdout.strip()
+        except Exception:
+            pass
+    return ""
+
+
+def git(root: str, *args: str) -> str:
+    try:
+        p = subprocess.run(["git", "-C", root, *args], capture_output=True, text=True, timeout=10)
+        return p.stdout.strip() if p.returncode == 0 else ""
+    except Exception:
+        return ""
+
+
+def gitdir(root: str) -> str:
+    d = git(root, "rev-parse", "--git-common-dir")
+    return d if os.path.isabs(d) else os.path.join(root, d)
+
+
+def sfx(session_id: str) -> str:
+    return f".{session_id}" if session_id else ""
+
+
+def read_state(gitdir_: str, session_id: str) -> dict:
+    try:
+        parts = open(os.path.join(gitdir_, STATE + sfx(session_id))).read().split()
+        return {"verdict": parts[0], "sha": parts[1] if len(parts) > 1 else "",
+                "ts": int(parts[2]) if len(parts) > 2 else 0}
+    except Exception:
+        return {}
+
+
+def write_state(gitdir_: str, session_id: str, verdict: str, sha: str) -> None:
+    with open(os.path.join(gitdir_, STATE + sfx(session_id)), "w") as f:
+        f.write(f"{verdict} {sha} {int(time.time())} {session_id}\n")
+
+
+def clear_state(gitdir_: str, session_id: str, rounds: bool = False) -> None:
+    names = [STATE, LOOPS] + ([ROUNDS] if rounds else [])
+    for n in names:
+        try:
+            os.remove(os.path.join(gitdir_, n + sfx(session_id)))
+        except OSError:
+            pass
+
+
+def read_count(path: str) -> tuple:
+    try:
+        parts = open(path).read().split()
+        return int(parts[0]), int(parts[1]) if len(parts) > 1 else 0
+    except Exception:
+        return 0, 0
+
+
+def last_reviewed_sha(gitdir_: str, session_id: str) -> str:
+    sha = ""
+    try:
+        for line in open(os.path.join(gitdir_, HISTORY)):
+            try:
+                e = json.loads(line)
+            except Exception:
+                continue
+            if e.get("session_id") == session_id:
+                sha = e.get("sha", "")
+    except OSError:
+        pass
+    return sha
+
+
+def record(gitdir_: str, entry: dict) -> None:
+    try:
+        with open(os.path.join(gitdir_, HISTORY), "a") as f:
+            f.write(json.dumps(entry) + "\n")
+    except OSError:
+        pass
+
+
+def ship_challenge(cfg: dict, hook: dict, typ: str, challenge: dict) -> None:
+    try:
+        ship_lines(cfg, [synthetic_line(hook, typ, CHALLENGER, challenge=challenge)])
+    except Exception:
+        pass
+
+
+# ── plan review ──────────────────────────────────────────────────────────────
+
+def plan_text(hook: dict) -> tuple:
+    """(plan markdown, its name). ExitPlanMode carries the plan in tool_input on current Claude
+    Code; older builds only write ~/.claude/plans/<name>.md, so fall back to the newest file."""
+    inp = hook.get("tool_input") if isinstance(hook.get("tool_input"), dict) else {}
+    plan = inp.get("plan")
+    if isinstance(plan, str) and plan.strip():
+        return plan, "plan from ExitPlanMode"
+    d = os.path.join(os.environ.get("CLAUDE_CONFIG_DIR") or os.path.expanduser("~/.claude"), "plans")
+    try:
+        files = sorted((os.path.join(d, f) for f in os.listdir(d) if f.endswith(".md")),
+                       key=os.path.getmtime, reverse=True)
+    except OSError:
+        files = []
+    if not files:
+        return "", ""
+    try:
+        return open(files[0]).read(), os.path.basename(files[0])
+    except OSError:
+        return "", ""
+
+
+def review_plan(hook: dict, cfg: dict) -> dict:
+    text, name = plan_text(hook)
+    if not text.strip():
+        return {}
+    cwd = hook.get("cwd") or os.getcwd()
+    with tempfile.NamedTemporaryFile("w", suffix=".md", prefix="tares-plan-", delete=False) as f:
+        f.write(text)
+        path = f.name
+    try:
+        r = run_codex(["exec", *sandbox_args(), "--skip-git-repo-check", "--json",
+                       PLAN_PROMPT.format(path=path)], cwd)
+    finally:
+        try:
+            os.remove(path)
+        except OSError:
+            pass
+    verdict = r["verdict"] or ("FAIL" if any(f["priority"] in ("P1", "P2") for f in r["findings"]) else "PASS")
+    n, blocking, _ = counts(r["findings"])
+    ship_challenge(cfg, hook, "challenge_plan", {
+        "verdict": verdict, "plan": name, "finding_count": n, "blocking_count": blocking,
+        "waived_count": 0, "duration_seconds": r["duration_seconds"], "prose": r["prose"][:4000],
+        "findings": [{"priority": f["priority"], "title": f["title"], "waived": False} for f in r["findings"]]})
+    if verdict in ("TIMEOUT", "ERROR"):
+        return context("PostToolUse", f"Codex could not review the plan ({verdict.lower()}): {r['prose']} "
+                       "You are not blocked; mention it to the user.")
+    head = (f"Codex challenged the plan and found {blocking} blocking finding(s) ({n} total). Revise "
+            "the plan for the P1/P2 items before presenting it, or tell the user why you disagree."
+            if blocking else
+            f"Codex challenged the plan: no blocking findings ({n} advisory). Mention that the plan "
+            "was challenged when you present it.")
+    return context("PostToolUse", head + "\n\n" + r["prose"])
+
+
+# ── commit review ────────────────────────────────────────────────────────────
+
+def is_commit(hook: dict) -> bool:
+    inp = hook.get("tool_input") if isinstance(hook.get("tool_input"), dict) else {}
+    cmd = str(inp.get("command") or "")
+    if not cmd or not _COMMIT_RE.search(cmd):
+        return False
+    resp = hook.get("tool_response")
+    text = resp if isinstance(resp, str) else " ".join(
+        str(resp.get(k) or "") for k in ("stdout", "stderr", "output")) if isinstance(resp, dict) else ""
+    return not re.search(r"^(error|fatal):|nothing to commit", text, re.M)
+
+
+def review_commit(hook: dict, cfg: dict, session_id: str) -> dict:
+    inp = hook.get("tool_input") or {}
+    root = repo_root(hook.get("cwd") or os.getcwd(), str(inp.get("command") or ""))
+    if not root:
+        return {}
+    sha = git(root, "rev-parse", "HEAD")
+    if not sha:
+        return {}
+    gd = gitdir(root)
+    if os.path.exists(os.path.join(gd, SKIP)):
+        return {}
+    if last_reviewed_sha(gd, session_id) == sha:
+        return {}   # this sha was already reviewed (a retried hook)
+    strict = (_opt("challenger_mode") or "strict").strip().lower() != "advise"
+    write_state(gd, session_id, "RUNNING", sha)
+
+    r = run_codex(["exec", *sandbox_args(), "review", "--json", "--commit", sha], root)
+    apply_waivers(gd, r["findings"])
+    n, blocking, waived = counts(r["findings"])
+    verdict = r["verdict"]
+    if not verdict:
+        if not r["findings"] and not r["activity"]:
+            verdict = "INCONCLUSIVE"
+        else:
+            verdict = "FAIL" if blocking else "PASS"
+
+    rounds_path = os.path.join(gd, ROUNDS + sfx(session_id))
+    rnd, last = read_count(rounds_path)
+    if last and time.time() - last > FAIL_MAX_AGE:
+        rnd = 0
+    capped = False
+    if verdict == "FAIL":
+        rnd += 1
+        if rnd >= MAX_ROUNDS:
+            capped = True
+        with open(rounds_path, "w") as f:
+            f.write(f"{rnd} {int(time.time())}\n")
+    elif verdict == "PASS":
+        try:
+            os.remove(rounds_path)
+        except OSError:
+            pass
+        rnd = 0
+
+    short = sha[:8]
+    entry = {"timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()), "sha": sha,
+             "short_sha": short, "branch": git(root, "rev-parse", "--abbrev-ref", "HEAD"),
+             "session_id": session_id, "verdict": verdict, "capped": capped, "round": rnd,
+             "findings": r["findings"], "finding_count": n, "blocking_count": blocking,
+             "waived_count": waived, "review_prose": r["prose"][:2000], "codex_exit": r["exit"],
+             "duration_seconds": r["duration_seconds"]}
+    record(gd, entry)
+    ship_challenge(cfg, hook, "challenge_commit", {
+        "verdict": verdict, "sha": sha, "round": rnd, "finding_count": n, "blocking_count": blocking,
+        "waived_count": waived, "duration_seconds": r["duration_seconds"], "capped": capped,
+        "strict": strict, "prose": r["prose"][:4000],
+        "findings": [{"priority": f["priority"], "title": f["title"], "waived": f.get("waived", False)}
+                     for f in r["findings"]]})
+
+    if verdict == "TIMEOUT":
+        clear_state(gd, session_id)
+        return context("PostToolUse", f"Codex review of commit {short} timed out after {TIMEOUT}s and was "
+                       "skipped. You are not blocked. Mention the timeout to the user.")
+    if verdict == "ERROR":
+        clear_state(gd, session_id)
+        return context("PostToolUse", f"Codex review of commit {short} errored and produced no verdict. "
+                       f"You are not blocked.\n\n{r['prose']}\n\nMention the error to the user; likely a "
+                       "Codex auth or rate-limit issue.")
+    if verdict == "INCONCLUSIVE":
+        clear_state(gd, session_id)
+        return context("PostToolUse", f"Codex review of commit {short} was INCONCLUSIVE: it returned no "
+                       "findings but never inspected the code (its sandbox probably failed to start). "
+                       "This is NOT a clean pass. You are not blocked. Tell the user; they can set the "
+                       "plugin's codex_sandbox option to danger-full-access and amend the commit to "
+                       "re-run the review.\n\nReview output:\n" + r["prose"])
+    if verdict == "FAIL" and capped:
+        clear_state(gd, session_id, rounds=True)
+        return context("PostToolUse", f"Codex review of commit {short} still has findings, but this is "
+                       f"review round {rnd} of a max of {MAX_ROUNDS} since the last pass; the loop is "
+                       "CAPPED and no longer blocking. Treat the findings as ADVISORY: fix what you judge "
+                       "real, note the rest to the user, and proceed.\n\n" + r["prose"])
+    waive_note = f" ({waived} finding(s) waived)" if waived else ""
+    if verdict == "FAIL" and strict:
+        write_state(gd, session_id, "FAIL", sha)
+        pushed = git(root, "branch", "-r", "--contains", sha)
+        fix = ("Fix the issues and fold them into the reviewed commit with `git commit --amend` (it is "
+               "not on any remote)." if not pushed else
+               "Fix the issues in a new commit (the reviewed commit is already on a remote; do not amend).")
+        return block(f"Codex review of commit {short} found issues (fix round {rnd} of max {MAX_ROUNDS})"
+                     f"{waive_note}:\n\n{r['prose']}\n\n{fix} Do NOT re-run the review yourself; it runs "
+                     "on your next commit. Do NOT push until the review passes. If the user disagrees "
+                     "with a finding, they can suppress it with /tares:challenger-waive.")
+    if verdict == "FAIL":
+        clear_state(gd, session_id)
+        return context("PostToolUse", f"Codex review of commit {short} found {blocking} blocking "
+                       f"finding(s){waive_note}. Advise mode: you are not blocked. Fix what you judge "
+                       "real and tell the user the rest.\n\n" + r["prose"])
+    clear_state(gd, session_id)
+    return context("PostToolUse", f"Codex review of commit {short} passed{waive_note}.\n\n{r['prose']}\n\n"
+                   "Ask the user if they want to push.")
+
+
+# ── Stop: the fix loop ───────────────────────────────────────────────────────
+
+def stop_loop(hook: dict, session_id: str) -> dict:
+    root = repo_root(hook.get("cwd") or os.getcwd(), "")
+    if not root:
+        return {}
+    gd = gitdir(root)
+    state = read_state(gd, session_id)
+    if not state:
+        return {}
+    now = int(time.time())
+    if state["verdict"] == "RUNNING":
+        if now - state["ts"] > RUNNING_MAX_AGE:
+            clear_state(gd, session_id)
+        return {}
+    if state["verdict"] != "FAIL":
+        clear_state(gd, session_id)
+        return {}
+    if now - state["ts"] > FAIL_MAX_AGE or state["sha"] != git(root, "rev-parse", "HEAD"):
+        clear_state(gd, session_id)
+        return {}
+    loops_path = os.path.join(gd, LOOPS + sfx(session_id))
+    if hook.get("stop_hook_active") and not os.path.exists(loops_path):
+        clear_state(gd, session_id)
+        return {}
+    n, _ = read_count(loops_path)
+    n += 1
+    with open(loops_path, "w") as f:
+        f.write(f"{n}\n")
+    if n >= MAX_LOOPS:
+        clear_state(gd, session_id)
+        return context("Stop", f"The challenger fix loop reached its max of {MAX_LOOPS} iterations without "
+                       "passing. Stopping. Tell the user what is still open.")
+    return block("The Codex review of your last commit found issues that still need fixing. Fix them and "
+                 "commit (amend the reviewed commit if it is not pushed, otherwise a new commit). Do NOT "
+                 "re-run the review yourself; it runs on your commit. Do not stop until the review passes.")
+
+
+# ── waive (the /tares:challenger-waive command) ──────────────────────────────
+
+def waive(which: str) -> int:
+    root = repo_root(os.getcwd(), "")
+    if not root:
+        print("not in a git repository"); return 1
+    gd = gitdir(root)
+    last = None
+    try:
+        for line in open(os.path.join(gd, HISTORY)):
+            try:
+                e = json.loads(line)
+            except Exception:
+                continue
+            if e.get("verdict") == "FAIL":
+                last = e
+    except OSError:
+        pass
+    if not last:
+        print("no failed review to waive from"); return 1
+    blocking = [f for f in last["findings"] if f["priority"] in ("P1", "P2") and not f.get("waived")]
+    if not blocking:
+        print("the last failed review has no unwaived blocking findings"); return 1
+    if which == "all":
+        chosen = blocking
+    elif which.isdigit() and 1 <= int(which) <= len(blocking):
+        chosen = [blocking[int(which) - 1]]
+    elif not which and len(blocking) == 1:
+        chosen = blocking
+    else:
+        print("which finding? one of:")
+        for i, f in enumerate(blocking, 1):
+            print(f"  {i}. [{f['priority']}] {f['title']}")
+        return 1
+    with open(os.path.join(gd, WAIVED), "a") as f:
+        for c in chosen:
+            f.write(waive_key(c["title"]) + "\n")
+    clear_state(gd, last.get("session_id", ""))
+    cfg = config()
+    hook = {"session_id": last.get("session_id", ""), "cwd": root}
+    ship_challenge(cfg, hook, "challenge_waived", {
+        "sha": last.get("sha"), "finding_count": len(chosen),
+        "findings": [{"priority": c["priority"], "title": c["title"], "waived": True} for c in chosen]})
+    for c in chosen:
+        print(f"waived: [{c['priority']}] {c['title']}")
+    print(f"waivers live in {os.path.join(gd, WAIVED)}; the commit is no longer blocked")
+    return 0
+
+
+# ── main ─────────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    if len(sys.argv) > 1 and sys.argv[1] == "waive":
+        sys.exit(waive(sys.argv[2] if len(sys.argv) > 2 else ""))
+    try:
+        hook = json.load(sys.stdin)
+    except Exception:
+        out({}); return
+    session_id = str(hook.get("session_id") or "")
+    cfg = config()
+    if read_flow(cfg["data_dir"], session_id) != CHALLENGER:
+        out({}); return   # not a challenger session: nothing runs
+    event = hook.get("hook_event_name")
+    try:
+        if event == "Stop":
+            out(stop_loop(hook, session_id)); return
+        if event != "PostToolUse":
+            out({}); return
+        tool = hook.get("tool_name")
+        if tool == "ExitPlanMode":
+            if not codex_bin():
+                out(context("PostToolUse", "The challenger is on for this session but the Codex CLI is not "
+                            "installed (npm install -g @openai/codex && codex login). The plan was not "
+                            "challenged; tell the user."))
+                return
+            out(review_plan(hook, cfg)); return
+        if tool == "Bash" and is_commit(hook):
+            if not codex_bin():
+                out({}); return
+            out(review_commit(hook, cfg, session_id)); return
+        out({})
+    except Exception as e:   # a hook must never take the session down
+        out(context("PostToolUse" if event == "PostToolUse" else "Stop",
+                    f"The challenger hook failed ({type(e).__name__}: {e}); nothing was reviewed."))
+
+
+if __name__ == "__main__":
+    main()

--- a/claude-plugin/scripts/ship.py
+++ b/claude-plugin/scripts/ship.py
@@ -9,15 +9,27 @@ maps each line into the data plane (same mapping as the local file tail).
 The source is created automatically on Tares the first time the plugin runs (and re-created if it's
 missing), so installing the plugin is the only setup step — no need to provision a source by hand.
 
+Session flows (the challenger workflow): when Claude calls the `set_session_flow` MCP tool, that
+call is a tool_use line in the transcript. The shipper is the one component that sees the transcript
+together with the session id, so it is the bridge: it writes a per-session marker file the local
+challenger hooks gate on, stamps `flow` on every line it ships from then on, and writes synthetic
+`session_flow` / `session_end` lines so Tares can tell a challenger session and its end apart.
+Tares is never asked whether a session is marked; the decision travels through the transcript.
+
 Idempotent: the offset only advances after a successful POST. Best-effort: never raises into the
 session. Configured entirely via plugin userConfig env vars.
 """
 import hashlib
 import json
 import os
+import subprocess
 import sys
 import urllib.error
 import urllib.request
+from datetime import datetime, timezone
+
+FLOW_TOOL = "mcp__tares__set_session_flow"
+CHALLENGER = "challenger"
 
 
 def _truthy(v: str) -> bool:
@@ -33,9 +45,14 @@ def _opt(name: str, default: str = "") -> str:
             or default)
 
 
-def _post(url: str, data: bytes, headers: dict):
+def _post(url: str, data: bytes, headers: dict, timeout: float = 5):
     req = urllib.request.Request(url, data=data, headers=headers, method="POST")
-    return urllib.request.urlopen(req, timeout=5)
+    return urllib.request.urlopen(req, timeout=timeout)
+
+
+def _get(url: str, headers: dict, timeout: float = 3):
+    req = urllib.request.Request(url, headers=headers, method="GET")
+    return urllib.request.urlopen(req, timeout=timeout)
 
 
 def _auth_only(headers: dict) -> dict:
@@ -43,6 +60,106 @@ def _auth_only(headers: dict) -> dict:
     if "Authorization" in headers:
         h["Authorization"] = headers["Authorization"]
     return h
+
+
+# ── shared with challenger.py ────────────────────────────────────────────────
+
+def config() -> dict:
+    """Where Tares is, how to talk to it, and where this plugin keeps its state."""
+    base = (_opt("tares_url") or "http://127.0.0.1:8787").rstrip("/")
+    token = (_opt("access_token") or "").strip()
+    headers = {"Content-Type": "application/x-ndjson"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    data_dir = os.environ.get("CLAUDE_PLUGIN_DATA") or os.path.expanduser("~/.tares-plugin")
+    os.makedirs(data_dir, exist_ok=True)
+    return {"base": base, "headers": headers, "data_dir": data_dir}
+
+
+def flow_marker(data_dir: str, session_id: str) -> str:
+    d = os.path.join(data_dir, "sessions")
+    os.makedirs(d, exist_ok=True)
+    return os.path.join(d, hashlib.sha1(str(session_id).encode()).hexdigest()[:16] + ".flow")
+
+
+def read_flow(data_dir: str, session_id: str) -> str:
+    """The flow this session is marked with ("" when unmarked)."""
+    try:
+        return open(flow_marker(data_dir, session_id)).read().strip()
+    except OSError:
+        return ""
+
+
+def write_flow(data_dir: str, session_id: str, flow: str) -> None:
+    path = flow_marker(data_dir, session_id)
+    if flow:
+        with open(path, "w") as f:
+            f.write(flow)
+    else:
+        try:
+            os.remove(path)
+        except OSError:
+            pass
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+
+
+def git_branch(cwd: str) -> str:
+    try:
+        out = subprocess.run(["git", "-C", cwd or ".", "rev-parse", "--abbrev-ref", "HEAD"],
+                             capture_output=True, text=True, timeout=3)
+        return out.stdout.strip() if out.returncode == 0 else ""
+    except Exception:
+        return ""
+
+
+def synthetic_line(hook: dict, typ: str, flow: str, **extra) -> dict:
+    """A transcript-shaped line the shipper (or a challenger hook) writes itself, keyed like the
+    real lines so it lands on the same session timeline."""
+    cwd = hook.get("cwd") or os.getcwd()
+    o = {"type": typ, "sessionId": hook.get("session_id"), "cwd": cwd, "timestamp": now_iso(),
+         "version": "tares-plugin"}
+    branch = git_branch(cwd)
+    if branch:
+        o["gitBranch"] = branch
+    if flow:
+        o["flow"] = flow
+    o.update(extra)
+    return o
+
+
+def ship_lines(cfg: dict, objs: list) -> bool:
+    """POST transcript-shaped objects to the claude_code source. Best effort."""
+    if not objs:
+        return True
+    body = ("\n".join(json.dumps(o, separators=(",", ":")) for o in objs) + "\n").encode()
+    return _ship_body(cfg, body)
+
+
+def _ship_body(cfg: dict, body: bytes) -> bool:
+    base, headers = cfg["base"], cfg["headers"]
+    marker = os.path.join(cfg["data_dir"], "ensured-" + hashlib.sha1(base.encode()).hexdigest()[:12])
+    try:
+        _post(base + "/ingest/claude_code", body, headers)
+        return True
+    except urllib.error.HTTPError as e:
+        if e.code == 404:          # source went missing — recreate and retry once
+            try:
+                os.remove(marker)
+            except OSError:
+                pass
+            if ensure_source(base, headers):
+                open(marker, "w").write("1")
+                try:
+                    _post(base + "/ingest/claude_code", body, headers)
+                    return True
+                except Exception:
+                    return False
+        return False
+    except Exception:
+        return False
 
 
 def ensure_source(base: str, headers: dict) -> bool:
@@ -58,6 +175,77 @@ def ensure_source(base: str, headers: dict) -> bool:
         return False
 
 
+# ── the flow tool call, seen in the transcript ───────────────────────────────
+
+def flow_call(obj: dict):
+    """The flow a `set_session_flow` tool_use line asks for, or None when the line is not one."""
+    msg = obj.get("message") if isinstance(obj.get("message"), dict) else {}
+    content = msg.get("content")
+    if not isinstance(content, list):
+        return None
+    for b in content:
+        if isinstance(b, dict) and b.get("type") == "tool_use" and b.get("name") == FLOW_TOOL:
+            inp = b.get("input") if isinstance(b.get("input"), dict) else {}
+            return str(inp.get("flow", CHALLENGER) or "").strip()
+    return None
+
+
+def process_lines(raw_lines: list, flow: str, hook: dict) -> tuple:
+    """Stamp `flow` on each line of a marked session and react to a set_session_flow call: update
+    the flow, and emit a synthetic session_flow line right after the call so Tares records the
+    change. Returns (objects to ship, the flow after these lines, whether it changed)."""
+    out, changed = [], False
+    for raw in raw_lines:
+        try:
+            o = json.loads(raw)
+        except Exception:
+            continue
+        if not isinstance(o, dict):
+            continue
+        asked = flow_call(o)
+        switched = asked is not None and asked != flow
+        if switched:
+            flow, changed = asked, True
+        if flow:
+            o["flow"] = flow   # the call line itself is the first stamped line
+        out.append(o)
+        if switched:
+            line = synthetic_line(hook, "session_flow", flow)
+            line["flow"] = flow   # kept even when empty: Tares renders it as "cleared"
+            out.append(line)
+    return out, flow, changed
+
+
+# ── SessionStart: hand accepted memory to Claude ─────────────────────────────
+
+def memory_context(cfg: dict, cwd: str) -> str:
+    """Accepted memory for this project (decisions on the memory source keyed by the project
+    name), as a short block Claude sees at session start. Empty on any failure."""
+    project = os.path.basename((cwd or "").rstrip("/")) or ""
+    if not project:
+        return ""
+    try:
+        r = _get(f"{cfg['base']}/api/sources/agent_memory/events?limit=200",
+                 _auth_only(cfg["headers"]))
+        rows = json.loads(r.read().decode() or "[]")
+    except Exception:
+        return ""
+    lines = []
+    for row in rows if isinstance(rows, list) else []:
+        if row.get("key") == project and row.get("event_type") == "decision" and row.get("text"):
+            lines.append(row["text"].strip())
+    if not lines:
+        return ""
+    seen, uniq = set(), []
+    for l in lines:
+        if l not in seen:
+            seen.add(l); uniq.append(l)
+    return ("Memory from earlier Tares sessions on this project (accepted by the user):\n"
+            + "\n".join(f"- {l}" for l in uniq[:20]))
+
+
+# ── main ─────────────────────────────────────────────────────────────────────
+
 def main() -> None:
     try:
         hook = json.load(sys.stdin)
@@ -67,14 +255,8 @@ def main() -> None:
     if not _truthy(_opt("stream_sessions", "true")):
         return
 
-    base = (_opt("tares_url") or "http://127.0.0.1:8787").rstrip("/")
-    token = (_opt("access_token") or "").strip()
-    headers = {"Content-Type": "application/x-ndjson"}
-    if token:
-        headers["Authorization"] = f"Bearer {token}"
-
-    data_dir = os.environ.get("CLAUDE_PLUGIN_DATA") or os.path.expanduser("~/.tares-plugin")
-    os.makedirs(data_dir, exist_ok=True)
+    cfg = config()
+    base, headers, data_dir = cfg["base"], cfg["headers"], cfg["data_dir"]
     marker = os.path.join(data_dir, "ensured-" + hashlib.sha1(base.encode()).hexdigest()[:12])
 
     # ensure the source exists (once per Tares URL; cheap fast-path via a marker file)
@@ -82,62 +264,58 @@ def main() -> None:
         if ensure_source(base, headers):
             open(marker, "w").write("1")
 
-    # SessionStart just provisions the source; there's nothing to ship yet
-    if hook.get("hook_event_name") == "SessionStart":
+    event = hook.get("hook_event_name")
+    session_id = str(hook.get("session_id") or "")
+
+    # SessionStart provisions the source and hands Claude the accepted memory; nothing to ship yet
+    # (the flow marker is left alone here: a resumed session keeps its mark, and SessionEnd
+    # removes it)
+    if event == "SessionStart":
+        ctx = memory_context(cfg, hook.get("cwd") or "")
+        if ctx:
+            print(ctx)
         return
 
     transcript = hook.get("transcript_path")
-    if not transcript or not os.path.isfile(transcript):
-        return
+    flow = read_flow(data_dir, session_id) if session_id else ""
 
-    off_dir = os.path.join(data_dir, "offsets")
-    os.makedirs(off_dir, exist_ok=True)
-    off_file = os.path.join(off_dir, hashlib.sha1(transcript.encode()).hexdigest()[:16] + ".off")
-    try:
-        offset = int(open(off_file).read().strip())
-    except Exception:
-        offset = 0
-
-    size = os.path.getsize(transcript)
-    if offset > size:      # transcript rotated/truncated — start over
-        offset = 0
-    if offset >= size:
-        return
-
-    with open(transcript, "rb") as f:
-        f.seek(offset)
-        chunk = f.read()
-    last_nl = chunk.rfind(b"\n")      # only ship complete lines
-    if last_nl < 0:
-        return
-    body = chunk[: last_nl + 1]
-    new_offset = offset + last_nl + 1
-
-    def ship() -> bool:
+    shipped_ok = True
+    if transcript and os.path.isfile(transcript):
+        off_dir = os.path.join(data_dir, "offsets")
+        os.makedirs(off_dir, exist_ok=True)
+        off_file = os.path.join(off_dir, hashlib.sha1(transcript.encode()).hexdigest()[:16] + ".off")
         try:
-            _post(base + "/ingest/claude_code", body, headers)
-            return True
-        except urllib.error.HTTPError as e:
-            if e.code == 404:          # source went missing — recreate and retry once
-                try:
-                    os.remove(marker)
-                except OSError:
-                    pass
-                if ensure_source(base, headers):
-                    open(marker, "w").write("1")
-                    try:
-                        _post(base + "/ingest/claude_code", body, headers)
-                        return True
-                    except Exception:
-                        return False
-            return False
+            offset = int(open(off_file).read().strip())
         except Exception:
-            return False
+            offset = 0
 
-    if ship():
-        with open(off_file, "w") as f:
-            f.write(str(new_offset))   # advance only on success; failures retry next hook
+        size = os.path.getsize(transcript)
+        if offset > size:      # transcript rotated/truncated — start over
+            offset = 0
+        if offset < size:
+            with open(transcript, "rb") as f:
+                f.seek(offset)
+                chunk = f.read()
+            last_nl = chunk.rfind(b"\n")      # only ship complete lines
+            if last_nl >= 0:
+                raw_lines = chunk[: last_nl + 1].decode("utf-8", "replace").splitlines()
+                new_offset = offset + last_nl + 1
+                objs, flow, changed = process_lines(raw_lines, flow, hook)
+                if changed and session_id:
+                    write_flow(data_dir, session_id, flow)   # the local hooks gate on this
+                shipped_ok = ship_lines(cfg, objs)
+                if shipped_ok:
+                    with open(off_file, "w") as f:
+                        f.write(str(new_offset))   # advance only on success; failures retry next hook
+
+    if event == "SessionEnd" and session_id and flow:
+        # the line the challenger_session_ended trigger watches; the marker goes with the session
+        ship_lines(cfg, [synthetic_line(hook, "session_end", flow)])
+        write_flow(data_dir, session_id, "")
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except Exception:   # a hook must never take the session down
+        pass

--- a/claude-plugin/skills/tares/SKILL.md
+++ b/claude-plugin/skills/tares/SKILL.md
@@ -21,6 +21,14 @@ this service healthy", "what has this customer done recently" — read Tares ins
 This plugin also streams the current Claude Code session into Tares (the `claude_code` source) when
 session streaming is enabled, so prior sessions are queryable as a source.
 
+## Challenger sessions
+
+When the user asks to make this a challenger session (any wording: "challenger session",
+"let Codex challenge this", "/tares:challenger"), call the `set_session_flow` tool with
+`flow="challenger"` and say so in one sentence. Do not run Codex yourself: the plugin's hooks
+challenge the plan when you leave plan mode and every commit you make, and hand you the findings.
+`set_session_flow` with an empty `flow` turns it off.
+
 ## Authoring: sources, labels, and views
 
 Tares's data model has three layers — get them right and correlation just works; guess and it

--- a/tares/builtin_agents.py
+++ b/tares/builtin_agents.py
@@ -175,6 +175,12 @@ class AgentRunner:
         self.store = store
         self.runtime = runtime
         self._tasks: set[asyncio.Task] = set()
+        # The daemon's loop, so run_now() also works from a worker thread (a use case action runs
+        # in one); None when constructed outside a loop (tests building a runner by hand).
+        try:
+            self._event_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            self._event_loop = None
         # (agent, key) currently running. Dispatch is at-least-once, so a retried delivery would
         # otherwise run the same investigation twice and pay for it twice.
         self._inflight: set[tuple[str, str]] = set()
@@ -227,10 +233,23 @@ class AgentRunner:
             finally:
                 self._inflight.discard(marker)
 
-        task = asyncio.create_task(go())
-        self._tasks.add(task)
-        task.add_done_callback(self._tasks.discard)
+        self._spawn(go)
         return run_id
+
+    def _spawn(self, coro_fn) -> None:
+        """Start `coro_fn()` as a task on the daemon's loop, from that loop or from a thread."""
+        def start():
+            task = asyncio.create_task(coro_fn())
+            self._tasks.add(task)
+            task.add_done_callback(self._tasks.discard)
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            if self._event_loop is None:
+                raise RuntimeError("no event loop to run the agent on")
+            self._event_loop.call_soon_threadsafe(start)
+            return
+        start()
 
     def bootstrap(self, agent_name: str, trigger_name: str, view_name: str, keys: list[str],
                   window: str = "7d", limit: int = 20, delay_s: float = 90.0,

--- a/tares/connectors/claude_code.py
+++ b/tares/connectors/claude_code.py
@@ -76,7 +76,17 @@ class ClaudeCodeConnector(Connector):
         {"name": "sidechain", "help": "sub-agent (sidechain) message"},
         {"name": "flow", "help": "session flow set from inside Claude Code (e.g. challenger); "
                                  "the plugin stamps it on every line of a marked session"},
+        {"name": "verdict", "help": "challenge events: PASS / FAIL / ERROR / TIMEOUT / INCONCLUSIVE"},
+        {"name": "sha", "help": "challenge_commit: the reviewed commit"},
+        {"name": "finding_count", "help": "challenge events: findings reported (number)"},
+        {"name": "blocking_count", "help": "challenge events: unwaived P1/P2 findings (number)"},
+        {"name": "round", "help": "challenge_commit: fix round since the last pass (number)"},
+        {"name": "duration_seconds", "help": "challenge events: how long the challenger ran (number)"},
     ]
+    # Lines the plugin's challenger hooks write next to the transcript. Each carries a
+    # `challenge` object: {verdict, sha?, plan?, findings: [{priority, title, waived}],
+    # finding_count, blocking_count, waived_count, round?, duration_seconds, prose}.
+    CHALLENGE_TYPES = ("challenge_plan", "challenge_commit", "challenge_waived")
     # Push-only: the Claude Code plugin POSTs transcript lines to /ingest/claude_code; events are
     # mapped by map_payload(). There is no local file tail.
     ACCEPTS_PUSH = True
@@ -127,6 +137,8 @@ class ClaudeCodeConnector(Connector):
         msg = o.get("message") if isinstance(o.get("message"), dict) else {}
         labels = {k: v for k, v in self.label_context(o).items() if v not in (None, "")}
         labels.setdefault("type", "event")
+        if o.get("type") in self.CHALLENGE_TYPES:
+            labels.update(self._challenge_labels(o))
 
         text = self._render_text(o, msg, include_thinking)[:500]
         if redact:
@@ -145,6 +157,20 @@ class ClaudeCodeConnector(Connector):
             labels=labels,
         )
         return env
+
+    @staticmethod
+    def _challenge_labels(o: dict) -> dict:
+        ch = o.get("challenge") if isinstance(o.get("challenge"), dict) else {}
+        out = {}
+        if ch.get("verdict"):
+            out["verdict"] = str(ch["verdict"]).upper()
+        if ch.get("sha"):
+            out["sha"] = str(ch["sha"])[:12]
+        for k in ("finding_count", "blocking_count", "round", "duration_seconds"):
+            v = ch.get(k)
+            if isinstance(v, (int, float)) and not isinstance(v, bool):
+                out[k] = v
+        return out
 
     @staticmethod
     def _ts(o: dict) -> datetime:
@@ -170,12 +196,32 @@ class ClaudeCodeConnector(Connector):
 
 
     @staticmethod
+    def _render_challenge(o: dict) -> str:
+        ch = o.get("challenge") if isinstance(o.get("challenge"), dict) else {}
+        typ = o.get("type")
+        verdict = str(ch.get("verdict") or "?").upper()
+        n, b = ch.get("finding_count", 0), ch.get("blocking_count", 0)
+        findings = ", ".join(f"[{f.get('priority')}] {f.get('title')}"
+                             for f in (ch.get("findings") or [])[:3] if isinstance(f, dict))
+        tail = f": {findings}" if findings else ""
+        if typ == "challenge_plan":
+            what = f"Challenger reviewed the plan {ch.get('plan') or ''}".rstrip()
+        elif typ == "challenge_commit":
+            rnd = f", round {ch['round']}" if ch.get("round") else ""
+            what = f"Challenger reviewed commit {str(ch.get('sha') or '')[:8]}{rnd}"
+        else:
+            return f"Challenger finding waived{tail}"
+        return f"{what}: {verdict}, {n} findings ({b} blocking){tail}"
+
+    @staticmethod
     def _render_text(o: dict, msg: dict, include_thinking: bool) -> str:
         if o.get("type") == "summary" and o.get("summary"):
             return str(o["summary"])
         if o.get("type") == "session_flow":
             # written by the plugin when Claude calls set_session_flow; `flow` empty = cleared
             return f"session flow: {o.get('flow') or 'cleared'}"
+        if o.get("type") in ClaudeCodeConnector.CHALLENGE_TYPES:
+            return ClaudeCodeConnector._render_challenge(o)
         content = msg.get("content")
         if isinstance(content, str):
             return content

--- a/tares/connectors/claude_code.py
+++ b/tares/connectors/claude_code.py
@@ -74,6 +74,8 @@ class ClaudeCodeConnector(Connector):
         {"name": "model", "help": "model on assistant turns"},
         {"name": "type", "help": "message type (user / assistant / tool_use / …)"},
         {"name": "sidechain", "help": "sub-agent (sidechain) message"},
+        {"name": "flow", "help": "session flow set from inside Claude Code (e.g. challenger); "
+                                 "the plugin stamps it on every line of a marked session"},
     ]
     # Push-only: the Claude Code plugin POSTs transcript lines to /ingest/claude_code; events are
     # mapped by map_payload(). There is no local file tail.
@@ -113,7 +115,8 @@ class ClaudeCodeConnector(Connector):
                 "branch": str(o["gitBranch"]) if o.get("gitBranch") else None,
                 "model": str(msg["model"]) if msg.get("model") else None,
                 "type": str(o.get("type")) if o.get("type") else None,
-                "sidechain": "true" if o.get("isSidechain") else "false"}
+                "sidechain": "true" if o.get("isSidechain") else "false",
+                "flow": str(o["flow"]) if o.get("flow") else None}
 
     # ── mapping: one JSONL object → one Envelope ───────────────────────────────
     def _obj_to_envelope(self, o: dict, redact: bool, include_thinking: bool):
@@ -170,6 +173,9 @@ class ClaudeCodeConnector(Connector):
     def _render_text(o: dict, msg: dict, include_thinking: bool) -> str:
         if o.get("type") == "summary" and o.get("summary"):
             return str(o["summary"])
+        if o.get("type") == "session_flow":
+            # written by the plugin when Claude calls set_session_flow; `flow` empty = cleared
+            return f"session flow: {o.get('flow') or 'cleared'}"
         content = msg.get("content")
         if isinstance(content, str):
             return content

--- a/tares/mcp_server.py
+++ b/tares/mcp_server.py
@@ -185,6 +185,19 @@ async def remember(key: str, content: str, memory_type: str = "observation") -> 
     return r.text
 
 
+@mcp.tool()
+async def set_session_flow(flow: str = "challenger") -> str:
+    """Mark this Claude Code session as running a named flow, e.g. "challenger" (a second model
+    challenges your plan and every commit; Tares keeps the whole exchange and writes the session
+    summary). Pass an empty string to clear it. Call it when the user asks for the flow at the
+    start of a session. This tool only acknowledges: the Tares plugin sees the call in the
+    transcript and marks the session on both the laptop and Tares."""
+    flow = (flow or "").strip()
+    if flow:
+        return f"noted: the Tares plugin will mark this session as a {flow} session"
+    return "noted: the Tares plugin will clear this session's flow"
+
+
 # ── setup surface: an agent can wire up its own data sources ─────────────────
 
 @mcp.tool()

--- a/tares/usecases/__init__.py
+++ b/tares/usecases/__init__.py
@@ -11,6 +11,7 @@ from .engine import Engine
 from .registry import get_recipe, list_recipes, register
 from . import shared_code_context as _shared_code_context  # noqa: F401  (registers itself)
 from . import ai_sre_demo as _ai_sre_demo  # noqa: F401  (registers itself)
+from . import challenger_workflow as _challenger_workflow  # noqa: F401  (registers itself)
 
 __all__ = ["Engine", "PlannedObject", "Recipe", "UsecaseError",
            "get_recipe", "list_recipes", "register"]

--- a/tares/usecases/challenger_workflow.py
+++ b/tares/usecases/challenger_workflow.py
@@ -1,0 +1,226 @@
+"""Use case: challenger workflow.
+
+A user works in Claude Code on their laptop and marks a session as a challenger session (Claude
+calls the `set_session_flow` MCP tool). From then on a second model, the Codex CLI running on the
+laptop, challenges Claude's plan and every commit; the Tares plugin ships the whole exchange into
+the `claude_code` source on one session timeline. Tares is the record and the after-session
+brain, never the control point: nothing here decides whether Codex runs.
+
+This recipe owns the Tares side: the `claude_code` source (adopted from the plugin, which creates
+it on first run), a view per session, a trigger that fires when a challenger session ends, and a
+Tares agent that reads the session and writes one finding: the session summary and up to five
+memory proposals. Proposals live inside the finding; nothing is written to memory until a person
+accepts one from the console, so only accepted memory ever exists.
+"""
+from __future__ import annotations
+
+import re
+
+from .base import PlannedObject, Recipe, UsecaseError
+from .registry import register
+
+FLOW = "challenger"
+SOURCE = "claude_code"           # the plugin's own name for the source, adopted as is
+VIEW = "challenger_session"
+ENDS_VIEW = "challenger_session_ends"
+TRIGGER = "challenger_session_ended"
+AGENT = "challenger_summarizer"
+PROPOSALS_HEADING = "Memory proposals"
+MAX_PROPOSALS = 5
+
+PROMPT = """You are handed the end of one Claude Code session that ran as a challenger session: the user \
+worked with Claude, and Codex (a second model on the user's laptop) challenged Claude's plan and \
+every commit. Your key is the session id. Before writing anything, call `read` with \
+{{"session": "<the key>"}} and window "24h" once to get the whole session: user prompts, Claude's \
+turns, tool calls, the plan, each Codex challenge (challenge_plan / challenge_commit events with a \
+verdict and findings), fix rounds, waived findings, commits, and token usage.
+
+Write the session summary in plain sentences, no em dashes, under these headings:
+
+Summary
+What the user asked for and what was built (name the commits). Whether the goal was reached.
+
+Plan
+What the plan was, what Codex found in it, and how the plan changed as a result.
+
+Challenges
+For each reviewed commit: the verdict, what Codex caught, how Claude resolved it, how many rounds \
+it took. Findings the user waived and the reason if the session shows one.
+
+Cost
+Tokens and cost if the timeline carries them, otherwise say they were not recorded.
+
+{heading}
+Up to {max_proposals} durable facts about this repository or this user's way of working that would save \
+time in the next session. One per line, starting with "- ". Only facts the session supports, none \
+about this session's specifics. Skip the heading if there are none.
+
+Do not speculate beyond the evidence. The summary is your final message and nothing else.
+""".format(heading=PROPOSALS_HEADING, max_proposals=MAX_PROPOSALS)
+
+
+class ChallengerWorkflow(Recipe):
+    key = "challenger_workflow"
+    title = "Challenger workflow"
+    description = ("Let a second model challenge Claude Code's plan and every commit on your laptop, "
+                   "keep the whole exchange on one session timeline, and get a session summary "
+                   "with memory proposals when the session ends.")
+    tags = ()
+    guide = {"label": "Challenger workflow guide",
+             "url": "https://docs.glassflow.ai/tares/guides/challenger-workflow"}
+
+    PARAMS = {
+        "slack_channel": {"type": "string", "default": "", "label": "Slack channel",
+                          "help": "post each session summary to this channel id (needs the Slack "
+                                  "surface set up); empty = console only"},
+        "model": {"type": "string", "default": "", "label": "Model",
+                  "help": "model for the summarizer (empty = the instance default)"},
+    }
+
+    SETUP = [
+        {"title": "Install the Tares plugin in Claude Code",
+         "text": "The plugin streams every session into Tares and registers the tares MCP server. "
+                 "One install, then /reload-plugins.",
+         "command": "/plugin marketplace add glassflow/tares\n/plugin install tares@tares"},
+        {"title": "Install the challenger",
+         "text": "Codex runs on your laptop and is billed to your OpenAI account; Tares never calls it.",
+         "command": "npm install -g @openai/codex\ncodex login"},
+        {"title": "Give the summarizer a key", "check": "anthropic_key",
+         "text": "The summarizer is a real agent: it needs an Anthropic key. Set one here or under "
+                 "Settings > Anthropic."},
+        {"title": "Start a challenger session",
+         "text": "In any Claude Code session say \"make this a challenger session\" or type "
+                 "/tares:challenger. Claude marks the session; the plan and every commit get "
+                 "challenged from then on, and the summary lands here when the session ends."},
+    ]
+
+    ACTIONS = [
+        {"name": "summarize", "label": "Summarize a session now",
+         "help": "run the summarizer on one session without waiting for it to end (the session id "
+                 "is the key on the claude_code timeline)",
+         "params": {"session": {"label": "session id", "type": "string"}}},
+    ]
+
+    def _facts(self) -> dict:
+        return {"you": ["install the Tares plugin and Codex on your laptop",
+                        "say \"make this a challenger session\" at the start of a session",
+                        "accept or reject the memory proposals after each session"],
+                "tares": ["the full Claude and Codex exchange on one timeline per session",
+                          "a trigger that fires when a challenger session ends",
+                          "an agent that writes the session summary and memory proposals",
+                          "accepted memory handed to Claude at the next session start"]}
+
+    def describe(self) -> dict:
+        d = super().describe()
+        d["facts"] = self._facts()
+        return d
+
+    # ── params ───────────────────────────────────────────────────────────────
+    def validate(self, params: dict) -> dict:
+        p = super().validate(params)
+        ch = str(p.get("slack_channel") or "").strip()
+        if ch and not re.fullmatch(r"[A-Z][A-Z0-9]{6,}", ch):
+            raise UsecaseError("slack_channel must be a Slack channel id like C0123456789")
+        p["slack_channel"] = ch
+        p["model"] = str(p.get("model") or "").strip()
+        return p
+
+    # ── plan ─────────────────────────────────────────────────────────────────
+    def plan(self, params: dict) -> list[PlannedObject]:
+        objs = [
+            # the same source the plugin creates on its first run (push is the connector's
+            # default, so the stored config is empty either way): an existing one is adopted
+            # unchanged rather than reconfigured
+            PlannedObject("source", "source", {
+                "name": SOURCE, "connector": "claude_code", "poll": "10s", "config": {}}),
+            # the session timeline people and the agent read. The summarizer's finding lands on
+            # the same session key and joins it through `read` (the findings source is internal,
+            # provisioned by the daemon on the first finding, so a view must not name it).
+            PlannedObject("view", "view", {
+                "name": VIEW, "key_field": "session", "sources": [SOURCE]}),
+            # the detection view: only the end-of-session line of a challenger session. The
+            # plugin stamps `flow` on every line of a marked session and writes a session_end
+            # line when the session closes.
+            PlannedObject("view", "ends", {
+                "name": ENDS_VIEW, "key_field": "session", "sources": [SOURCE],
+                "filters": [{"field": "event_type", "op": "eq", "value": "session_end"},
+                            {"field": "flow", "op": "eq", "value": FLOW}]}),
+            PlannedObject("trigger", "trigger", {
+                "name": TRIGGER, "view": ENDS_VIEW,
+                "condition": {"aggregate": "count", "predicate": "> 0", "window": "5m",
+                              "group_by": ["key_value"]},
+                "emit": {"kind": "session_ended", "attach_view": True, "context_window": "24h"},
+                "cooldown": "30m"}),
+        ]
+        agent = {"name": AGENT, "trigger": TRIGGER, "prompt": PROMPT, "enabled": True,
+                 "max_rounds": 6}
+        if params.get("model"):
+            agent["model"] = params["model"]
+        if params.get("slack_channel"):
+            agent["slack_channel"] = params["slack_channel"]
+        objs.append(PlannedObject("agent", "agent", agent))
+        return objs
+
+    # ── actions ──────────────────────────────────────────────────────────────
+    def run_action(self, instance: dict, action: str, args: dict, store, runtime) -> dict:
+        if action != "summarize":
+            raise UsecaseError(f"{self.key}: no action {action!r}")
+        session = str(args.get("session") or "").strip()
+        if not session:
+            raise UsecaseError("session id is required")
+        agents = getattr(getattr(runtime, "dispatcher", None), "agents", None)
+        if agents is None or not hasattr(agents, "run_now"):
+            raise UsecaseError("the agent runner is not available")
+        run_id = agents.run_now(AGENT, TRIGGER, session, f"summarize session {session} on request")
+        return {"session": session, "run_id": run_id,
+                "message": f"summarizer started on session {session}; its finding appears under Runs"}
+
+    # ── summary (the use case page) ──────────────────────────────────────────
+    def summary(self, instance: dict, store) -> dict:
+        params = self.validate(instance["params"])
+        stats = {x["source"]: x for x in store.event_stats()}
+        st = stats.get(SOURCE) or {}
+        runs = []
+        for r in store.list_agent_runs(AGENT, limit=20):
+            finding = r.get("finding") or ""
+            runs.append({"id": r.get("id"), "started_at": _iso(r.get("started_at")),
+                         "key": r.get("key"), "session": r.get("key"), "agent": AGENT,
+                         "status": r.get("status"), "rounds": r.get("rounds"),
+                         "max_rounds": r.get("max_rounds"), "finding": finding,
+                         "proposals": parse_proposals(finding), "error": r.get("error")})
+        return {"source": SOURCE, "events": int(st.get("events") or 0),
+                "last_event": _iso(st.get("last_ingest")),
+                "slack_channel": params["slack_channel"], "runs": runs, "runs_total": len(runs),
+                "sessions_summarized": len({r["session"] for r in runs if r["status"] == "ok"}),
+                "names": {"view": VIEW, "ends_view": ENDS_VIEW, "trigger": TRIGGER, "agent": AGENT},
+                "guide": self.guide["url"]}
+
+
+_HEADING_RE = re.compile(rf"^\s*#*\s*{PROPOSALS_HEADING}\s*:?\s*$", re.IGNORECASE | re.MULTILINE)
+
+
+def parse_proposals(finding: str) -> list[str]:
+    """The memory proposals section of a summarizer finding: the "- " lines after the heading, up
+    to the next heading or the end. Empty when the agent skipped the section."""
+    m = _HEADING_RE.search(finding or "")
+    if not m:
+        return []
+    out = []
+    for line in finding[m.end():].splitlines():
+        s = line.strip()
+        if not s:
+            continue
+        if s.startswith(("- ", "* ")):
+            out.append(s[2:].strip())
+        elif out or not s.startswith(("-", "*")):
+            break   # a new heading or prose ends the list
+    return out[:MAX_PROPOSALS]
+
+
+def _iso(v):
+    if v is None:
+        return None
+    return v.isoformat() if hasattr(v, "isoformat") else str(v)
+
+
+register(ChallengerWorkflow())

--- a/tests/test_challenger_workflow.py
+++ b/tests/test_challenger_workflow.py
@@ -1,0 +1,174 @@
+"""The challenger workflow as a use case (TR-197): recipe shape, adopting the plugin-created
+claude_code source, the session_ended trigger firing on a marked session's end line, memory
+proposal parsing, the summarize action. No laptop, no Codex, no Anthropic key needed.
+Run: .venv/bin/python tests/test_challenger_workflow.py
+"""
+import asyncio
+import json
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+DB = "/tmp/tares-challenger-test.duckdb"
+CATALOG = "/tmp/tares-challenger-test.catalog.yaml"
+os.environ["TARES_DB"] = DB
+os.environ["TARES_CATALOG"] = CATALOG
+os.environ.pop("ANTHROPIC_API_KEY", None)
+
+import httpx
+
+PASS = FAIL = 0
+
+
+def check(label, cond, detail=""):
+    global PASS, FAIL
+    if cond:
+        PASS += 1; print(f"  ok   {label}")
+    else:
+        FAIL += 1; print(f"  FAIL {label}  {detail}")
+
+
+def ts(minutes_ago: float) -> str:
+    return (datetime.now(timezone.utc) - timedelta(minutes=minutes_ago)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def line(sid, typ, ts, **extra):
+    o = {"sessionId": sid, "type": typ, "cwd": "/home/me/shop", "gitBranch": "pricing",
+         "timestamp": ts, "flow": "challenger", **extra}
+    return json.dumps(o)
+
+
+async def main():
+    for p in (DB, DB + ".wal", CATALOG):
+        if os.path.exists(p):
+            os.remove(p)
+
+    from tares.usecases import get_recipe
+    from tares.usecases.base import UsecaseError
+    from tares.usecases.challenger_workflow import (AGENT, ENDS_VIEW, PROMPT, SOURCE, TRIGGER,
+                                                    VIEW, parse_proposals)
+    r = get_recipe("challenger_workflow")
+
+    print("== recipe ==")
+    d = r.describe()
+    check("not a demo", d["tags"] == [])
+    check("setup and the summarize action advertised",
+          len(d["setup"]) == 4 and [a["name"] for a in d["actions"]] == ["summarize"])
+    check("facts for the card", "you" in d["facts"] and "tares" in d["facts"])
+    check("prompt fits the agent limit and has no em dash", len(PROMPT) < 8000 and "—" not in PROMPT)
+    check("no em dash in any rendered string", "—" not in json.dumps(d))
+    p = r.validate({})
+    check("defaults", p == {"slack_channel": "", "model": ""}, json.dumps(p))
+    try:
+        r.validate({"slack_channel": "general"}); check("bad slack channel rejected", False)
+    except UsecaseError:
+        check("bad slack channel rejected", True)
+    plan = r.plan(r.validate({"slack_channel": "C0123456789", "model": "claude-sonnet-4-6"}))
+    names = [(o.kind, o.name) for o in plan]
+    check("five objects", names == [("source", SOURCE), ("view", VIEW), ("view", ENDS_VIEW),
+                                    ("trigger", TRIGGER), ("agent", AGENT)], str(names))
+    ends = plan[2].spec
+    check("detection view filters on session_end and the challenger flow",
+          {(f["field"], f["value"]) for f in ends["filters"]} == {("event_type", "session_end"), ("flow", "challenger")})
+    agent = plan[4].spec
+    check("agent on the trigger with slack and model applied",
+          agent["trigger"] == TRIGGER and agent["slack_channel"] == "C0123456789"
+          and agent["model"] == "claude-sonnet-4-6")
+    plain = {o.kind: o.spec for o in r.plan(r.validate({}))}
+    check("no slack/model keys when unset", "slack_channel" not in plain["agent"] and "model" not in plain["agent"])
+
+    print("== proposals ==")
+    finding = ("Summary\nBuilt the pricing page.\n\nMemory proposals\n- The shop repo runs tests with "
+               "`make test`, not pytest.\n- Codex flags missing aria labels; add them up front.\n\n"
+               "Cost\n12k tokens.")
+    check("parses the list under the heading",
+          parse_proposals(finding) == ["The shop repo runs tests with `make test`, not pytest.",
+                                       "Codex flags missing aria labels; add them up front."],
+          str(parse_proposals(finding)))
+    check("markdown heading and * bullets work",
+          parse_proposals("## Memory proposals:\n* a\n* b\nNext heading\n- c") == ["a", "b"])
+    check("no section, no proposals", parse_proposals("Summary\nnothing") == [])
+    check("caps at five", len(parse_proposals("Memory proposals\n" + "\n".join(f"- {i}" for i in range(9)))) == 5)
+
+    from tares.daemon import make_app
+    app = make_app()
+    async with app.router.lifespan_context(app):
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as cx:
+            print("== adopt the plugin's source ==")
+            # exactly what ship.py does on its first run
+            rr = await cx.post("/api/sources", json={"name": SOURCE, "connector": "claude_code",
+                                                     "poll": "10s", "config": {"push": True}})
+            check("plugin-style source created", rr.status_code in (200, 201), rr.text[:200])
+            rr = await cx.post("/api/usecases", json={"recipe": "challenger_workflow",
+                                                     "name": "Challenger workflow", "params": {}})
+            check("create -> 201", rr.status_code == 201, rr.text[:300])
+            uid = rr.json()["id"]
+            srcs = {s["name"]: s for s in (await cx.get("/api/sources")).json()}
+            check("one claude_code source, owned by the use case",
+                  sum(1 for n in srcs if n == SOURCE) == 1 and srcs[SOURCE]["owned_by"] == uid,
+                  json.dumps(srcs.get(SOURCE))[:200])
+            agents = (await cx.get("/api/agents/builtin")).json()["agents"]
+            a = next(x for x in agents if x["name"] == AGENT)
+            check("agent owned and subscribed to the trigger", a["owned_by"] == uid and a["trigger"] == TRIGGER)
+
+            print("== a marked session ends ==")
+            body = "\n".join([
+                line("s1", "user", ts(30),
+                     message={"role": "user", "content": "build a pricing page"}),
+                line("s1", "session_flow", ts(29)),
+                line("s1", "challenge_commit", ts(10),
+                     challenge={"verdict": "PASS", "sha": "abc1234", "finding_count": 0,
+                                "blocking_count": 0, "duration_seconds": 30, "findings": []}),
+                line("s1", "session_end", ts(1)),
+            ]) + "\n"
+            rr = await cx.post(f"/ingest/{SOURCE}", content=body,
+                               headers={"content-type": "application/x-ndjson"})
+            check("session lines ingested", rr.status_code == 202 and rr.json()["ingested"] == 4, rr.text[:200])
+            # an unmarked session that ends must not fire
+            rr = await cx.post(f"/ingest/{SOURCE}", content=json.dumps(
+                {"sessionId": "s2", "type": "session_end", "cwd": "/x", "timestamp": ts(1)}) + "\n",
+                headers={"content-type": "application/x-ndjson"})
+            check("unmarked session end ingested", rr.status_code == 202)
+
+            rr = await cx.post("/query", json={"view": ENDS_VIEW, "key": "s1", "window": "24h"})
+            check("detection view shows only the end line of s1",
+                  rr.status_code == 200 and rr.text.count("session_end") >= 1 and "pricing page" not in rr.text, rr.text[:300])
+            rr = await cx.post("/query", json={"view": VIEW, "key": "s1", "window": "24h"})
+            check("session view has the transcript and the challenge",
+                  "pricing page" in rr.text and "Challenger reviewed commit abc1234" in rr.text, rr.text[:400])
+
+            from tares.triggers import eval_triggers
+            st = app.state
+            await eval_triggers(st.store, st.runtime.catalog, st.runtime.dispatcher, None)
+            await asyncio.sleep(0.5)
+            check("trigger fired for the marked session", st.store.last_fired(TRIGGER, "s1") is not None)
+            check("trigger did not fire for the unmarked session", st.store.last_fired(TRIGGER, "s2") is None)
+
+            print("== summary and action ==")
+            s = (await cx.get(f"/api/usecases/{uid}/summary")).json()
+            check("summary counts events and names the objects",
+                  s["events"] == 5 and s["names"]["agent"] == AGENT and "runs" in s, json.dumps(s)[:300])
+            rr = await cx.post(f"/api/usecases/{uid}/actions/summarize", json={})
+            check("summarize without a session -> 400", rr.status_code == 400, rr.text[:200])
+            rr = await cx.post(f"/api/usecases/{uid}/actions/summarize", json={"session": "s1"})
+            check("summarize s1 starts a run from the action thread",
+                  rr.status_code == 200 and rr.json().get("run_id", "").startswith("run_"), rr.text[:200])
+            await asyncio.sleep(0.5)
+            runs = (await cx.get(f"/api/usecases/{uid}/summary")).json()["runs"]
+            check("the run is recorded on the use case page (no key, so it did not conclude)",
+                  any(r["session"] == "s1" for r in runs), json.dumps(runs)[:300])
+
+            print("== delete ==")
+            rr = await cx.delete(f"/api/usecases/{uid}")
+            check("delete -> 200", rr.status_code == 200, rr.text[:200])
+            names = {v["name"] for v in (await cx.get("/api/views")).json()}
+            check("views gone", not ({VIEW, ENDS_VIEW} & names), str(names))
+
+    print(f"\n{PASS} passed, {FAIL} failed")
+    sys.exit(1 if FAIL else 0)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_plugin_challenger.py
+++ b/tests/test_plugin_challenger.py
@@ -1,0 +1,282 @@
+"""The plugin side of the challenger workflow (TR-198, TR-199, TR-200): the shipper marks a
+session when it sees the set_session_flow call, stamps flow on every line and writes the
+session_flow / session_end lines; the challenger hooks review plans and commits with a fake Codex,
+block and loop like codex-review, ship challenge events to a fake Tares, and stay inert for an
+unmarked session; SessionStart hands accepted memory to Claude.
+Run: .venv/bin/python tests/test_plugin_challenger.py   (no Codex, no daemon, no network)
+"""
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SHIP = os.path.join(ROOT, "claude-plugin", "scripts", "ship.py")
+CHAL = os.path.join(ROOT, "claude-plugin", "scripts", "challenger.py")
+
+PASS = FAIL = 0
+
+
+def check(label, cond, detail=""):
+    global PASS, FAIL
+    if cond:
+        PASS += 1; print(f"  ok   {label}")
+    else:
+        FAIL += 1; print(f"  FAIL {label}  {detail}")
+
+
+# ── a fake Tares: records what lands on /ingest/claude_code, serves memory ───
+INGESTED = []
+MEMORY = [{"key": "shop", "event_type": "decision", "text": "The shop repo runs tests with make test."},
+          {"key": "other", "event_type": "decision", "text": "not this project"},
+          {"key": "shop", "event_type": "observation", "text": "not accepted memory"}]
+
+
+class FakeTares(BaseHTTPRequestHandler):
+    def log_message(self, *a):
+        pass
+
+    def do_GET(self):
+        if self.path.startswith("/api/sources/agent_memory/events"):
+            body = json.dumps(MEMORY).encode()
+            self.send_response(200); self.send_header("content-type", "application/json")
+            self.end_headers(); self.wfile.write(body)
+        else:
+            self.send_response(404); self.end_headers()
+
+    def do_POST(self):
+        n = int(self.headers.get("content-length") or 0)
+        raw = self.rfile.read(n).decode()
+        if self.path == "/api/sources":
+            self.send_response(409); self.end_headers(); return
+        if self.path == "/ingest/claude_code":
+            for line in raw.splitlines():
+                if line.strip():
+                    INGESTED.append(json.loads(line))
+            self.send_response(202); self.end_headers(); self.wfile.write(b'{"ingested":1}')
+            return
+        self.send_response(404); self.end_headers()
+
+
+FAKE_CODEX = r'''#!/usr/bin/env python3
+import json, os, sys
+mode = open(os.environ["FAKE_CODEX_MODE"]).read().strip()
+open(os.environ["FAKE_CODEX_LOG"], "a").write(json.dumps(sys.argv[1:]) + "\n")
+def emit(o): print(json.dumps(o))
+if mode == "fail":
+    emit({"type": "item.completed", "item": {"type": "command_execution", "exit_code": 0}})
+    emit({"type": "item.completed", "item": {"type": "agent_message",
+          "text": "Reviewed.\n- [P1] Null deref in pricing at line 12\n- [P3] Naming nit"}})
+elif mode == "pass":
+    emit({"type": "item.completed", "item": {"type": "command_execution", "exit_code": 0}})
+    emit({"type": "item.completed", "item": {"type": "agent_message", "text": "Looks good, no findings."}})
+elif mode == "inconclusive":
+    emit({"type": "item.completed", "item": {"type": "agent_message", "text": "ok"}})
+elif mode == "error":
+    sys.stderr.write("auth failure\n"); sys.exit(2)
+'''
+
+
+def run(script, hook, env, args=()):
+    p = subprocess.run([sys.executable, script, *args], input=json.dumps(hook), capture_output=True,
+                       text=True, env=env, timeout=60)
+    try:
+        out = json.loads(p.stdout.strip() or "{}") if p.stdout.strip().startswith("{") else p.stdout
+    except Exception:
+        out = p.stdout
+    return out, p
+
+
+def main():
+    srv = HTTPServer(("127.0.0.1", 0), FakeTares)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    base = f"http://127.0.0.1:{srv.server_port}"
+
+    tmp = tempfile.mkdtemp(prefix="tares-plugin-test-")
+    data_dir = os.path.join(tmp, "plugin-data")
+    repo = os.path.join(tmp, "shop")
+    os.makedirs(repo)
+    subprocess.run(["git", "init", "-q", "-b", "main", repo], check=True)
+    subprocess.run(["git", "-C", repo, "config", "user.email", "t@t"], check=True)
+    subprocess.run(["git", "-C", repo, "config", "user.name", "t"], check=True)
+    open(os.path.join(repo, "a.txt"), "w").write("a\n")
+    subprocess.run(["git", "-C", repo, "add", "-A"], check=True)
+    subprocess.run(["git", "-C", repo, "commit", "-qm", "first"], check=True)
+    codex = os.path.join(tmp, "codex")
+    open(codex, "w").write(FAKE_CODEX); os.chmod(codex, 0o755)
+    mode_file, log_file = os.path.join(tmp, "mode"), os.path.join(tmp, "codex.log")
+    open(mode_file, "w").write("pass"); open(log_file, "w").close()
+    transcript = os.path.join(tmp, "session.jsonl")
+    open(transcript, "w").close()
+
+    env = {**os.environ, "CLAUDE_PLUGIN_OPTION_TARES_URL": base, "CLAUDE_PLUGIN_DATA": data_dir,
+           "CLAUDE_PLUGIN_OPTION_CODEX_BIN": codex, "FAKE_CODEX_MODE": mode_file,
+           "FAKE_CODEX_LOG": log_file, "TARES_CHALLENGER_MAX_LOOPS": "3"}
+    env.pop("CLAUDE_PLUGIN_OPTION_CHALLENGER_MODE", None)
+    sid = "sess-abc"
+    hook = {"session_id": sid, "transcript_path": transcript, "cwd": repo}
+
+    def tline(typ, **msg):
+        return json.dumps({"sessionId": sid, "type": typ, "cwd": repo, "timestamp": "2026-08-26T10:00:00Z",
+                           "message": msg}) + "\n"
+
+    def codex_calls():
+        return [json.loads(l) for l in open(log_file) if l.strip()]
+
+    def set_mode(m):
+        open(mode_file, "w").write(m)
+
+    def commit(msg):
+        open(os.path.join(repo, "a.txt"), "a").write(msg + "\n")
+        subprocess.run(["git", "-C", repo, "add", "-A"], check=True)
+        subprocess.run(["git", "-C", repo, "commit", "-qm", msg], check=True)
+        return {**hook, "hook_event_name": "PostToolUse", "tool_name": "Bash",
+                "tool_input": {"command": f"git commit -m '{msg}'"},
+                "tool_response": {"stdout": f"[main abc] {msg}", "stderr": ""}}
+
+    print("== session start: memory ==")
+    o, p = run(SHIP, {**hook, "hook_event_name": "SessionStart", "source": "startup"}, env)
+    check("accepted memory for this project printed as context",
+          "make test" in p.stdout and "not this project" not in p.stdout and "not accepted" not in p.stdout,
+          p.stdout[:300] + p.stderr[:300])
+
+    print("== unmarked session ==")
+    with open(transcript, "a") as f:
+        f.write(tline("user", role="user", content="build a pricing page"))
+    run(SHIP, {**hook, "hook_event_name": "UserPromptSubmit"}, env)
+    check("plain line shipped without a flow", INGESTED and "flow" not in INGESTED[-1], str(INGESTED[-1:]))
+    o, p = run(CHAL, commit("unmarked commit"), env)
+    check("commit in an unmarked session: hook says {} and Codex never ran", o == {} and codex_calls() == [], f"{o} {p.stderr[:200]}")
+
+    print("== mark the session ==")
+    with open(transcript, "a") as f:
+        f.write(tline("assistant", role="assistant", content=[
+            {"type": "tool_use", "id": "t1", "name": "mcp__tares__set_session_flow", "input": {"flow": "challenger"}}]))
+        f.write(tline("user", role="user", content=[{"type": "tool_result", "tool_use_id": "t1", "content": "noted"}]))
+    run(SHIP, {**hook, "hook_event_name": "PostToolUse", "tool_name": "mcp__tares__set_session_flow"}, env)
+    types = [(x.get("type"), x.get("flow")) for x in INGESTED[-3:]]
+    check("tool_use line, synthetic session_flow line, then the stamped result line",
+          types == [("assistant", "challenger"), ("session_flow", "challenger"), ("user", "challenger")], str(types))
+    sys.path.insert(0, os.path.dirname(SHIP))
+    from ship import read_flow
+    check("marker written for the session", read_flow(data_dir, sid) == "challenger")
+
+    print("== plan challenged ==")
+    set_mode("fail")
+    o, p = run(CHAL, {**hook, "hook_event_name": "PostToolUse", "tool_name": "ExitPlanMode",
+                      "tool_input": {"plan": "# Plan\n1. build it"}}, env)
+    ctx = o.get("hookSpecificOutput", {}).get("additionalContext", "") if isinstance(o, dict) else ""
+    check("plan review is advisory context with the findings",
+          "decision" not in o and "1 blocking" in ctx and "[P1] Null deref" in ctx, str(o)[:300] + p.stderr[:300])
+    check("codex ran exec on a plan file", codex_calls()[-1][0] == "exec" and "--skip-git-repo-check" in codex_calls()[-1])
+    ev = INGESTED[-1]
+    check("challenge_plan shipped with verdict and counts",
+          ev["type"] == "challenge_plan" and ev["flow"] == "challenger" and ev["challenge"]["verdict"] == "FAIL"
+          and ev["challenge"]["blocking_count"] == 1 and ev["challenge"]["finding_count"] == 2, json.dumps(ev)[:300])
+
+    print("== commit challenged: FAIL blocks ==")
+    o, p = run(CHAL, commit("pricing v1"), env)
+    check("strict mode blocks on P1", isinstance(o, dict) and o.get("decision") == "block" and "amend" in o.get("reason", ""),
+          str(o)[:300] + p.stderr[:300])
+    check("codex ran review --commit HEAD", codex_calls()[-1][:2] == ["exec", "--full-auto"] and "review" in codex_calls()[-1]
+          and "--commit" in codex_calls()[-1], str(codex_calls()[-1]))
+    ev = INGESTED[-1]
+    check("challenge_commit shipped with sha, round and counts",
+          ev["type"] == "challenge_commit" and ev["challenge"]["verdict"] == "FAIL" and ev["challenge"]["round"] == 1
+          and len(ev["challenge"]["sha"]) == 40 and ev["challenge"]["blocking_count"] == 1, json.dumps(ev)[:300])
+    gd = os.path.join(repo, ".git")
+    check("review recorded in .git history", os.path.exists(os.path.join(gd, "tares-challenger-reviews.jsonl")))
+    check("nothing written to the working tree", set(os.listdir(repo)) == {"a.txt", ".git"}, str(os.listdir(repo)))
+
+    print("== stop loop ==")
+    o, _ = run(CHAL, {**hook, "hook_event_name": "Stop", "stop_hook_active": False}, env)
+    check("stop is blocked while the review is FAIL", o.get("decision") == "block", str(o)[:200])
+    o, _ = run(CHAL, {**hook, "hook_event_name": "Stop", "stop_hook_active": True}, env)
+    check("second stop still blocked (loop 2 of 3)", o.get("decision") == "block", str(o)[:200])
+    o, _ = run(CHAL, {**hook, "hook_event_name": "Stop", "stop_hook_active": True}, env)
+    check("third stop hits the cap and lets Claude stop with context",
+          "decision" not in o and "max of 3" in o.get("hookSpecificOutput", {}).get("additionalContext", ""), str(o)[:200])
+    o, _ = run(CHAL, {**hook, "hook_event_name": "Stop", "stop_hook_active": True}, env)
+    check("state cleared after the cap", o == {}, str(o))
+
+    print("== same sha not reviewed twice, PASS clears ==")
+    before = len(codex_calls())
+    o, _ = run(CHAL, {**hook, "hook_event_name": "PostToolUse", "tool_name": "Bash",
+                      "tool_input": {"command": "git commit --amend --no-edit"}, "tool_response": {"stdout": "ok"}}, env)
+    check("a retried hook on the same sha does not re-run Codex", len(codex_calls()) == before, str(o)[:200])
+    set_mode("pass")
+    o, _ = run(CHAL, commit("pricing v2"), env)
+    ctx = o.get("hookSpecificOutput", {}).get("additionalContext", "")
+    check("PASS comes back as context and asks about pushing", "decision" not in o and "passed" in ctx and "push" in ctx, str(o)[:200])
+    o, _ = run(CHAL, {**hook, "hook_event_name": "Stop", "stop_hook_active": False}, env)
+    check("stop free after a pass", o == {}, str(o))
+
+    print("== other verdicts never block ==")
+    set_mode("inconclusive")
+    o, _ = run(CHAL, commit("v3"), env)
+    ctx = o.get("hookSpecificOutput", {}).get("additionalContext", "")
+    check("inconclusive: context, not a pass, not blocked", "decision" not in o and "INCONCLUSIVE" in ctx, str(o)[:200])
+    check("inconclusive shipped as such", INGESTED[-1]["challenge"]["verdict"] == "INCONCLUSIVE")
+    set_mode("error")
+    o, _ = run(CHAL, commit("v4"), env)
+    ctx = o.get("hookSpecificOutput", {}).get("additionalContext", "")
+    check("codex error: context with the stderr, not blocked", "decision" not in o and "auth failure" in ctx, str(o)[:200])
+
+    print("== waive ==")
+    set_mode("fail")
+    o, _ = run(CHAL, commit("v5"), env)
+    check("blocked again", o.get("decision") == "block")
+    p = subprocess.run([sys.executable, CHAL, "waive", "all"], cwd=repo, capture_output=True, text=True, env=env)
+    check("waive all writes the waiver and says so", p.returncode == 0 and "waived: [P1]" in p.stdout, p.stdout + p.stderr)
+    check("challenge_waived shipped", INGESTED[-1]["type"] == "challenge_waived" and INGESTED[-1]["challenge"]["findings"][0]["waived"])
+    o, _ = run(CHAL, {**hook, "hook_event_name": "Stop", "stop_hook_active": False}, env)
+    check("stop free after waiving", o == {}, str(o))
+    o, _ = run(CHAL, commit("v6"), env)
+    ctx = o.get("hookSpecificOutput", {}).get("additionalContext", "")
+    check("next review with the same finding passes with the waiver noted",
+          "decision" not in o and "1 finding(s) waived" in ctx, str(o)[:300])
+
+    print("== advise mode ==")
+    o, _ = run(CHAL, commit("v7"), {**env, "CLAUDE_PLUGIN_OPTION_CHALLENGER_MODE": "advise"})
+    # the waiver still applies, so use a fresh title via a plain non-waived run: switch waivers off
+    os.remove(os.path.join(gd, "tares-challenger-waived"))
+    o, _ = run(CHAL, commit("v8"), {**env, "CLAUDE_PLUGIN_OPTION_CHALLENGER_MODE": "advise"})
+    ctx = o.get("hookSpecificOutput", {}).get("additionalContext", "")
+    check("advise mode never blocks", "decision" not in o and "Advise mode" in ctx, str(o)[:200])
+
+    print("== session end ==")
+    run(SHIP, {**hook, "hook_event_name": "SessionEnd"}, env)
+    check("session_end line shipped with the flow", INGESTED[-1]["type"] == "session_end" and INGESTED[-1]["flow"] == "challenger",
+          json.dumps(INGESTED[-1]))
+    check("marker removed at session end", read_flow(data_dir, sid) == "")
+    o, _ = run(CHAL, commit("after end"), env)
+    check("hooks inert again after the session ended", o == {}, str(o))
+
+    print("== flow off mid-session ==")
+    sid2 = "sess-2"
+    hook2 = {**hook, "session_id": sid2}
+    with open(transcript, "a") as f:
+        f.write(tline("assistant", role="assistant", content=[
+            {"type": "tool_use", "id": "t2", "name": "mcp__tares__set_session_flow", "input": {"flow": "challenger"}}]).replace(sid, sid2))
+    run(SHIP, {**hook2, "hook_event_name": "PostToolUse"}, env)
+    check("second session marked", read_flow(data_dir, sid2) == "challenger")
+    with open(transcript, "a") as f:
+        f.write(tline("assistant", role="assistant", content=[
+            {"type": "tool_use", "id": "t3", "name": "mcp__tares__set_session_flow", "input": {"flow": ""}}]).replace(sid, sid2))
+    run(SHIP, {**hook2, "hook_event_name": "PostToolUse"}, env)
+    check("flow cleared by an empty set_session_flow", read_flow(data_dir, sid2) == "")
+    check("cleared session_flow line shipped without a flow stamp",
+          INGESTED[-1]["type"] == "session_flow" and INGESTED[-1].get("flow", "") == "", json.dumps(INGESTED[-1]))
+
+    srv.shutdown()
+    shutil.rmtree(tmp, ignore_errors=True)
+    print(f"\n{PASS} passed, {FAIL} failed")
+    sys.exit(1 if FAIL else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_session_flow.py
+++ b/tests/test_session_flow.py
@@ -1,5 +1,6 @@
 """TR-195: the set_session_flow MCP tool only acknowledges, and the claude_code connector turns a
-session_flow line (and a `flow` stamp on any line) into a `flow` label triggers and views can use."""
+session_flow line (and a `flow` stamp on any line) into a `flow` label triggers and views can use.
+TR-196: challenge_plan / challenge_commit / challenge_waived lines carry verdict, sha and counts as labels."""
 import asyncio
 from types import SimpleNamespace
 
@@ -38,6 +39,34 @@ def main():
     cleared = c.map_payload({"sessionId": "s1", "type": "session_flow", "flow": ""})[0]
     ck("cleared flow renders", cleared.text == "session flow: cleared", cleared.text)
     ck("flow is a declared axis", any(p["name"] == "flow" for p in ClaudeCodeConnector.PROVIDES))
+
+    commit = {"sessionId": "s1", "type": "challenge_commit", "flow": "challenger", "cwd": "/tmp/proj",
+              "timestamp": "2026-08-26T10:05:00Z",
+              "challenge": {"verdict": "fail", "sha": "abcdef1234567890", "round": 2,
+                            "finding_count": 2, "blocking_count": 1, "waived_count": 0,
+                            "duration_seconds": 41.5, "prose": "token ghp_abcdefghijklmnopqrstuvwxyz",
+                            "findings": [{"priority": "P1", "title": "Null deref in pricing", "waived": False},
+                                         {"priority": "P3", "title": "Naming", "waived": False}]}}
+    e = c.map_payload(commit)[0]
+    ck("challenge_commit keeps its type", e.event_type == "challenge_commit", e.event_type)
+    ck("verdict label uppercased", e.labels.get("verdict") == "FAIL", str(e.labels))
+    ck("sha label shortened", e.labels.get("sha") == "abcdef123456", str(e.labels))
+    ck("numeric challenge labels", e.labels.get("blocking_count") == 1 and e.labels.get("round") == 2
+       and e.labels.get("duration_seconds") == 41.5, str(e.labels))
+    ck("flow label rides along", e.labels.get("flow") == "challenger")
+    ck("text summarizes the review",
+       e.text.startswith("Challenger reviewed commit abcdef12, round 2: FAIL, 2 findings (1 blocking): [P1] Null deref"), e.text)
+    ck("prose in payload is redacted", "ghp_" not in str(e.payload), str(e.payload)[:200])
+
+    plan = {"sessionId": "s1", "type": "challenge_plan", "cwd": "/tmp/proj",
+            "challenge": {"verdict": "PASS", "plan": "pricing-page.md", "finding_count": 0,
+                          "blocking_count": 0, "duration_seconds": 12, "findings": []}}
+    e = c.map_payload(plan)[0]
+    ck("challenge_plan text", e.text == "Challenger reviewed the plan pricing-page.md: PASS, 0 findings (0 blocking)", e.text)
+    waived = {"sessionId": "s1", "type": "challenge_waived", "cwd": "/tmp/proj",
+              "challenge": {"findings": [{"priority": "P2", "title": "Missing test"}]}}
+    e = c.map_payload(waived)[0]
+    ck("challenge_waived text", e.text == "Challenger finding waived: [P2] Missing test", e.text)
 
     tools = asyncio.run(mcp_server.mcp.list_tools())
     ck("set_session_flow is an MCP tool", any(t.name == "set_session_flow" for t in tools))

--- a/tests/test_session_flow.py
+++ b/tests/test_session_flow.py
@@ -1,0 +1,54 @@
+"""TR-195: the set_session_flow MCP tool only acknowledges, and the claude_code connector turns a
+session_flow line (and a `flow` stamp on any line) into a `flow` label triggers and views can use."""
+import asyncio
+from types import SimpleNamespace
+
+P = F = 0
+def ck(l, c, d=""):
+    global P, F; P += 1 if c else 0; F += 0 if c else 1
+    print(("  ok   " if c else "  FAIL ") + l + ("" if c else f"  {d}"))
+
+
+def main():
+    from tares.connectors.claude_code import ClaudeCodeConnector
+    from tares import mcp_server
+
+    cfg = SimpleNamespace(name="claude_code", type="claude_code", config={})
+    c = ClaudeCodeConnector(cfg, store=None)
+    flow_line = {"sessionId": "s1", "type": "session_flow", "flow": "challenger",
+                 "cwd": "/tmp/proj", "timestamp": "2026-08-26T10:00:00Z"}
+    envs = c.map_payload([flow_line])
+    ck("session_flow line maps to one event", len(envs) == 1)
+    e = envs[0]
+    ck("event_type is session_flow", e.event_type == "session_flow", e.event_type)
+    ck("flow label set", e.labels.get("flow") == "challenger", str(e.labels))
+    ck("text names the flow", e.text == "session flow: challenger", e.text)
+
+    stamped = {"sessionId": "s1", "type": "assistant", "flow": "challenger", "cwd": "/tmp/proj",
+               "timestamp": "2026-08-26T10:00:01Z",
+               "message": {"role": "assistant", "content": [{"type": "text", "text": "hi"}]}}
+    e = c.map_payload(stamped)[0]
+    ck("flow stamp on an ordinary line becomes a label", e.labels.get("flow") == "challenger")
+    ck("ordinary line keeps its type", e.event_type == "assistant")
+
+    plain = {"sessionId": "s1", "type": "user", "cwd": "/tmp/proj",
+             "message": {"role": "user", "content": "hello"}}
+    e = c.map_payload(plain)[0]
+    ck("no flow, no label", "flow" not in e.labels, str(e.labels))
+    cleared = c.map_payload({"sessionId": "s1", "type": "session_flow", "flow": ""})[0]
+    ck("cleared flow renders", cleared.text == "session flow: cleared", cleared.text)
+    ck("flow is a declared axis", any(p["name"] == "flow" for p in ClaudeCodeConnector.PROVIDES))
+
+    tools = asyncio.run(mcp_server.mcp.list_tools())
+    ck("set_session_flow is an MCP tool", any(t.name == "set_session_flow" for t in tools))
+    ack = asyncio.run(mcp_server.set_session_flow("challenger"))
+    ck("ack names the flow", "challenger" in ack, ack)
+    ack = asyncio.run(mcp_server.set_session_flow(""))
+    ck("empty flow acks a clear", "clear" in ack, ack)
+
+    print(f"\n{P} passed, {F} failed")
+    raise SystemExit(1 if F else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The challenger workflow (Linear project: Challenger workflow), everything except the console (TR-201) and docs (TR-202).

Tares side
- TR-195: `set_session_flow(flow)` on `tares-mcp`. It only acknowledges: the proxy is stateless and shared, so it cannot know which Claude Code session is calling. Its value is the `mcp__tares__set_session_flow` tool_use line it leaves in the transcript. The `claude_code` connector renders `session_flow` lines and lifts a `flow` key on any line into a `flow` label.
- TR-196: `challenge_plan` / `challenge_commit` / `challenge_waived` lines carry a `challenge` object; the connector renders a one-line summary and lifts `verdict`, `sha`, `finding_count`, `blocking_count`, `round`, `duration_seconds` into labels.
- TR-197: recipe `challenger_workflow`: adopts the plugin's `claude_code` source, `challenger_session` view, `challenger_session_ends` view (`event_type == session_end`, `flow == challenger`), `challenger_session_ended` trigger, `challenger_summarizer` agent whose finding carries the summary and a "Memory proposals" section (`parse_proposals()` lifts them out; nothing reaches memory until a person accepts one). `AgentRunner.run_now` works from a worker thread.

Plugin (0.2.0)
- TR-198: `ship.py` sees the `set_session_flow` call in the transcript, writes the per-session marker the hooks gate on, stamps `flow` on every line it ships from then on, and writes synthetic `session_flow` and `session_end` lines. `/tares:challenger [off]` command; a skill section so plain wording works too.
- TR-199: `challenger.py` (Python rewrite of the andreidavid/codex-review mechanism, credited in the README): plan critique on `ExitPlanMode` (advisory), `codex exec review --json --commit HEAD` after every `git commit` with strict (block on P1/P2) or advise mode, Stop fix loop with loop and round caps, INCONCLUSIVE detection, waivers via `/tares:challenger-waive`, state and history under `.git/`, every review shipped to Tares. Inert for an unmarked session; never calls Tares to decide.
- TR-200: SessionStart hands Claude the accepted memory (decisions on `agent_memory` keyed by the project name) as hook context.

Tests: `test_session_flow.py`, `test_challenger_workflow.py`, `test_plugin_challenger.py` (fake Codex, fake Tares, temp repo), all in CI.

Release order: this ships in one Tares release; the plugin is pulled with `/plugin marketplace update`. A new plugin against an old daemon is harmless (best-effort POSTs), and the old plugin against this daemon just never marks a session.