### PR TITLE
Challenger thread shows every finding in full

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ the project follows [Semantic Versioning](https://semver.org/).
   `POST /api/projects {"template": "custom", "name": ..., "objects": [{"kind", "name"}, ...]}`;
   catalog YAML takes the same shape.
 
+### Fixed
+- The challenger session thread showed only the first three findings of a review, cut mid-word
+  at 500 characters. The thread now lists every finding in full (from the event payload, so
+  sessions already recorded get it too), and challenge events keep their whole text.
+
 ### Changed
 - **Use cases are now projects; recipes are templates.** A project is a named set of sources,
   views, triggers, agents and MCP servers with one page; the shipped recipes are Tares

--- a/tares/connectors/claude_code.py
+++ b/tares/connectors/claude_code.py
@@ -140,7 +140,10 @@ class ClaudeCodeConnector(Connector):
         if o.get("type") in self.CHALLENGE_TYPES:
             labels.update(self._challenge_labels(o))
 
-        text = self._render_text(o, msg, include_thinking)[:500]
+        # challenge events carry the whole review; chopping them mid-finding is what the 500-char
+        # cap would do, and the summarizer reads this text
+        cap = 4000 if o.get("type") in self.CHALLENGE_TYPES else 500
+        text = self._render_text(o, msg, include_thinking)[:cap]
         if redact:
             text = _redact(text)
 
@@ -201,9 +204,9 @@ class ClaudeCodeConnector(Connector):
         typ = o.get("type")
         verdict = str(ch.get("verdict") or "?").upper()
         n, b = ch.get("finding_count", 0), ch.get("blocking_count", 0)
-        findings = ", ".join(f"[{f.get('priority')}] {f.get('title')}"
-                             for f in (ch.get("findings") or [])[:3] if isinstance(f, dict))
-        tail = f": {findings}" if findings else ""
+        findings = "\n".join(f"[{f.get('priority')}] {f.get('title')}"
+                              for f in (ch.get("findings") or []) if isinstance(f, dict))
+        tail = f"\n{findings}" if findings else ""
         if typ == "challenge_plan":
             what = f"Challenger reviewed the plan {ch.get('plan') or ''}".rstrip()
         elif typ == "challenge_commit":

--- a/tares/projects/challenger_workflow.py
+++ b/tares/projects/challenger_workflow.py
@@ -324,8 +324,15 @@ def recent_sessions(store) -> list[dict]:
                                     "blocking": lbls.get("blocking_count")})
         elif typ == "challenge_waived":
             sess["waived"] += 1
-        sess["thread"].append({"at": _iso(event_time), "event_type": typ, "text": text or "",
-                               "labels": lbls})
+        entry = {"at": _iso(event_time), "event_type": typ, "text": text or "", "labels": lbls}
+        ch = raw.get("challenge") if isinstance(raw.get("challenge"), dict) else {}
+        if ch.get("findings"):
+            # the full findings, from the lossless payload: the event text is capped and older
+            # events carried only the first three findings in it
+            entry["findings"] = [{"priority": f.get("priority"), "title": f.get("title"),
+                                  "waived": bool(f.get("waived"))}
+                                 for f in ch["findings"] if isinstance(f, dict)]
+        sess["thread"].append(entry)
     out = sorted(by_session.values(), key=lambda x: x["last_at"] or "", reverse=True)
     return out[:MAX_SESSIONS]
 

--- a/tests/test_challenger_workflow.py
+++ b/tests/test_challenger_workflow.py
@@ -178,11 +178,16 @@ async def main(app):
                 line("s1", "challenge_commit", ts(10),
                      challenge={"verdict": "PASS", "sha": "abc1234", "finding_count": 0,
                                 "blocking_count": 0, "duration_seconds": 30, "findings": []}),
+                line("s1", "challenge_plan", ts(8),
+                     challenge={"verdict": "FAIL", "plan": "p.md", "finding_count": 5,
+                                "blocking_count": 2, "findings": [
+                                    {"priority": "P1", "title": "finding " + str(i) + " " + "x" * 150,
+                                     "waived": False} for i in range(5)]}),
                 line("s1", "session_end", ts(1)),
             ]) + "\n"
             rr = await cx.post(f"/ingest/{SOURCE}", content=body,
                                headers={"content-type": "application/x-ndjson"})
-            check("session lines ingested", rr.status_code == 202 and rr.json()["ingested"] == 4, rr.text[:200])
+            check("session lines ingested", rr.status_code == 202 and rr.json()["ingested"] == 5, rr.text[:200])
             # an unmarked session that ends must not fire
             rr = await cx.post(f"/ingest/{SOURCE}", content=json.dumps(
                 {"sessionId": "s2", "type": "session_end", "cwd": "/x", "timestamp": ts(1)}) + "\n",
@@ -206,7 +211,7 @@ async def main(app):
             print("== summary and action ==")
             s = (await cx.get(f"/api/projects/{uid}/summary")).json()
             check("summary counts events and names the objects",
-                  s["events"] == 8 and s["names"]["agent"] == AGENT and "runs" in s, json.dumps(s)[:300])
+                  s["events"] == 9 and s["names"]["agent"] == AGENT and "runs" in s, json.dumps(s)[:300])
             sess = {x["session"]: x for x in s["sessions"]}
             check("summary lists the marked sessions only", set(sess) == {"s0", "s1"}, json.dumps(s["sessions"])[:400])
             s1 = sess.get("s1") or {}
@@ -217,9 +222,15 @@ async def main(app):
             check("events carry a repo label, not project",
                   any(l.get("repo") == "shop" for l in lbls) and not any("project" in l for l in lbls),
                   json.dumps(lbls)[:300])
+            plan_ev = next((t for t in s1.get("thread", []) if t["event_type"] == "challenge_plan"), {})
+            check("a plan review's thread entry carries every finding in full",
+                  len(plan_ev.get("findings") or []) == 5
+                  and all(len(f["title"]) > 150 for f in plan_ev["findings"]), json.dumps(plan_ev)[:300])
+            check("the challenge text is not chopped at 500 characters",
+                  len(plan_ev.get("text") or "") > 500 and "finding 4" in plan_ev["text"], str(len(plan_ev.get("text") or "")))
             check("session carries the commit verdict and thread",
                   s1.get("commits") and s1["commits"][0]["verdict"] == "PASS" and s1.get("ended")
-                  and [t["event_type"] for t in s1["thread"]] == ["session_flow", "challenge_commit", "session_end"],
+                  and [t["event_type"] for t in s1["thread"]] == ["session_flow", "challenge_commit", "challenge_plan", "session_end"],
                   json.dumps(s1)[:400])
             rr = await cx.post(f"/api/projects/{uid}/actions/summarize", json={})
             check("summarize without a session -> 400", rr.status_code == 400, rr.text[:200])

--- a/tests/test_session_flow.py
+++ b/tests/test_session_flow.py
@@ -55,7 +55,7 @@ def main():
        and e.labels.get("duration_seconds") == 41.5, str(e.labels))
     ck("flow label rides along", e.labels.get("flow") == "challenger")
     ck("text summarizes the review",
-       e.text.startswith("Challenger reviewed commit abcdef12, round 2: 2 findings (1 blocking): [P1] Null deref"), e.text)
+       e.text.startswith("Challenger reviewed commit abcdef12, round 2: 2 findings (1 blocking)\n[P1] Null deref"), e.text)
     ck("prose in payload is redacted", "ghp_" not in str(e.payload), str(e.payload)[:200])
 
     plan = {"sessionId": "s1", "type": "challenge_plan", "cwd": "/tmp/proj",
@@ -66,7 +66,7 @@ def main():
     waived = {"sessionId": "s1", "type": "challenge_waived", "cwd": "/tmp/proj",
               "challenge": {"findings": [{"priority": "P2", "title": "Missing test"}]}}
     e = c.map_payload(waived)[0]
-    ck("challenge_waived text", e.text == "Challenger finding waived: [P2] Missing test", e.text)
+    ck("challenge_waived text", e.text == "Challenger finding waived\n[P2] Missing test", e.text)
 
     tools = asyncio.run(mcp_server.mcp.list_tools())
     ck("set_session_flow is an MCP tool", any(t.name == "set_session_flow" for t in tools))

--- a/ui/src/components/ChallengerSessions.tsx
+++ b/ui/src/components/ChallengerSessions.tsx
@@ -150,8 +150,28 @@ function SessionThread({ s, view, onClose }: { s: ChallengerSession; view: strin
                 <tr key={i}>
                   <td style={{ whiteSpace: "nowrap" }}><TimeAgo ts={t.at} /></td>
                   <td>
-                    <span className="mono" style={{ whiteSpace: "pre-wrap" }}>{t.text}</span>
-                    {t.labels.verdict && <span className="tl-labels"><Verdict v={t.labels.verdict} findings={t.labels.finding_count} blocking={t.labels.blocking_count} /></span>}
+                    {t.findings?.length ? (
+                      <>
+                        {/* the first line of the text is the header; the findings themselves come
+                            from the payload, complete (the event text is capped) */}
+                        <span className="mono">{t.text.split("\n")[0].split(": [P")[0]}</span>
+                        {t.labels.verdict && <span className="tl-labels"><Verdict v={t.labels.verdict} findings={t.labels.finding_count} blocking={t.labels.blocking_count} /></span>}
+                        <ul style={{ margin: "6px 0 0", paddingLeft: 18 }}>
+                          {t.findings.map((f, j) => (
+                            <li key={j} className={f.waived ? "dim" : undefined} style={{ marginBottom: 2 }}>
+                              {f.priority && <span className="badge" style={{ marginRight: 6 }}>{f.priority}</span>}
+                              <span className="mono" style={{ whiteSpace: "pre-wrap" }}>{f.title}</span>
+                              {f.waived && <span className="help"> waived</span>}
+                            </li>
+                          ))}
+                        </ul>
+                      </>
+                    ) : (
+                      <>
+                        <span className="mono" style={{ whiteSpace: "pre-wrap" }}>{t.text}</span>
+                        {t.labels.verdict && <span className="tl-labels"><Verdict v={t.labels.verdict} findings={t.labels.finding_count} blocking={t.labels.blocking_count} /></span>}
+                      </>
+                    )}
                   </td>
                 </tr>
               ))}

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -492,6 +492,7 @@ export interface ProjectSummary extends Project {
 }
 export interface ChallengeEvent {
   at: string; event_type: string; text: string; labels: Record<string, string>;
+  findings?: { priority?: string; title?: string; waived?: boolean }[];
 }
 export interface ChallengerSession {
   session: string; repo?: string | null; branch?: string | null;


### PR DESCRIPTION
Fixes TR-213.

A challenge review's event text was capped at 500 characters and carried only the first three findings, so the session thread showed a review cut mid-word. The thread now lists every finding in full (from the event payload, so sessions already recorded get it too), and challenge events keep their whole text, one finding per line.