### PR TITLE
Console: challenger sessions and memory proposals (TR-201)

### DIFF
--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -50,7 +50,7 @@
     "codex_sandbox": {
       "type": "string",
       "title": "Codex sandbox (optional)",
-      "description": "Empty = Codex's --full-auto sandbox. workspace-write or danger-full-access when the default sandbox fails inside an already sandboxed session.",
+      "description": "Empty = Codex's read-only sandbox (enough for reviews). workspace-write or danger-full-access when Codex needs to run the project's commands.",
       "default": ""
     }
   }

--- a/claude-plugin/README.md
+++ b/claude-plugin/README.md
@@ -51,7 +51,7 @@ Claude calls the `set_session_flow` MCP tool; the shipper sees that call in the 
 the session locally and on Tares, and from then on:
 
 - when Claude leaves plan mode, the OpenAI Codex CLI on your laptop critiques the plan and Claude
-  gets the findings before you see the plan (advisory);
+  gets the findings before you see the plan (advisory; only `[P1]` counts as blocking on a plan);
 - after every `git commit` Claude makes, Codex reviews the commit. `[P1]`/`[P2]` findings block
   Claude until it fixes and amends (strict, the default) or come back as context (`challenger_mode`
   = `advise`). Errors, timeouts and inconclusive reviews never block. Consecutive failed rounds are

--- a/claude-plugin/scripts/challenger.py
+++ b/claude-plugin/scripts/challenger.py
@@ -53,6 +53,7 @@ SKIP = "tares-challenger-skip"
 _COMMIT_RE = re.compile(r"(^|[^\w])git\s.*?\bcommit\b|(^|[^\w])git\s+commit\b", re.S)
 _FINDING_RE = re.compile(r"^\s*(?:[-*>]\s+)?\[(P[123])\]\s+(\S.*?)\s*$")
 
+PLAN_BLOCKING = ("P1",)
 PLAN_PROMPT = (
     "Review the implementation plan at {path}. Read it fully, then critique from these angles: "
     "missing steps or gaps; design flaws or wrong-architecture choices; scope creep or "
@@ -150,8 +151,8 @@ def apply_waivers(gitdir: str, findings: list) -> None:
         f["waived"] = f["waive_key"] in keys
 
 
-def counts(findings: list) -> tuple:
-    blocking = sum(1 for f in findings if f["priority"] in ("P1", "P2") and not f.get("waived"))
+def counts(findings: list, blocking_levels=("P1", "P2")) -> tuple:
+    blocking = sum(1 for f in findings if f["priority"] in blocking_levels and not f.get("waived"))
     waived = sum(1 for f in findings if f.get("waived"))
     return len(findings), blocking, waived
 
@@ -297,8 +298,10 @@ def review_plan(hook: dict, cfg: dict) -> dict:
             os.remove(path)
         except OSError:
             pass
-    verdict = r["verdict"] or ("FAIL" if any(f["priority"] in ("P1", "P2") for f in r["findings"]) else "PASS")
-    n, blocking, _ = counts(r["findings"])
+    # a plan is a sketch: only P1 counts as blocking here (P2 on a commit blocks, on a plan it
+    # is advice), otherwise every plan comes back with a long list of "blocking" items
+    n, blocking, _ = counts(r["findings"], PLAN_BLOCKING)
+    verdict = r["verdict"] or ("FAIL" if blocking else "PASS")
     ship_challenge(cfg, hook, "challenge_plan", {
         "verdict": verdict, "plan": name, "finding_count": n, "blocking_count": blocking,
         "waived_count": 0, "duration_seconds": r["duration_seconds"], "prose": r["prose"][:4000],
@@ -307,7 +310,8 @@ def review_plan(hook: dict, cfg: dict) -> dict:
         return context("PostToolUse", f"Codex could not review the plan ({verdict.lower()}): {r['prose']} "
                        "You are not blocked; mention it to the user.")
     head = (f"Codex challenged the plan and found {blocking} blocking finding(s) ({n} total). Revise "
-            "the plan for the P1/P2 items before presenting it, or tell the user why you disagree."
+            "the plan for the P1 items before presenting it, or tell the user why you disagree. "
+            "P2 and P3 items are advice; take what is worth it."
             if blocking else
             f"Codex challenged the plan: no blocking findings ({n} advisory). Mention that the plan "
             "was challenged when you present it.")

--- a/claude-plugin/scripts/challenger.py
+++ b/claude-plugin/scripts/challenger.py
@@ -7,7 +7,7 @@ calls the `set_session_flow` MCP tool (see ship.py). Nothing here ever asks Tare
 
 - PostToolUse(ExitPlanMode): Codex critiques the plan. Findings come back to Claude as context so
   it can revise before the user sees the plan. Never blocks: the user approves the plan anyway.
-- PostToolUse(Bash) after a successful `git commit`: `codex exec review --json --commit HEAD`.
+- PostToolUse(Bash) after a successful `git commit`: `codex exec --sandbox read-only review --json --commit HEAD`.
   P1/P2 findings block Claude with the review (strict mode, the default) or come back as context
   (advise mode). Errors, timeouts and inconclusive reviews never block.
 - Stop: while the last review of this session's commit is FAIL, keep Claude in the fix loop
@@ -80,7 +80,7 @@ def codex_bin() -> str:
 def sandbox_args() -> list:
     mode = (_opt("codex_sandbox") or "").strip()
     return {"workspace-write": ["--sandbox", "workspace-write"],
-            "danger-full-access": ["--sandbox", "danger-full-access"]}.get(mode, ["--full-auto"])
+            "danger-full-access": ["--sandbox", "danger-full-access"]}.get(mode, ["--sandbox", "read-only"])
 
 
 # ── Codex ────────────────────────────────────────────────────────────────────

--- a/claude-plugin/scripts/challenger.py
+++ b/claude-plugin/scripts/challenger.py
@@ -48,7 +48,9 @@ HISTORY = "tares-challenger-reviews.jsonl"
 WAIVED = "tares-challenger-waived"
 SKIP = "tares-challenger-skip"
 
-_COMMIT_RE = re.compile(r"(^|[^\w])git(\s[^;&|]*)?\scommit([^\w]|$)")
+# `git commit`, with any options in between (`git -c user.name="$(git config user.name || echo x)"
+# commit`, `git -C dir commit`); the response check below drops the failed ones
+_COMMIT_RE = re.compile(r"(^|[^\w])git\s.*?\bcommit\b|(^|[^\w])git\s+commit\b", re.S)
 _FINDING_RE = re.compile(r"^\s*(?:[-*>]\s+)?\[(P[123])\]\s+(\S.*?)\s*$")
 
 PLAN_PROMPT = (

--- a/claude-plugin/scripts/ship.py
+++ b/claude-plugin/scripts/ship.py
@@ -28,7 +28,8 @@ import urllib.error
 import urllib.request
 from datetime import datetime, timezone
 
-FLOW_TOOL = "mcp__tares__set_session_flow"
+FLOW_TOOL = "set_session_flow"   # the tares MCP tool; Claude Code prefixes the server name
+                                  # (mcp__tares__..., or mcp__plugin_tares_tares__... from a plugin)
 CHALLENGER = "challenger"
 
 
@@ -177,6 +178,11 @@ def ensure_source(base: str, headers: dict) -> bool:
 
 # ── the flow tool call, seen in the transcript ───────────────────────────────
 
+def _is_flow_tool(name) -> bool:
+    name = str(name or "")
+    return name == FLOW_TOOL or name.endswith("__" + FLOW_TOOL)
+
+
 def flow_call(obj: dict):
     """The flow a `set_session_flow` tool_use line asks for, or None when the line is not one."""
     msg = obj.get("message") if isinstance(obj.get("message"), dict) else {}
@@ -184,7 +190,7 @@ def flow_call(obj: dict):
     if not isinstance(content, list):
         return None
     for b in content:
-        if isinstance(b, dict) and b.get("type") == "tool_use" and b.get("name") == FLOW_TOOL:
+        if isinstance(b, dict) and b.get("type") == "tool_use" and _is_flow_tool(b.get("name")):
             inp = b.get("input") if isinstance(b.get("input"), dict) else {}
             return str(inp.get("flow", CHALLENGER) or "").strip()
     return None

--- a/tares/builtin_agents.py
+++ b/tares/builtin_agents.py
@@ -220,9 +220,6 @@ class AgentRunner:
         run_id = "run_" + uuid.uuid4().hex[:12]
         marker = (agent_name, key)
         self._inflight.add(marker)
-        self.store.start_agent_run(run_id, agent_name, trigger_name, "", key,
-                                   prompt_hash(agent["prompt"]), effective_max_rounds(agent))
-
         async def go():
             try:
                 await self._run(agent, trigger_name, key, payload, run_id, None)
@@ -233,8 +230,19 @@ class AgentRunner:
             finally:
                 self._inflight.discard(marker)
 
-        self._spawn(go)
+        try:
+            self._spawn(go)
+        except RuntimeError:
+            self._inflight.discard(marker)
+            raise
+        self.store.start_agent_run(run_id, agent_name, trigger_name, "", key,
+                                   prompt_hash(agent["prompt"]), effective_max_rounds(agent))
         return run_id
+
+    def attach_loop(self) -> None:
+        """Remember the daemon's loop. Called at startup (the app is built before uvicorn's loop
+        exists), so run_now() from a worker thread finds it."""
+        self._event_loop = asyncio.get_running_loop()
 
     def _spawn(self, coro_fn) -> None:
         """Start `coro_fn()` as a task on the daemon's loop, from that loop or from a thread."""

--- a/tares/connectors/claude_code.py
+++ b/tares/connectors/claude_code.py
@@ -211,7 +211,15 @@ class ClaudeCodeConnector(Connector):
             what = f"Challenger reviewed commit {str(ch.get('sha') or '')[:8]}{rnd}"
         else:
             return f"Challenger finding waived{tail}"
-        return f"{what}: {verdict}, {n} findings ({b} blocking){tail}"
+        # say what happened, not Codex's verdict word: "FAIL" reads as a broken run elsewhere
+        # in the console (a run that did not finish, a delivery that did not arrive)
+        if verdict == "PASS":
+            outcome = "no findings"
+        elif verdict == "FAIL":
+            outcome = f"{n} finding{'s' if n != 1 else ''} ({b} blocking)"
+        else:
+            outcome = f"no verdict ({verdict.lower()})"
+        return f"{what}: {outcome}{tail}"
 
     @staticmethod
     def _render_text(o: dict, msg: dict, include_thinking: bool) -> str:

--- a/tares/daemon.py
+++ b/tares/daemon.py
@@ -828,7 +828,29 @@ def make_app() -> FastAPI:
             _err(e, 404)
         except ValueError as e:
             _err(e, 400)
+        await _seed_challenger(token, body)
         return JSONResponse({"ingested": n}, status_code=202, headers=_verify_headers(request))
+
+    _seed_lock = asyncio.Lock()
+
+    async def _seed_challenger(token: str, body) -> None:
+        """The first marked session creates the challenger_workflow use case (view, trigger,
+        summarizer). Best effort: an ingest never fails because of it."""
+        from .usecases.challenger_workflow import ensure_instance, has_challenger_line
+        if not has_challenger_line(body):
+            return
+        cfg = runtime.catalog.sources.get(token) or next(
+            (c for c in runtime.catalog.sources.values() if c.ingest_key == token), None)
+        if cfg is None or cfg.connector != "claude_code":
+            return
+        async with _seed_lock:
+            try:
+                uid = await asyncio.to_thread(ensure_instance, usecases)
+            except Exception as e:
+                print(f"taresd: could not create the challenger workflow use case: {e}")
+                return
+        if uid:
+            print(f"taresd: created the challenger workflow use case {uid} (first challenger session)")
 
     # ── OTLP receiver (OpenTelemetry/HTTP JSON; gRPC counterpart in lifespan) ──
     def _resolve_otlp_source(header: str | None) -> str:

--- a/tares/daemon.py
+++ b/tares/daemon.py
@@ -430,6 +430,7 @@ def make_app() -> FastAPI:
 
     @asynccontextmanager
     async def lifespan(_app):
+        dispatcher.agents.attach_loop()
         runtime.start_all()
         print(f"taresd: {len(runtime.catalog.sources)} source(s); "
               f"console at / · agent API at /query · management API at /api")

--- a/tares/daemon.py
+++ b/tares/daemon.py
@@ -845,7 +845,7 @@ def make_app() -> FastAPI:
             return
         async with _seed_lock:
             try:
-                uid = await asyncio.to_thread(ensure_instance, usecases)
+                uid = ensure_instance(usecases)   # inline, like the create route: reload needs the loop
             except Exception as e:
                 print(f"taresd: could not create the challenger workflow use case: {e}")
                 return

--- a/tares/usecases/challenger_workflow.py
+++ b/tares/usecases/challenger_workflow.py
@@ -14,8 +14,11 @@ accepts one from the console, so only accepted memory ever exists.
 """
 from __future__ import annotations
 
+import json
 import re
+from datetime import datetime, timedelta, timezone
 
+from ..connectors.claude_code import ClaudeCodeConnector
 from .base import PlannedObject, Recipe, UsecaseError
 from .registry import register
 
@@ -180,17 +183,24 @@ class ChallengerWorkflow(Recipe):
         params = self.validate(instance["params"])
         stats = {x["source"]: x for x in store.event_stats()}
         st = stats.get(SOURCE) or {}
+        sessions = recent_sessions(store) if SOURCE in {x["source"] for x in stats.values()} else []
+        projects = {x["session"]: x["project"] for x in sessions}
         runs = []
         for r in store.list_agent_runs(AGENT, limit=20):
             finding = r.get("finding") or ""
             runs.append({"id": r.get("id"), "started_at": _iso(r.get("started_at")),
                          "key": r.get("key"), "session": r.get("key"), "agent": AGENT,
+                         "project": projects.get(r.get("key")),
                          "status": r.get("status"), "rounds": r.get("rounds"),
                          "max_rounds": r.get("max_rounds"), "finding": finding,
                          "proposals": parse_proposals(finding), "error": r.get("error")})
+        summarized = {r["session"]: r["id"] for r in reversed(runs) if r["status"] == "ok"}
+        for x in sessions:
+            x["run_id"] = summarized.get(x["session"])
         return {"source": SOURCE, "events": int(st.get("events") or 0),
                 "last_event": _iso(st.get("last_ingest")),
                 "slack_channel": params["slack_channel"], "runs": runs, "runs_total": len(runs),
+                "sessions": sessions,
                 "sessions_summarized": len({r["session"] for r in runs if r["status"] == "ok"}),
                 "names": {"view": VIEW, "ends_view": ENDS_VIEW, "trigger": TRIGGER, "agent": AGENT},
                 "guide": self.guide["url"]}
@@ -215,6 +225,59 @@ def parse_proposals(finding: str) -> list[str]:
         elif out or not s.startswith(("-", "*")):
             break   # a new heading or prose ends the list
     return out[:MAX_PROPOSALS]
+
+
+SESSION_DAYS = 30
+MAX_SESSIONS = 20
+THREAD_TYPES = tuple(ClaudeCodeConnector.CHALLENGE_TYPES) + ("session_flow", "session_end")
+
+
+def recent_sessions(store) -> list[dict]:
+    """The challenger sessions of the last SESSION_DAYS, newest first: who and where, what Codex
+    said about the plan and each commit, and the challenge thread (only the challenge events, so
+    the Claude/Codex exchange reads on its own; the full session stays on the view)."""
+    from ..views import _labels
+    since = datetime.now(timezone.utc) - timedelta(days=SESSION_DAYS)
+    rows = store.read_view_window([SOURCE], None, since, cap=5000, where={"flow": FLOW},
+                                  include_payload=True)
+    by_session: dict[str, dict] = {}
+    for event_time, _source, text, labels, payload in rows:
+        try:
+            raw = json.loads(payload) if isinstance(payload, (str, bytes)) else (payload or {})
+        except (TypeError, ValueError):
+            raw = {}
+        sid = str(raw.get("sessionId") or "")
+        if not sid:
+            continue
+        typ = str(raw.get("type") or "")
+        cwd = str(raw.get("cwd") or "")
+        sess = by_session.setdefault(sid, {
+            "session": sid, "project": cwd.rstrip("/").rsplit("/", 1)[-1] or None,
+            "branch": raw.get("gitBranch"), "started_at": _iso(event_time), "last_at": None,
+            "ended": False, "events": 0, "plan_verdict": None, "commits": [], "waived": 0,
+            "thread": []})
+        sess["events"] += 1
+        sess["last_at"] = _iso(event_time)
+        if raw.get("gitBranch"):
+            sess["branch"] = raw["gitBranch"]
+        if typ not in THREAD_TYPES:
+            continue
+        lbls = _labels(labels)
+        if typ == "session_end":
+            sess["ended"] = True
+        elif typ == "challenge_plan":
+            sess["plan_verdict"] = lbls.get("verdict")
+        elif typ == "challenge_commit":
+            sess["commits"].append({"sha": lbls.get("sha"), "verdict": lbls.get("verdict"),
+                                    "round": lbls.get("round"),
+                                    "findings": lbls.get("finding_count"),
+                                    "blocking": lbls.get("blocking_count")})
+        elif typ == "challenge_waived":
+            sess["waived"] += 1
+        sess["thread"].append({"at": _iso(event_time), "event_type": typ, "text": text or "",
+                               "labels": lbls})
+    out = sorted(by_session.values(), key=lambda x: x["last_at"] or "", reverse=True)
+    return out[:MAX_SESSIONS]
 
 
 def _iso(v):

--- a/tares/usecases/challenger_workflow.py
+++ b/tares/usecases/challenger_workflow.py
@@ -272,7 +272,8 @@ def recent_sessions(store) -> list[dict]:
         sess = by_session.setdefault(sid, {
             "session": sid, "project": cwd.rstrip("/").rsplit("/", 1)[-1] or None,
             "branch": raw.get("gitBranch"), "started_at": _iso(event_time), "last_at": None,
-            "ended": False, "events": 0, "plan_verdict": None, "commits": [], "waived": 0,
+            "ended": False, "events": 0, "plan_verdict": None, "plan_findings": None,
+            "plan_blocking": None, "commits": [], "waived": 0,
             "thread": []})
         sess["events"] += 1
         sess["last_at"] = _iso(event_time)
@@ -285,6 +286,8 @@ def recent_sessions(store) -> list[dict]:
             sess["ended"] = True
         elif typ == "challenge_plan":
             sess["plan_verdict"] = lbls.get("verdict")
+            sess["plan_findings"] = lbls.get("finding_count")
+            sess["plan_blocking"] = lbls.get("blocking_count")
         elif typ == "challenge_commit":
             sess["commits"].append({"sha": lbls.get("sha"), "verdict": lbls.get("verdict"),
                                     "round": lbls.get("round"),

--- a/tares/usecases/challenger_workflow.py
+++ b/tares/usecases/challenger_workflow.py
@@ -227,6 +227,24 @@ def parse_proposals(finding: str) -> list[str]:
     return out[:MAX_PROPOSALS]
 
 
+def has_challenger_line(payload) -> bool:
+    """True when an ingest body carries a line stamped flow=challenger (the plugin marks every
+    line of a marked session)."""
+    items = payload if isinstance(payload, list) else [payload]
+    return any(isinstance(o, dict) and o.get("flow") == FLOW for o in items)
+
+
+def ensure_instance(engine) -> str | None:
+    """Create the challenger_workflow use case the first time a marked session ships, so saying
+    "make this a challenger session" in Claude Code is the whole setup. Returns the new instance id,
+    or None when one already exists."""
+    if any(u.get("recipe") == "challenger_workflow" for u in engine.store.list_usecases()):
+        return None
+    inst = engine.create("challenger_workflow", {})
+    engine.store.log_usecase(inst["id"], "auto", "created on the first challenger session shipped by the plugin")
+    return inst["id"]
+
+
 SESSION_DAYS = 30
 MAX_SESSIONS = 20
 THREAD_TYPES = tuple(ClaudeCodeConnector.CHALLENGE_TYPES) + ("session_flow", "session_end")

--- a/tares/usecases/challenger_workflow.py
+++ b/tares/usecases/challenger_workflow.py
@@ -194,6 +194,11 @@ class ChallengerWorkflow(Recipe):
                          "status": r.get("status"), "rounds": r.get("rounds"),
                          "max_rounds": r.get("max_rounds"), "finding": finding,
                          "proposals": parse_proposals(finding), "error": r.get("error")})
+        decided = proposal_decisions(store)
+        for r in runs:
+            r["decisions"] = {str(i): decided.get((r["project"], text))
+                              for i, text in enumerate(r["proposals"])
+                              if decided.get((r["project"], text))}
         summarized = {r["session"]: r["id"] for r in reversed(runs) if r["status"] == "ok"}
         for x in sessions:
             x["run_id"] = summarized.get(x["session"])
@@ -243,6 +248,30 @@ def ensure_instance(engine) -> str | None:
     inst = engine.create("challenger_workflow", {})
     engine.store.log_usecase(inst["id"], "auto", "created on the first challenger session shipped by the plugin")
     return inst["id"]
+
+
+REJECTED_TYPE = "rejected_proposal"   # stored as custom:rejected_proposal; the plugin only reads decisions
+
+
+def proposal_decisions(store) -> dict:
+    """{(project, proposal text): "accepted" | "rejected"} from the memory source. Accept writes
+    the proposal as a decision keyed by the project; reject writes it as a rejected_proposal, so
+    the choice is kept on Tares (not in one browser) without ever reaching Claude."""
+    out = {}
+    try:
+        rows = store.recent_events(source="agent_memory", limit=2000)
+    except Exception:
+        return out
+    for row in rows:
+        text = (row.get("text") or "").strip()
+        if not text:
+            continue
+        typ = row.get("event_type")
+        state = ("accepted" if typ == "decision"
+                 else "rejected" if typ == f"custom:{REJECTED_TYPE}" else None)
+        if state:
+            out.setdefault((row.get("key"), text), state)
+    return out
 
 
 SESSION_DAYS = 30

--- a/tests/test_challenger_workflow.py
+++ b/tests/test_challenger_workflow.py
@@ -101,10 +101,21 @@ async def main():
             rr = await cx.post("/api/sources", json={"name": SOURCE, "connector": "claude_code",
                                                      "poll": "10s", "config": {"push": True}})
             check("plugin-style source created", rr.status_code in (200, 201), rr.text[:200])
-            rr = await cx.post("/api/usecases", json={"recipe": "challenger_workflow",
-                                                     "name": "Challenger workflow", "params": {}})
-            check("create -> 201", rr.status_code == 201, rr.text[:300])
-            uid = rr.json()["id"]
+            print("== the first marked line creates the use case ==")
+            rr = await cx.post(f"/ingest/{SOURCE}", content=json.dumps(
+                {"sessionId": "s0", "type": "user", "cwd": "/x", "timestamp": ts(60)}) + "\n",
+                headers={"content-type": "application/x-ndjson"})
+            check("an unmarked line creates nothing",
+                  rr.status_code == 202 and (await cx.get("/api/usecases")).json()["usecases"] == [])
+            rr = await cx.post(f"/ingest/{SOURCE}", content=line("s0", "session_flow", ts(59)) + "\n",
+                               headers={"content-type": "application/x-ndjson"})
+            ucs = (await cx.get("/api/usecases")).json()["usecases"]
+            check("a flow=challenger line creates the challenger_workflow use case",
+                  rr.status_code == 202 and len(ucs) == 1 and ucs[0]["recipe"] == "challenger_workflow", json.dumps(ucs)[:300])
+            uid = ucs[0]["id"]
+            rr = await cx.post(f"/ingest/{SOURCE}", content=line("s0", "session_flow", ts(58)) + "\n",
+                               headers={"content-type": "application/x-ndjson"})
+            check("a second marked line does not create another", len((await cx.get("/api/usecases")).json()["usecases"]) == 1)
             srcs = {s["name"]: s for s in (await cx.get("/api/sources")).json()}
             check("one claude_code source, owned by the use case",
                   sum(1 for n in srcs if n == SOURCE) == 1 and srcs[SOURCE]["owned_by"] == uid,
@@ -149,9 +160,9 @@ async def main():
             print("== summary and action ==")
             s = (await cx.get(f"/api/usecases/{uid}/summary")).json()
             check("summary counts events and names the objects",
-                  s["events"] == 5 and s["names"]["agent"] == AGENT and "runs" in s, json.dumps(s)[:300])
+                  s["events"] == 8 and s["names"]["agent"] == AGENT and "runs" in s, json.dumps(s)[:300])
             sess = {x["session"]: x for x in s["sessions"]}
-            check("summary lists the marked session only", set(sess) == {"s1"}, json.dumps(s["sessions"])[:400])
+            check("summary lists the marked sessions only", set(sess) == {"s0", "s1"}, json.dumps(s["sessions"])[:400])
             s1 = sess.get("s1") or {}
             check("session carries the commit verdict and thread",
                   s1.get("commits") and s1["commits"][0]["verdict"] == "PASS" and s1.get("ended")

--- a/tests/test_challenger_workflow.py
+++ b/tests/test_challenger_workflow.py
@@ -150,6 +150,13 @@ async def main():
             s = (await cx.get(f"/api/usecases/{uid}/summary")).json()
             check("summary counts events and names the objects",
                   s["events"] == 5 and s["names"]["agent"] == AGENT and "runs" in s, json.dumps(s)[:300])
+            sess = {x["session"]: x for x in s["sessions"]}
+            check("summary lists the marked session only", set(sess) == {"s1"}, json.dumps(s["sessions"])[:400])
+            s1 = sess.get("s1") or {}
+            check("session carries the commit verdict and thread",
+                  s1.get("commits") and s1["commits"][0]["verdict"] == "PASS" and s1.get("ended")
+                  and [t["event_type"] for t in s1["thread"]] == ["session_flow", "challenge_commit", "session_end"],
+                  json.dumps(s1)[:400])
             rr = await cx.post(f"/api/usecases/{uid}/actions/summarize", json={})
             check("summarize without a session -> 400", rr.status_code == 400, rr.text[:200])
             rr = await cx.post(f"/api/usecases/{uid}/actions/summarize", json={"session": "s1"})

--- a/tests/test_challenger_workflow.py
+++ b/tests/test_challenger_workflow.py
@@ -181,6 +181,14 @@ async def main(app):
             check("the run is recorded on the use case page (no key, so it did not conclude)",
                   any(r["session"] == "s1" for r in runs), json.dumps(runs)[:300])
 
+            print("== proposal decisions live on the memory source ==")
+            from tares.usecases.challenger_workflow import proposal_decisions
+            await cx.post("/remember", json={"key": "shop", "content": "use make test", "memory_type": "decision"})
+            await cx.post("/remember", json={"key": "shop", "content": "21 tests", "memory_type": "rejected_proposal"})
+            d = proposal_decisions(app.state.store)
+            check("accept -> accepted, reject -> rejected, keyed by project",
+                  d.get(("shop", "use make test")) == "accepted" and d.get(("shop", "21 tests")) == "rejected", str(d))
+
             print("== delete ==")
             rr = await cx.delete(f"/api/usecases/{uid}")
             check("delete -> 200", rr.status_code == 200, rr.text[:200])

--- a/tests/test_challenger_workflow.py
+++ b/tests/test_challenger_workflow.py
@@ -39,10 +39,13 @@ def line(sid, typ, ts, **extra):
     return json.dumps(o)
 
 
-async def main():
+def clean():
     for p in (DB, DB + ".wal", CATALOG):
         if os.path.exists(p):
             os.remove(p)
+
+
+async def main(app):
 
     from tares.usecases import get_recipe
     from tares.usecases.base import UsecaseError
@@ -92,7 +95,7 @@ async def main():
     check("caps at five", len(parse_proposals("Memory proposals\n" + "\n".join(f"- {i}" for i in range(9)))) == 5)
 
     from tares.daemon import make_app
-    app = make_app()
+    # the app is built before the loop, like `tares up` (the runner attaches the loop at startup)
     async with app.router.lifespan_context(app):
         transport = httpx.ASGITransport(app=app)
         async with httpx.AsyncClient(transport=transport, base_url="http://test") as cx:
@@ -189,4 +192,6 @@ async def main():
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    from tares.daemon import make_app
+    clean()
+    asyncio.run(main(make_app()))

--- a/tests/test_plugin_challenger.py
+++ b/tests/test_plugin_challenger.py
@@ -182,7 +182,7 @@ def main():
     o, p = run(CHAL, commit("pricing v1"), env)
     check("strict mode blocks on P1", isinstance(o, dict) and o.get("decision") == "block" and "amend" in o.get("reason", ""),
           str(o)[:300] + p.stderr[:300])
-    check("codex ran review --commit HEAD", codex_calls()[-1][:2] == ["exec", "--full-auto"] and "review" in codex_calls()[-1]
+    check("codex ran review --commit HEAD", codex_calls()[-1][:2] == ["exec", "--sandbox"] and "review" in codex_calls()[-1]
           and "--commit" in codex_calls()[-1], str(codex_calls()[-1]))
     ev = INGESTED[-1]
     check("challenge_commit shipped with sha, round and counts",

--- a/tests/test_plugin_challenger.py
+++ b/tests/test_plugin_challenger.py
@@ -178,6 +178,13 @@ def main():
           ev["type"] == "challenge_plan" and ev["flow"] == "challenger" and ev["challenge"]["verdict"] == "FAIL"
           and ev["challenge"]["blocking_count"] == 1 and ev["challenge"]["finding_count"] == 2, json.dumps(ev)[:300])
 
+    sys.path.insert(0, os.path.dirname(CHAL))
+    import challenger as _c
+    check("on a plan only P1 blocks (P2 is advice)",
+          _c.counts([{"priority": "P2"}, {"priority": "P1"}], _c.PLAN_BLOCKING) == (2, 1, 0)
+          and _c.counts([{"priority": "P2"}], _c.PLAN_BLOCKING) == (1, 0, 0)
+          and _c.counts([{"priority": "P2"}]) == (1, 1, 0))
+
     print("== commit challenged: FAIL blocks ==")
     o, p = run(CHAL, commit("pricing v1"), env)
     check("strict mode blocks on P1", isinstance(o, dict) and o.get("decision") == "block" and "amend" in o.get("reason", ""),

--- a/tests/test_plugin_challenger.py
+++ b/tests/test_plugin_challenger.py
@@ -155,7 +155,7 @@ def main():
     print("== mark the session ==")
     with open(transcript, "a") as f:
         f.write(tline("assistant", role="assistant", content=[
-            {"type": "tool_use", "id": "t1", "name": "mcp__tares__set_session_flow", "input": {"flow": "challenger"}}]))
+            {"type": "tool_use", "id": "t1", "name": "mcp__plugin_tares_tares__set_session_flow", "input": {"flow": "challenger"}}]))
         f.write(tline("user", role="user", content=[{"type": "tool_result", "tool_use_id": "t1", "content": "noted"}]))
     run(SHIP, {**hook, "hook_event_name": "PostToolUse", "tool_name": "mcp__tares__set_session_flow"}, env)
     types = [(x.get("type"), x.get("flow")) for x in INGESTED[-3:]]

--- a/tests/test_session_flow.py
+++ b/tests/test_session_flow.py
@@ -55,14 +55,14 @@ def main():
        and e.labels.get("duration_seconds") == 41.5, str(e.labels))
     ck("flow label rides along", e.labels.get("flow") == "challenger")
     ck("text summarizes the review",
-       e.text.startswith("Challenger reviewed commit abcdef12, round 2: FAIL, 2 findings (1 blocking): [P1] Null deref"), e.text)
+       e.text.startswith("Challenger reviewed commit abcdef12, round 2: 2 findings (1 blocking): [P1] Null deref"), e.text)
     ck("prose in payload is redacted", "ghp_" not in str(e.payload), str(e.payload)[:200])
 
     plan = {"sessionId": "s1", "type": "challenge_plan", "cwd": "/tmp/proj",
             "challenge": {"verdict": "PASS", "plan": "pricing-page.md", "finding_count": 0,
                           "blocking_count": 0, "duration_seconds": 12, "findings": []}}
     e = c.map_payload(plan)[0]
-    ck("challenge_plan text", e.text == "Challenger reviewed the plan pricing-page.md: PASS, 0 findings (0 blocking)", e.text)
+    ck("challenge_plan text", e.text == "Challenger reviewed the plan pricing-page.md: no findings", e.text)
     waived = {"sessionId": "s1", "type": "challenge_waived", "cwd": "/tmp/proj",
               "challenge": {"findings": [{"priority": "P2", "title": "Missing test"}]}}
     e = c.map_payload(waived)[0]

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -262,6 +262,9 @@ export const api = {
   recipes: () => request<{ recipes: Recipe[] }>("/api/usecases/recipes"),
   usecases: () => request<{ usecases: Usecase[] }>("/api/usecases"),
   usecase: (id: string) => request<Usecase>(`/api/usecases/${encodeURIComponent(id)}`),
+  // Accepted memory: only what a user accepted is ever written (a proposal is just text until then).
+  remember: (body: { key: string; content: string; memory_type?: string }) =>
+    request<{ ok: boolean; source: string }>("/remember", { method: "POST", body: JSON.stringify(body) }),
   usecaseSummary: (id: string) =>
     request<UsecaseSummary>(`/api/usecases/${encodeURIComponent(id)}/summary`),
   createUsecase: (body: { recipe: string; name?: string; params: Record<string, unknown> }) =>

--- a/ui/src/components/ChallengerSessions.tsx
+++ b/ui/src/components/ChallengerSessions.tsx
@@ -20,7 +20,10 @@ function Verdict({ v }: { v: string | undefined | null }) {
   return <span className={`badge ${verdictClass(v)}`}>{v}</span>;
 }
 
-export function SessionsPanel({ sessions, view }: { sessions: ChallengerSession[]; view: string }) {
+export function SessionsPanel({ sessions, view, onSummarize, busy, message }: {
+  sessions: ChallengerSession[]; view: string;
+  onSummarize?: (session: string) => Promise<unknown>; busy?: boolean; message?: string;
+}) {
   const [open, setOpen] = useState<string>();
   if (!sessions.length) {
     return (
@@ -36,7 +39,7 @@ export function SessionsPanel({ sessions, view }: { sessions: ChallengerSession[
     <div className="panel">
       <h2 style={{ marginTop: 0 }}>Sessions</h2>
       <table>
-        <thead><tr><th>when</th><th>project</th><th>branch</th><th>plan</th><th>commits</th><th>state</th></tr></thead>
+        <thead><tr><th>when</th><th>project</th><th>branch</th><th>plan</th><th>commits</th><th>state</th><th aria-label="actions" /></tr></thead>
         <tbody>
           {sessions.map((x) => (
             <tr key={x.session} style={{ cursor: "pointer" }} onClick={() => setOpen(open === x.session ? undefined : x.session)}>
@@ -56,10 +59,21 @@ export function SessionsPanel({ sessions, view }: { sessions: ChallengerSession[
                 {x.ended ? (x.run_id ? <span className="badge ok">summarized</span> : <span className="badge paused">ended</span>)
                   : <span className="badge agent">live</span>}
               </td>
+              <td onClick={(e) => e.stopPropagation()}>
+                {onSummarize && (
+                  <div className="btnrow" style={{ justifyContent: "flex-end" }}>
+                    <button disabled={busy} onClick={() => onSummarize(x.session)}
+                            title={x.run_id ? "run the summarizer again on this session" : "summarize this session now, without waiting for it to end"}>
+                      {busy ? "working…" : x.run_id ? "Summarize again" : "Summarize"}
+                    </button>
+                  </div>
+                )}
+              </td>
             </tr>
           ))}
         </tbody>
       </table>
+      {message && <p className="help" style={{ margin: "8px 0 0" }}>{message}</p>}
       {open && sessions.find((x) => x.session === open) && (
         <SessionThread s={sessions.find((x) => x.session === open)!} view={view} onClose={() => setOpen(undefined)} />
       )}

--- a/ui/src/components/ChallengerSessions.tsx
+++ b/ui/src/components/ChallengerSessions.tsx
@@ -27,9 +27,19 @@ function verdictText(v: string | undefined | null, findings?: string | number, b
   return "no verdict";
 }
 
-function Verdict({ v, findings, blocking }: { v: string | undefined | null; findings?: string | number; blocking?: string | number }) {
-  if (!v) return <span className="dim">not reviewed</span>;
-  return <span className={`badge ${verdictClass(v)}`} title={`Codex verdict: ${v}`}>{verdictText(v, findings, blocking)}</span>;
+function Verdict({ v, findings, blocking, compact, what }: {
+  v: string | undefined | null; findings?: string | number; blocking?: string | number;
+  compact?: boolean;   // the collapsed row: just the finding count, wording on hover
+  what?: string;
+}) {
+  if (!v) return <span className="dim">{compact ? "none" : "not reviewed"}</span>;
+  const text = verdictText(v, findings, blocking);
+  const title = `${what ? what + ": " : ""}${text} (Codex verdict ${v})`;
+  if (compact) {
+    const n = v === "PASS" ? 0 : Number(findings);
+    return <span className={`badge ${verdictClass(v)}`} title={title}>{v === "FAIL" || v === "PASS" ? (Number.isFinite(n) ? n : "?") : "?"}</span>;
+  }
+  return <span className={`badge ${verdictClass(v)}`} title={title}>{text}</span>;
 }
 
 export function SessionsPanel({ sessions, view, onSummarize, busy, message }: {
@@ -51,18 +61,19 @@ export function SessionsPanel({ sessions, view, onSummarize, busy, message }: {
     <div className="panel">
       <h2 style={{ marginTop: 0 }}>Sessions</h2>
       <table>
-        <thead><tr><th>when</th><th>project</th><th>branch</th><th>plan</th><th>commits</th><th>state</th><th aria-label="actions" /></tr></thead>
+        <thead><tr><th>when</th><th>project</th><th>branch</th><th title="findings on the plan">plan</th><th title="findings per reviewed commit, in order">commits</th><th>state</th><th aria-label="actions" /></tr></thead>
         <tbody>
           {sessions.map((x) => (
             <tr key={x.session} style={{ cursor: "pointer" }} onClick={() => setOpen(open === x.session ? undefined : x.session)}>
               <td style={{ whiteSpace: "nowrap" }}><TimeAgo ts={x.started_at ?? null} /></td>
               <td className="mono">{x.project ?? <span className="dim">unknown</span>}</td>
               <td className="mono">{x.branch ?? ""}</td>
-              <td><Verdict v={x.plan_verdict} findings={x.plan_findings ?? undefined} blocking={x.plan_blocking ?? undefined} /></td>
+              <td><Verdict compact what="plan" v={x.plan_verdict} findings={x.plan_findings ?? undefined} blocking={x.plan_blocking ?? undefined} /></td>
               <td>
                 {x.commits.length === 0 ? <span className="dim">none</span> : (
                   <span className="tl-labels">
-                    {x.commits.map((c, i) => <span key={i} className={`badge ${verdictClass(c.verdict)}`} title={`commit ${c.sha ?? "?"}${c.round ? `, round ${c.round}` : ""}: Codex verdict ${c.verdict ?? "?"}`}>{verdictText(c.verdict, c.findings, c.blocking)}</span>)}
+                    {x.commits.map((c, i) => <Verdict key={i} compact v={c.verdict} findings={c.findings} blocking={c.blocking}
+                                                       what={`commit ${c.sha ?? "?"}${c.round ? `, round ${c.round}` : ""}`} />)}
                   </span>
                 )}
                 {x.waived > 0 && <span className="help"> · {x.waived} waived</span>}

--- a/ui/src/components/ChallengerSessions.tsx
+++ b/ui/src/components/ChallengerSessions.tsx
@@ -36,8 +36,9 @@ function Verdict({ v, findings, blocking, compact, what }: {
   const text = verdictText(v, findings, blocking);
   const title = `${what ? what + ": " : ""}${text} (Codex verdict ${v})`;
   if (compact) {
-    const n = v === "PASS" ? 0 : Number(findings);
-    return <span className={`badge ${verdictClass(v)}`} title={title}>{v === "FAIL" || v === "PASS" ? (Number.isFinite(n) ? n : "?") : "?"}</span>;
+    const n = Number(findings);
+    const label = v === "PASS" ? "Pass" : v === "FAIL" ? `Findings (${Number.isFinite(n) ? n : "?"})` : "No verdict";
+    return <span className={`badge ${verdictClass(v)}`} title={title}>{label}</span>;
   }
   return <span className={`badge ${verdictClass(v)}`} title={title}>{text}</span>;
 }

--- a/ui/src/components/ChallengerSessions.tsx
+++ b/ui/src/components/ChallengerSessions.tsx
@@ -11,13 +11,25 @@ import type { ChallengerSession, TimelineEventRow, UsecaseSummary } from "../typ
 // accepts it; accept is the only thing that writes memory, so the plugin only ever hands Claude
 // what a person chose to keep.
 
+// Codex's verdict word stays in the data (the `verdict` label); on screen we say what happened.
+// "FAIL" elsewhere in the console means a run or delivery that did not work; here the review
+// worked and found things.
 function verdictClass(v: string | undefined | null) {
-  return v === "PASS" ? "ok" : v === "FAIL" ? "error" : "paused";
+  return v === "PASS" ? "ok" : v === "FAIL" ? "paused" : "blanked";
+}
+function verdictText(v: string | undefined | null, findings?: string | number, blocking?: string | number) {
+  if (v === "PASS") return "no findings";
+  if (v === "FAIL") {
+    const n = Number(findings), b = Number(blocking);
+    if (!Number.isFinite(n) || n <= 0) return "findings";
+    return `${n} finding${n === 1 ? "" : "s"}` + (Number.isFinite(b) && b > 0 ? `, ${b} blocking` : "");
+  }
+  return "no verdict";
 }
 
-function Verdict({ v }: { v: string | undefined | null }) {
-  if (!v) return <span className="dim">none</span>;
-  return <span className={`badge ${verdictClass(v)}`}>{v}</span>;
+function Verdict({ v, findings, blocking }: { v: string | undefined | null; findings?: string | number; blocking?: string | number }) {
+  if (!v) return <span className="dim">not reviewed</span>;
+  return <span className={`badge ${verdictClass(v)}`} title={`Codex verdict: ${v}`}>{verdictText(v, findings, blocking)}</span>;
 }
 
 export function SessionsPanel({ sessions, view, onSummarize, busy, message }: {
@@ -46,11 +58,11 @@ export function SessionsPanel({ sessions, view, onSummarize, busy, message }: {
               <td style={{ whiteSpace: "nowrap" }}><TimeAgo ts={x.started_at ?? null} /></td>
               <td className="mono">{x.project ?? <span className="dim">unknown</span>}</td>
               <td className="mono">{x.branch ?? ""}</td>
-              <td><Verdict v={x.plan_verdict} /></td>
+              <td><Verdict v={x.plan_verdict} findings={x.plan_findings ?? undefined} blocking={x.plan_blocking ?? undefined} /></td>
               <td>
                 {x.commits.length === 0 ? <span className="dim">none</span> : (
                   <span className="tl-labels">
-                    {x.commits.map((c, i) => <span key={i} className={`badge ${verdictClass(c.verdict)}`} title={c.sha ? `commit ${c.sha}` : undefined}>{c.verdict ?? "?"}</span>)}
+                    {x.commits.map((c, i) => <span key={i} className={`badge ${verdictClass(c.verdict)}`} title={`commit ${c.sha ?? "?"}${c.round ? `, round ${c.round}` : ""}: Codex verdict ${c.verdict ?? "?"}`}>{verdictText(c.verdict, c.findings, c.blocking)}</span>)}
                   </span>
                 )}
                 {x.waived > 0 && <span className="help"> · {x.waived} waived</span>}
@@ -102,7 +114,7 @@ function SessionThread({ s, view, onClose }: { s: ChallengerSession; view: strin
         <div>
           <h3 style={{ margin: 0 }}><span className="mono">{s.project ?? s.session}</span>{s.branch && <span className="help"> on {s.branch}</span>}</h3>
           <span className="subtitle" style={{ margin: 0 }}>
-            challenger session · plan <Verdict v={s.plan_verdict} /> · {s.commits.length} commit{s.commits.length === 1 ? "" : "s"} reviewed
+            challenger session · plan <Verdict v={s.plan_verdict} findings={s.plan_findings ?? undefined} blocking={s.plan_blocking ?? undefined} /> · {s.commits.length} commit{s.commits.length === 1 ? "" : "s"} reviewed
             {blocking > 0 && <> · {blocking} blocking finding{blocking === 1 ? "" : "s"}</>}
             {s.waived > 0 && <> · {s.waived} waived</>}
             {s.run_id && <> · <Link to={`/agents/challenger_summarizer?run=${encodeURIComponent(s.run_id)}`}>summary</Link></>}
@@ -127,7 +139,7 @@ function SessionThread({ s, view, onClose }: { s: ChallengerSession; view: strin
                   <td style={{ whiteSpace: "nowrap" }}><TimeAgo ts={t.at} /></td>
                   <td>
                     <span className="mono" style={{ whiteSpace: "pre-wrap" }}>{t.text}</span>
-                    {t.labels.verdict && <span className="tl-labels"><Verdict v={t.labels.verdict} /></span>}
+                    {t.labels.verdict && <span className="tl-labels"><Verdict v={t.labels.verdict} findings={t.labels.finding_count} blocking={t.labels.blocking_count} /></span>}
                   </td>
                 </tr>
               ))}

--- a/ui/src/components/ChallengerSessions.tsx
+++ b/ui/src/components/ChallengerSessions.tsx
@@ -177,72 +177,84 @@ function SessionThread({ s, view, onClose }: { s: ChallengerSession; view: strin
 }
 
 type Decision = "accepted" | "rejected";
-const storeKey = (runId: string, i: number) => `tares.proposal:${runId}:${i}`;
-function readDecision(runId: string, i: number): Decision | undefined {
-  try { return (localStorage.getItem(storeKey(runId, i)) as Decision) || undefined; } catch { return undefined; }
-}
-function writeDecision(runId: string, i: number, d: Decision) {
-  try { localStorage.setItem(storeKey(runId, i), d); } catch { /* private mode */ }
-}
+type Row = { runId: string; i: number; project: string; text: string; agent: string; started_at?: string; decision?: Decision };
 
 export function ProposalsPanel({ runs }: { runs: NonNullable<UsecaseSummary["runs"]> }) {
-  const withProposals = runs.filter((r) => r.id && r.proposals && r.proposals.length);
-  const [tick, setTick] = useState(0);
   const [busy, setBusy] = useState<string>();
   const [err, setErr] = useState<string>();
-  if (!withProposals.length) return null;
+  // decided locally this render cycle, until the next poll brings the state back from Tares
+  const [local, setLocal] = useState<Record<string, Decision>>({});
+  const rows: Row[] = runs.flatMap((r) => (r.id && r.proposals ? r.proposals : []).map((text, i) => ({
+    runId: r.id!, i, project: r.project ?? "", text, agent: r.agent ?? "challenger_summarizer",
+    started_at: r.started_at, decision: local[`${r.id}:${i}`] ?? r.decisions?.[String(i)],
+  })));
+  if (!rows.length) return null;
+  const open = rows.filter((x) => !x.decision);
+  const done = rows.filter((x) => x.decision);
 
-  const accept = async (runId: string, i: number, project: string, text: string) => {
-    setBusy(storeKey(runId, i)); setErr(undefined);
+  const decide = async (x: Row, d: Decision) => {
+    const k = `${x.runId}:${x.i}`;
+    setBusy(k); setErr(undefined);
     try {
-      await api.remember({ key: project, content: text, memory_type: "decision" });
-      writeDecision(runId, i, "accepted");
+      await api.remember({ key: x.project, content: x.text, memory_type: d === "accepted" ? "decision" : "rejected_proposal" });
+      setLocal({ ...local, [k]: d });
     } catch (e) { setErr(String((e as Error).message ?? e)); }
-    setBusy(undefined); setTick(tick + 1);
+    setBusy(undefined);
   };
-  const reject = (runId: string, i: number) => { writeDecision(runId, i, "rejected"); setTick(tick + 1); };
+
+  const cell = (x: Row) => (
+    <td className="mono" style={{ whiteSpace: "nowrap" }}>
+      {x.project || <span className="dim" title="the session's project is unknown, so accept has no key">unknown</span>}
+      <div><Link to={`/agents/${encodeURIComponent(x.agent)}?run=${encodeURIComponent(x.runId)}`} className="help"><TimeAgo ts={x.started_at ?? null} /></Link></div>
+    </td>
+  );
 
   return (
     <div className="panel">
       <h2 style={{ marginTop: 0 }}>Memory proposals</h2>
       <p className="help" style={{ marginTop: 0 }}>
-        What the summarizer thinks is worth remembering about a project. Accept writes it as a decision
+        What the summarizer thinks is worth remembering about a project. Accept stores it as a decision
         on the memory source, keyed by the project, and the plugin hands it to Claude at the start of
-        the next session there. Reject hides it; nothing is written.
+        the next session there. Reject keeps it out of memory for good.
       </p>
       {err && <div className="alert error">{err}</div>}
-      <table>
-        <thead><tr><th>project</th><th>proposal</th><th aria-label="decision" /></tr></thead>
-        <tbody>
-          {withProposals.flatMap((r) => (r.proposals ?? []).map((text, i) => {
-            const runId = r.id!;
-            const project = r.project ?? "";
-            const d = readDecision(runId, i);
-            return (
-              <tr key={storeKey(runId, i)}>
-                <td className="mono" style={{ whiteSpace: "nowrap" }}>
-                  {project || <span className="dim" title="the session's project is unknown, so accept has no key">unknown</span>}
-                  <div><Link to={`/agents/${encodeURIComponent(r.agent ?? "challenger_summarizer")}?run=${encodeURIComponent(runId)}`} className="help"><TimeAgo ts={r.started_at ?? null} /></Link></div>
-                </td>
-                <td style={{ whiteSpace: "pre-wrap" }}>{text}</td>
+      {open.length ? (
+        <table>
+          <thead><tr><th>project</th><th>proposal</th><th aria-label="decision" /></tr></thead>
+          <tbody>
+            {open.map((x) => (
+              <tr key={`${x.runId}:${x.i}`}>
+                {cell(x)}
+                <td style={{ whiteSpace: "pre-wrap" }}>{x.text}</td>
                 <td>
-                  {d === "accepted" ? <span className="badge ok">accepted</span>
-                    : d === "rejected" ? <span className="help">rejected</span>
-                    : (
-                      <div className="btnrow" style={{ justifyContent: "flex-end" }}>
-                        <button className="primary" disabled={!project || busy === storeKey(runId, i)}
-                                onClick={() => accept(runId, i, project, text)}>
-                          {busy === storeKey(runId, i) ? "saving…" : "Accept"}
-                        </button>
-                        <button onClick={() => reject(runId, i)}>Reject</button>
-                      </div>
-                    )}
+                  <div className="btnrow" style={{ justifyContent: "flex-end" }}>
+                    <button className="primary" disabled={!x.project || busy === `${x.runId}:${x.i}`} onClick={() => decide(x, "accepted")}>
+                      {busy === `${x.runId}:${x.i}` ? "saving…" : "Accept"}
+                    </button>
+                    <button disabled={!x.project || busy === `${x.runId}:${x.i}`} onClick={() => decide(x, "rejected")}>Reject</button>
+                  </div>
                 </td>
               </tr>
-            );
-          }))}
-        </tbody>
-      </table>
+            ))}
+          </tbody>
+        </table>
+      ) : <div className="empty">nothing waiting for a decision</div>}
+      {done.length > 0 && (
+        <details className="uc-how" style={{ marginTop: 10 }}>
+          <summary>{done.length} decided</summary>
+          <table style={{ marginTop: 8 }}>
+            <tbody>
+              {done.map((x) => (
+                <tr key={`${x.runId}:${x.i}`}>
+                  {cell(x)}
+                  <td style={{ whiteSpace: "pre-wrap" }}>{x.text}</td>
+                  <td>{x.decision === "accepted" ? <span className="badge ok">accepted</span> : <span className="help">rejected</span>}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </details>
+      )}
     </div>
   );
 }

--- a/ui/src/components/ChallengerSessions.tsx
+++ b/ui/src/components/ChallengerSessions.tsx
@@ -1,0 +1,210 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+
+import { api } from "../api";
+import { TimeAgo } from "./bits";
+import type { ChallengerSession, TimelineEventRow, UsecaseSummary } from "../types";
+
+// The challenger workflow's own panels on the use case page: the sessions Codex challenged (with
+// the plan and commit verdicts, and the Claude/Codex exchange as one thread) and the summarizer's
+// memory proposals with accept / reject. A proposal is text inside a finding until the user
+// accepts it; accept is the only thing that writes memory, so the plugin only ever hands Claude
+// what a person chose to keep.
+
+function verdictClass(v: string | undefined | null) {
+  return v === "PASS" ? "ok" : v === "FAIL" ? "error" : "paused";
+}
+
+function Verdict({ v }: { v: string | undefined | null }) {
+  if (!v) return <span className="dim">none</span>;
+  return <span className={`badge ${verdictClass(v)}`}>{v}</span>;
+}
+
+export function SessionsPanel({ sessions, view }: { sessions: ChallengerSession[]; view: string }) {
+  const [open, setOpen] = useState<string>();
+  if (!sessions.length) {
+    return (
+      <div className="panel">
+        <h2 style={{ marginTop: 0 }}>Sessions</h2>
+        <div className="empty">
+          no challenger sessions yet; in Claude Code run <span className="mono">/tares:challenger</span>, then leave plan mode or commit
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div className="panel">
+      <h2 style={{ marginTop: 0 }}>Sessions</h2>
+      <table>
+        <thead><tr><th>when</th><th>project</th><th>branch</th><th>plan</th><th>commits</th><th>state</th></tr></thead>
+        <tbody>
+          {sessions.map((x) => (
+            <tr key={x.session} style={{ cursor: "pointer" }} onClick={() => setOpen(open === x.session ? undefined : x.session)}>
+              <td style={{ whiteSpace: "nowrap" }}><TimeAgo ts={x.started_at ?? null} /></td>
+              <td className="mono">{x.project ?? <span className="dim">unknown</span>}</td>
+              <td className="mono">{x.branch ?? ""}</td>
+              <td><Verdict v={x.plan_verdict} /></td>
+              <td>
+                {x.commits.length === 0 ? <span className="dim">none</span> : (
+                  <span className="tl-labels">
+                    {x.commits.map((c, i) => <span key={i} className={`badge ${verdictClass(c.verdict)}`} title={c.sha ? `commit ${c.sha}` : undefined}>{c.verdict ?? "?"}</span>)}
+                  </span>
+                )}
+                {x.waived > 0 && <span className="help"> · {x.waived} waived</span>}
+              </td>
+              <td>
+                {x.ended ? (x.run_id ? <span className="badge ok">summarized</span> : <span className="badge paused">ended</span>)
+                  : <span className="badge agent">live</span>}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {open && sessions.find((x) => x.session === open) && (
+        <SessionThread s={sessions.find((x) => x.session === open)!} view={view} onClose={() => setOpen(undefined)} />
+      )}
+    </div>
+  );
+}
+
+function SessionThread({ s, view, onClose }: { s: ChallengerSession; view: string; onClose: () => void }) {
+  const [all, setAll] = useState(false);
+  const [rows, setRows] = useState<TimelineEventRow[]>();
+  const [err, setErr] = useState<string>();
+  useEffect(() => {
+    if (!all) return;
+    let live = true;
+    setRows(undefined); setErr(undefined);
+    api.runQueryWhere(view, { key_value: s.session }, "30d")
+      .then((r) => { if (live) setRows(r.rows ?? []); })
+      .catch((e) => { if (live) setErr(String((e as Error).message ?? e)); });
+    return () => { live = false; };
+  }, [all, s.session, view]);
+
+  const blocking = s.commits.reduce((n, c) => n + (Number(c.blocking) || 0), 0);
+  return (
+    <div style={{ marginTop: 14 }}>
+      <div className="tl-head">
+        <div>
+          <h3 style={{ margin: 0 }}><span className="mono">{s.project ?? s.session}</span>{s.branch && <span className="help"> on {s.branch}</span>}</h3>
+          <span className="subtitle" style={{ margin: 0 }}>
+            challenger session · plan <Verdict v={s.plan_verdict} /> · {s.commits.length} commit{s.commits.length === 1 ? "" : "s"} reviewed
+            {blocking > 0 && <> · {blocking} blocking finding{blocking === 1 ? "" : "s"}</>}
+            {s.waived > 0 && <> · {s.waived} waived</>}
+            {s.run_id && <> · <Link to={`/agents/challenger_summarizer?run=${encodeURIComponent(s.run_id)}`}>summary</Link></>}
+          </span>
+        </div>
+        <div className="btnrow">
+          <div className="seg small">
+            <button className={!all ? "active" : ""} onClick={() => setAll(false)}>challenges only</button>
+            <button className={all ? "active" : ""} onClick={() => setAll(true)}>whole session</button>
+          </div>
+          <button onClick={onClose}>Close</button>
+        </div>
+      </div>
+      {err && <div className="alert error">{err}</div>}
+      {!all ? (
+        s.thread.length ? (
+          <table style={{ marginTop: 10 }}>
+            <thead><tr><th style={{ width: 90 }}>when</th><th>event</th></tr></thead>
+            <tbody>
+              {s.thread.map((t, i) => (
+                <tr key={i}>
+                  <td style={{ whiteSpace: "nowrap" }}><TimeAgo ts={t.at} /></td>
+                  <td>
+                    <span className="mono" style={{ whiteSpace: "pre-wrap" }}>{t.text}</span>
+                    {t.labels.verdict && <span className="tl-labels"><Verdict v={t.labels.verdict} /></span>}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        ) : <div className="empty">no challenge events in this session yet</div>
+      ) : rows === undefined && !err ? <div className="help" style={{ marginTop: 10 }}>reading session…</div>
+        : rows && rows.length ? (
+          <table style={{ marginTop: 10 }}>
+            <thead><tr><th style={{ width: 74 }}>when</th><th>event</th></tr></thead>
+            <tbody>
+              {rows.map((r, i) => (
+                <tr key={i}>
+                  <td className="mono dim" style={{ whiteSpace: "nowrap" }}>{r.offset}</td>
+                  <td><span className="mono" style={{ whiteSpace: "pre-wrap" }}>{r.text}</span></td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        ) : rows && <div className="empty">the view holds nothing for this session in the last 30 days</div>}
+    </div>
+  );
+}
+
+type Decision = "accepted" | "rejected";
+const storeKey = (runId: string, i: number) => `tares.proposal:${runId}:${i}`;
+function readDecision(runId: string, i: number): Decision | undefined {
+  try { return (localStorage.getItem(storeKey(runId, i)) as Decision) || undefined; } catch { return undefined; }
+}
+function writeDecision(runId: string, i: number, d: Decision) {
+  try { localStorage.setItem(storeKey(runId, i), d); } catch { /* private mode */ }
+}
+
+export function ProposalsPanel({ runs }: { runs: NonNullable<UsecaseSummary["runs"]> }) {
+  const withProposals = runs.filter((r) => r.id && r.proposals && r.proposals.length);
+  const [tick, setTick] = useState(0);
+  const [busy, setBusy] = useState<string>();
+  const [err, setErr] = useState<string>();
+  if (!withProposals.length) return null;
+
+  const accept = async (runId: string, i: number, project: string, text: string) => {
+    setBusy(storeKey(runId, i)); setErr(undefined);
+    try {
+      await api.remember({ key: project, content: text, memory_type: "decision" });
+      writeDecision(runId, i, "accepted");
+    } catch (e) { setErr(String((e as Error).message ?? e)); }
+    setBusy(undefined); setTick(tick + 1);
+  };
+  const reject = (runId: string, i: number) => { writeDecision(runId, i, "rejected"); setTick(tick + 1); };
+
+  return (
+    <div className="panel">
+      <h2 style={{ marginTop: 0 }}>Memory proposals</h2>
+      <p className="help" style={{ marginTop: 0 }}>
+        What the summarizer thinks is worth remembering about a project. Accept writes it as a decision
+        on the memory source, keyed by the project, and the plugin hands it to Claude at the start of
+        the next session there. Reject hides it; nothing is written.
+      </p>
+      {err && <div className="alert error">{err}</div>}
+      <table>
+        <thead><tr><th>project</th><th>proposal</th><th aria-label="decision" /></tr></thead>
+        <tbody>
+          {withProposals.flatMap((r) => (r.proposals ?? []).map((text, i) => {
+            const runId = r.id!;
+            const project = r.project ?? "";
+            const d = readDecision(runId, i);
+            return (
+              <tr key={storeKey(runId, i)}>
+                <td className="mono" style={{ whiteSpace: "nowrap" }}>
+                  {project || <span className="dim" title="the session's project is unknown, so accept has no key">unknown</span>}
+                  <div><Link to={`/agents/${encodeURIComponent(r.agent ?? "challenger_summarizer")}?run=${encodeURIComponent(runId)}`} className="help"><TimeAgo ts={r.started_at ?? null} /></Link></div>
+                </td>
+                <td style={{ whiteSpace: "pre-wrap" }}>{text}</td>
+                <td>
+                  {d === "accepted" ? <span className="badge ok">accepted</span>
+                    : d === "rejected" ? <span className="help">rejected</span>
+                    : (
+                      <div className="btnrow" style={{ justifyContent: "flex-end" }}>
+                        <button className="primary" disabled={!project || busy === storeKey(runId, i)}
+                                onClick={() => accept(runId, i, project, text)}>
+                          {busy === storeKey(runId, i) ? "saving…" : "Accept"}
+                        </button>
+                        <button onClick={() => reject(runId, i)}>Reject</button>
+                      </div>
+                    )}
+                </td>
+              </tr>
+            );
+          }))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Link, useNavigate, useParams, useSearchParams } from "react-router-dom";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -318,11 +318,15 @@ function RunRow({ r, open, focused, onToggle }: {
       {r.finding ? " What it had so far:" : ""}
     </p>
   );
+  // Scroll the focused run into view once, when it is opened from a link; not on every poll
+  // re-render, which would drag the page back while the user reads the finding.
+  const rowRef = useRef<HTMLTableRowElement>(null);
+  useEffect(() => { if (focused) rowRef.current?.scrollIntoView({ block: "center" }); }, [focused]);
   return (
     <>
       <tr className="clickable" onClick={onToggle}
           style={focused ? { outline: "2px solid var(--accent)", outlineOffset: -2 } : undefined}
-          ref={(el) => { if (el && focused) el.scrollIntoView({ block: "center" }); }}>
+          ref={rowRef}>
         <td>{statusBadge(r)}</td>
         <td style={{ whiteSpace: "nowrap" }}><TimeAgo ts={r.started_at} /></td>
         <td className="mono">{r.key}</td>

--- a/ui/src/pages/UsecaseDetail.tsx
+++ b/ui/src/pages/UsecaseDetail.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 
 import { api } from "../api";
-import { ErrorState, Picker, TimeAgo, usePolling } from "../components/bits";
+import { Combo, ErrorState, Picker, TimeAgo, usePolling } from "../components/bits";
 import ConfirmDialog from "../components/ConfirmDialog";
 import type { Recipe, RecipeActionOption, UsecaseObject, UsecaseSummary } from "../types";
 import InfoDialog, { HelpButton } from "../components/InfoDialog";
@@ -193,11 +193,18 @@ export default function UsecaseDetail() {
                 {Object.entries(a.params ?? {}).map(([k, spec]) => {
                   const o = opts(spec.options);
                   if (!o.length) {
-                    // free-form parameter: a text field; known values (the sessions on this page) are
-                    // offered as suggestions, anything else can still be typed
+                    // free-form parameter: a text field; the sessions on this page are offered as
+                    // suggestions in the console's own list, anything else can still be typed
                     const suggestions = k === "session" ? (s.sessions ?? []) : [];
-                    const listId = `${a.name}-${k}-suggestions`;
                     return (
+                      <Combo key={k} value={actionArgs[`${a.name}.${k}`] ?? ""} placeholder={spec.label ?? k}
+                             options={suggestions.map((x) => x.session)} style={{ width: 340 }}
+                             hints={Object.fromEntries(suggestions.map((x) => [x.session,
+                               [x.project, x.branch, x.ended ? "ended" : "live"].filter(Boolean).join(" · ")]))}
+                             onChange={(v) => setActionArgs({ ...actionArgs, [`${a.name}.${k}`]: v })} />
+                    );
+                  }
+                  return (
                       <span key={k}>
                         <input type="text" placeholder={spec.label ?? k} aria-label={spec.label ?? k}
                                list={suggestions.length ? listId : undefined}

--- a/ui/src/pages/UsecaseDetail.tsx
+++ b/ui/src/pages/UsecaseDetail.tsx
@@ -90,13 +90,16 @@ export default function UsecaseDetail() {
   }, [s?.recipe]);
   const opts = (o?: (string | RecipeActionOption)[]): RecipeActionOption[] =>
     (o ?? []).map((x) => (typeof x === "string" ? { value: x } : x));
-  const runAction = async (name: string, params?: Record<string, { options?: (string | RecipeActionOption)[] }>) => {
+  const runActionWith = async (name: string, args: Record<string, unknown>) => {
     setActionBusy(name); setActionError(undefined); setActionMsg(undefined);
-    const args: Record<string, unknown> = {};
-    for (const [k, spec] of Object.entries(params ?? {})) args[k] = actionArgs[`${name}.${k}`] ?? opts(spec.options)[0]?.value;
     try { const r = await api.usecaseAction(id, name, args); setActionMsg(r.message); reload(); }
     catch (e) { setActionError(String((e as Error).message ?? e)); }
     setActionBusy(undefined);
+  };
+  const runAction = (name: string, params?: Record<string, { options?: (string | RecipeActionOption)[] }>) => {
+    const args: Record<string, unknown> = {};
+    for (const [k, spec] of Object.entries(params ?? {})) args[k] = actionArgs[`${name}.${k}`] ?? opts(spec.options)[0]?.value;
+    return runActionWith(name, args);
   };
 
   const act = (fn: () => Promise<unknown>) => async () => {
@@ -189,6 +192,11 @@ export default function UsecaseDetail() {
               <span key={a.name} className="uc-actions" title={a.help}>
                 {Object.entries(a.params ?? {}).map(([k, spec]) => {
                   const o = opts(spec.options);
+                  if (!o.length) return (   // free-form parameter: a text field, not an empty menu
+                    <input key={k} type="text" placeholder={spec.label ?? k} aria-label={spec.label ?? k}
+                           value={actionArgs[`${a.name}.${k}`] ?? ""} style={{ width: 260 }}
+                           onChange={(e) => setActionArgs({ ...actionArgs, [`${a.name}.${k}`]: e.target.value })} />
+                  );
                   return (
                     <Picker key={k} value={actionArgs[`${a.name}.${k}`] ?? o[0]?.value ?? ""}
                             onChange={(v) => setActionArgs({ ...actionArgs, [`${a.name}.${k}`]: v })}
@@ -244,7 +252,11 @@ export default function UsecaseDetail() {
         <button className={tab === "config" ? "active" : ""} onClick={() => setTab("config")}>Configuration</button>
       </div>
 
-      {tab === "sessions" && s.sessions && <SessionsPanel sessions={s.sessions} view={s.names?.view ?? "challenger_session"} />}
+      {tab === "sessions" && s.sessions && (
+        <SessionsPanel sessions={s.sessions} view={s.names?.view ?? "challenger_session"}
+                       onSummarize={s.status === "active" ? (sid) => { setActionArgs({ ...actionArgs, "summarize.session": sid }); return runActionWith("summarize", { session: sid }); } : undefined}
+                       busy={actionBusy === "summarize"} message={actionMsg} />
+      )}
 
       {tab === "runs" && (<>
       {runs && <ProposalsPanel runs={runs} />}

--- a/ui/src/pages/UsecaseDetail.tsx
+++ b/ui/src/pages/UsecaseDetail.tsx
@@ -192,11 +192,29 @@ export default function UsecaseDetail() {
               <span key={a.name} className="uc-actions" title={a.help}>
                 {Object.entries(a.params ?? {}).map(([k, spec]) => {
                   const o = opts(spec.options);
-                  if (!o.length) return (   // free-form parameter: a text field, not an empty menu
-                    <input key={k} type="text" placeholder={spec.label ?? k} aria-label={spec.label ?? k}
-                           value={actionArgs[`${a.name}.${k}`] ?? ""} style={{ width: 260 }}
-                           onChange={(e) => setActionArgs({ ...actionArgs, [`${a.name}.${k}`]: e.target.value })} />
-                  );
+                  if (!o.length) {
+                    // free-form parameter: a text field; known values (the sessions on this page) are
+                    // offered as suggestions, anything else can still be typed
+                    const suggestions = k === "session" ? (s.sessions ?? []) : [];
+                    const listId = `${a.name}-${k}-suggestions`;
+                    return (
+                      <span key={k}>
+                        <input type="text" placeholder={spec.label ?? k} aria-label={spec.label ?? k}
+                               list={suggestions.length ? listId : undefined}
+                               value={actionArgs[`${a.name}.${k}`] ?? ""} style={{ width: 300 }}
+                               onChange={(e) => setActionArgs({ ...actionArgs, [`${a.name}.${k}`]: e.target.value })} />
+                        {suggestions.length > 0 && (
+                          <datalist id={listId}>
+                            {suggestions.map((x) => (
+                              <option key={x.session} value={x.session}>
+                                {[x.project, x.branch, x.ended ? "ended" : "live"].filter(Boolean).join(" · ")}
+                              </option>
+                            ))}
+                          </datalist>
+                        )}
+                      </span>
+                    );
+                  }
                   return (
                     <Picker key={k} value={actionArgs[`${a.name}.${k}`] ?? o[0]?.value ?? ""}
                             onChange={(v) => setActionArgs({ ...actionArgs, [`${a.name}.${k}`]: v })}

--- a/ui/src/pages/UsecaseDetail.tsx
+++ b/ui/src/pages/UsecaseDetail.tsx
@@ -205,24 +205,6 @@ export default function UsecaseDetail() {
                     );
                   }
                   return (
-                      <span key={k}>
-                        <input type="text" placeholder={spec.label ?? k} aria-label={spec.label ?? k}
-                               list={suggestions.length ? listId : undefined}
-                               value={actionArgs[`${a.name}.${k}`] ?? ""} style={{ width: 300 }}
-                               onChange={(e) => setActionArgs({ ...actionArgs, [`${a.name}.${k}`]: e.target.value })} />
-                        {suggestions.length > 0 && (
-                          <datalist id={listId}>
-                            {suggestions.map((x) => (
-                              <option key={x.session} value={x.session}>
-                                {[x.project, x.branch, x.ended ? "ended" : "live"].filter(Boolean).join(" · ")}
-                              </option>
-                            ))}
-                          </datalist>
-                        )}
-                      </span>
-                    );
-                  }
-                  return (
                     <Picker key={k} value={actionArgs[`${a.name}.${k}`] ?? o[0]?.value ?? ""}
                             onChange={(v) => setActionArgs({ ...actionArgs, [`${a.name}.${k}`]: v })}
                             options={o.map((x) => x.value)}

--- a/ui/src/pages/UsecaseDetail.tsx
+++ b/ui/src/pages/UsecaseDetail.tsx
@@ -6,6 +6,7 @@ import { ErrorState, Picker, TimeAgo, usePolling } from "../components/bits";
 import ConfirmDialog from "../components/ConfirmDialog";
 import type { Recipe, RecipeActionOption, UsecaseObject, UsecaseSummary } from "../types";
 import InfoDialog, { HelpButton } from "../components/InfoDialog";
+import { ProposalsPanel, SessionsPanel } from "../components/ChallengerSessions";
 
 // One use case instance: what it created, what it has done lately, and the actions on the whole
 // (pause, resume, edit, delete). The objects are ordinary; this page is the combined view of them,
@@ -50,6 +51,12 @@ const HOW_IT_WORKS: Record<string, string[]> = {
     "The incident trigger fires when an alert event lands (Prometheus keeps owning alerting; nothing is re-thresholded).",
     "incident-first-look wakes with the correlated timeline and writes an incident note back onto it. Cause an incident above and watch it happen.",
   ],
+  challenger_workflow: [
+    "In Claude Code, /tares:challenger marks the session; the plugin then runs Codex on the plan when you leave plan mode and on every commit, and blocks on P1/P2 findings until fixed or waived.",
+    "The plugin streams the session, with every Codex review, into the claude_code source, keyed by session.",
+    "When the session ends, the trigger fires and the summarizer reads the whole session and writes a summary with memory proposals.",
+    "Accept a proposal below to store it as project memory; the plugin gives it to Claude at the start of the next session on that project.",
+  ],
   default: [
     "The use case created ordinary sources, views, triggers and agents; see Configuration for the list.",
     "Pause stops the trigger and agent; sources keep ingesting so the timeline stays complete.",
@@ -61,8 +68,10 @@ export default function UsecaseDetail() {
   const navigate = useNavigate();
   const { data: s, error, reload } = usePolling(() => api.usecaseSummary(id), 10000);
   const [actionError, setActionError] = useState<string>();
-  const [tab, setTab] = useState<"runs" | "config">(() =>
-    (new URLSearchParams(window.location.search).get("tab") === "config" ? "config" : "runs"));
+  const [tab, setTab] = useState<"runs" | "config" | "sessions">(() => {
+    const t = new URLSearchParams(window.location.search).get("tab");
+    return t === "config" || t === "sessions" ? t : "runs";
+  });
   const [confirmDel, setConfirmDel] = useState(false);
   const [purge, setPurge] = useState(false);
   const [busyKey, setBusyKey] = useState<string>();
@@ -71,6 +80,10 @@ export default function UsecaseDetail() {
   const [actionMsg, setActionMsg] = useState<string>();
   const [actionBusy, setActionBusy] = useState<string>();
   const [actionHelp, setActionHelp] = useState(false);
+  // a use case with sessions opens on them unless the URL asked for a tab
+  useEffect(() => {
+    if (s?.sessions && !new URLSearchParams(window.location.search).get("tab")) setTab("sessions");
+  }, [!!s?.sessions]); // eslint-disable-line react-hooks/exhaustive-deps
   useEffect(() => {
     if (!s?.recipe) return;
     api.recipes().then((r) => setRecipe(r.recipes.find((x) => x.key === s.recipe))).catch(() => {});
@@ -226,11 +239,15 @@ export default function UsecaseDetail() {
       )}
 
       <div className="tabs">
+        {s.sessions && <button className={tab === "sessions" ? "active" : ""} onClick={() => setTab("sessions")}>Sessions</button>}
         <button className={tab === "runs" ? "active" : ""} onClick={() => setTab("runs")}>Runs</button>
         <button className={tab === "config" ? "active" : ""} onClick={() => setTab("config")}>Configuration</button>
       </div>
 
+      {tab === "sessions" && s.sessions && <SessionsPanel sessions={s.sessions} view={s.names?.view ?? "challenger_session"} />}
+
       {tab === "runs" && (<>
+      {runs && <ProposalsPanel runs={runs} />}
       <div className="panel">
         <h2 style={{ marginTop: 0 }}>Runs</h2>
         {runs && runs.some((r) => r.first_look) && (
@@ -241,7 +258,7 @@ export default function UsecaseDetail() {
         )}
         {runs && runs.length > 0 ? (
           <table>
-            <thead><tr><th>when</th><th>repo</th><th>status</th><th>rounds</th><th>result</th></tr></thead>
+            <thead><tr><th>when</th><th>{s.sessions ? "session" : "repo"}</th><th>status</th><th>rounds</th><th>result</th></tr></thead>
             <tbody>
               {runs.map((r, i) => {
                 const link = prLink(r);

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -475,9 +475,22 @@ export interface UsecaseSummary extends Usecase {
   sources?: Record<string, { events: number; last: string | null }>;
   guide?: string;
   runs?: { id?: string; started_at?: string; key?: string; repo?: string; status?: string; rounds?: number; first_look?: boolean;
-           max_rounds?: number | null; pr_url?: string | null; agent?: string; finding?: string | null }[];
+           max_rounds?: number | null; pr_url?: string | null; agent?: string; finding?: string | null;
+           session?: string; project?: string | null; proposals?: string[] }[];
+  sessions?: ChallengerSession[];
+  names?: Record<string, string>;
   prs?: { open?: number; merged?: number };
   trigger_last_fired?: string | null;
   [k: string]: unknown;
+}
+export interface ChallengeEvent {
+  at: string; event_type: string; text: string; labels: Record<string, string>;
+}
+export interface ChallengerSession {
+  session: string; project?: string | null; branch?: string | null;
+  started_at?: string | null; last_at?: string | null; ended: boolean; events: number;
+  plan_verdict?: string | null; waived: number; run_id?: string | null;
+  commits: { sha?: string; verdict?: string; round?: string | number; findings?: string | number; blocking?: string | number }[];
+  thread: ChallengeEvent[];
 }
 export interface UsecaseUpdateReport { created: string[]; updated: string[]; kept: string[]; deleted: string[] }

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -489,7 +489,8 @@ export interface ChallengeEvent {
 export interface ChallengerSession {
   session: string; project?: string | null; branch?: string | null;
   started_at?: string | null; last_at?: string | null; ended: boolean; events: number;
-  plan_verdict?: string | null; waived: number; run_id?: string | null;
+  plan_verdict?: string | null; plan_findings?: string | number | null; plan_blocking?: string | number | null;
+  waived: number; run_id?: string | null;
   commits: { sha?: string; verdict?: string; round?: string | number; findings?: string | number; blocking?: string | number }[];
   thread: ChallengeEvent[];
 }

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -476,7 +476,8 @@ export interface UsecaseSummary extends Usecase {
   guide?: string;
   runs?: { id?: string; started_at?: string; key?: string; repo?: string; status?: string; rounds?: number; first_look?: boolean;
            max_rounds?: number | null; pr_url?: string | null; agent?: string; finding?: string | null;
-           session?: string; project?: string | null; proposals?: string[] }[];
+           session?: string; project?: string | null; proposals?: string[];
+           decisions?: Record<string, "accepted" | "rejected"> }[];
   sessions?: ChallengerSession[];
   names?: Record<string, string>;
   prs?: { open?: number; merged?: number };


### PR DESCRIPTION
Use case page for challenger_workflow:

- Sessions tab (default): every challenger session of the last 30 days with project, branch, the plan verdict, one badge per reviewed commit, waived count and state (live / ended / summarized). Opening a session shows the Claude/Codex exchange as one thread (challenge events only) with a switch to the whole session read through the view.
- Memory proposals panel on the Runs tab: the proposals inside each summarizer finding, with Accept and Reject. Accept POSTs /remember with key=<project>, memory_type=decision; reject only hides the line (decision kept in localStorage). Nothing is written to memory without an accept.
- Summary API gains `sessions` (built from the claude_code events carrying flow=challenger) and `project` on runs.

Test: tests/test_challenger_workflow.py covers the sessions summary. Console type-checks and builds.

Also: the first ingested line stamped flow=challenger creates the challenger_workflow use case (once, best effort, never fails the ingest), so /tares:challenger in Claude Code is the whole setup. Covered in tests/test_challenger_workflow.py.