### PR TITLE
Rerun an agent run; runs open with the previous finding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ the project follows [Semantic Versioning](https://semver.org/).
   `POST /api/projects {"template": "custom", "name": ..., "objects": [{"kind", "name"}, ...]}`;
   catalog YAML takes the same shape.
 
+### Added
+- A run that did not work (failed, out of rounds, capped, or empty) has a **Rerun** button on the
+  agent page: the agent runs again with the same inputs, same trigger, same entity, and the
+  firing's data when a firing woke it. `POST /api/agents/builtin/{name}/runs/{run_id}/rerun`.
+
 ### Fixed
 - The challenger session thread showed only the first three findings of a review, cut mid-word
   at 500 characters. The thread now lists every finding in full (from the event payload, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ the project follows [Semantic Versioning](https://semver.org/).
   catalog YAML takes the same shape.
 
 ### Added
+- An agent run now opens with the agent's previous finding for the same entity, so it builds on
+  its earlier conclusion instead of rediscovering it. Most useful for context-maintaining
+  agents, where the last summary is a head start.
 - A run that did not work (failed, out of rounds, capped, or empty) has a **Rerun** button on the
   agent page: the agent runs again with the same inputs, same trigger, same entity, and the
   firing's data when a firing woke it. `POST /api/agents/builtin/{name}/runs/{run_id}/rerun`.

--- a/tares/builtin_agents.py
+++ b/tares/builtin_agents.py
@@ -416,10 +416,17 @@ class AgentRunner:
         tools = TOOL_DEFS + toolbox.tool_defs
         max_rounds = effective_max_rounds(agent)
         external_used: list[str] = []
+        # The agent's own last conclusion for this entity, so a run builds on the previous one
+        # instead of rediscovering it (worth real rounds for a context-maintaining agent). Capped:
+        # it is a head start, not a second timeline.
+        prior = self.store.last_finding(FINDINGS_SOURCE, agent["name"], key)
+        prior_block = (f'Your finding from an earlier run on "{key}":\n\n{prior[:4000]}\n\n'
+                       if prior else "")
         messages = [{
             "role": "user",
             "content": (
                 f'The condition "{trigger_name}" tripped for "{key}".\n\n'
+                f"{prior_block}"
                 f"The correlated timeline at that moment:\n\n{payload}\n\n"
                 f"Take a first look, per your instructions. You already hold the evidence above; "
                 f"read again only if you need a wider window or a different entity."),

--- a/tares/daemon.py
+++ b/tares/daemon.py
@@ -1732,6 +1732,28 @@ def make_app() -> FastAPI:
         store.remove_subscription_by_url(agent_url(name))
         return {"ok": True, "enabled": False}
 
+    @app.post("/api/agents/builtin/{name}/runs/{run_id}/rerun", status_code=201)
+    async def rerun_builtin_agent(name: str, run_id: str):
+        """Run the agent again with the same inputs as an earlier run: same trigger, same key,
+        and the firing's payload when a firing woke it (a manual or bootstrap run reruns with an
+        empty note; the timeline the agent reads is the real input either way). Same run record,
+        caps and dedupe as any run."""
+        if store.get_catalog_agent(name) is None:
+            _err(KeyError(f"unknown agent {name!r}"), 404)
+        run = store.get_agent_run(run_id)
+        if run is None or run["agent"] != name:
+            _err(KeyError(f"unknown run {run_id!r} for agent {name!r}"), 404)
+        if run["status"] == "running":
+            _err(ValueError("that run is still going; wait for it to finish"))
+        payload = ""
+        if run.get("dispatch_id"):
+            d = store.get_dispatch(run["dispatch_id"])
+            payload = (d or {}).get("payload") or ""
+        rid = dispatcher.agents.run_now(name, run["trigger"], run["key"], payload)
+        if rid is None:
+            _err(ValueError(f"the agent is already running for {run['key']!r}"), 409)
+        return {"ok": True, "run_id": rid, "rerun_of": run_id}
+
     @app.get("/api/agents/builtin/{name}/runs")
     async def builtin_agent_runs(name: str, limit: int = 50):
         """The operational record — status, duration, errors. Distinct from findings, which are

--- a/tares/store.py
+++ b/tares/store.py
@@ -1583,6 +1583,22 @@ class Store:
             for r in rows
         ]
 
+    def last_finding(self, source: str, agent: str, key: str) -> str | None:
+        """The newest delivered finding this agent wrote for this key, or None. Feeds the next
+        run's opening message so it builds on the earlier conclusion instead of rediscovering."""
+        with self._lock:
+            rows = self.con.execute(
+                "SELECT payload FROM events WHERE source = ? AND key_value = ? "
+                "ORDER BY ingest_time DESC LIMIT 20", [source, key]).fetchall()
+        for (pj,) in rows:
+            try:
+                p = json.loads(pj) if pj else {}
+            except (TypeError, ValueError):
+                continue
+            if p.get("agent") == agent and p.get("finding"):
+                return str(p["finding"])
+        return None
+
     def recent_payloads(self, source: str, limit: int = 500) -> list[dict]:
         """The lossless payloads of a source's most recent events (for field profiling)."""
         with self._lock:

--- a/tares/store.py
+++ b/tares/store.py
@@ -1142,6 +1142,14 @@ class Store:
             "window_days": int(days),
         }
 
+    def get_agent_run(self, run_id: str) -> dict | None:
+        """One run by id, in the list_agent_runs shape."""
+        with self._lock:
+            row = self.con.execute("SELECT agent FROM agent_runs WHERE id = ?", [run_id]).fetchone()
+        if row is None:
+            return None
+        return next((r for r in self.list_agent_runs(row[0], limit=100000) if r["id"] == run_id), None)
+
     def agent_runs_today(self, agent: str, exclude_run_id: str | None = None) -> int:
         """Runs started in the last 24h — the cost ceiling's counter. `exclude_run_id` leaves out the
         run being checked: the row is inserted before the cap is evaluated, so the cap must count the

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -313,6 +313,39 @@ async def main():
        str(st.agent_runs_today("hot-loop")))
     st.con.close()
 
+    # ── rerun: run again with the same inputs as an earlier run ──────────────
+    os.environ["TARES_DB"] = "/tmp/agents_rerun.duckdb"
+    os.environ.pop("TARES_CATALOG", None)
+    os.environ.pop("ANTHROPIC_API_KEY", None)
+    for pth in ("/tmp/agents_rerun.duckdb", "/tmp/agents_rerun.duckdb.wal"):
+        if os.path.exists(pth):
+            os.remove(pth)
+    from tares.daemon import make_app
+    app = make_app()
+    async with app.router.lifespan_context(app):
+        async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://t") as cx:
+            st2 = app.state.store
+            st2.upsert_catalog_agent("fixer", "incident", "Take a first look.")
+            st2.start_agent_run("run_old", "fixer", "incident", "d_x", "checkout", "h")
+            st2.finish_agent_run("run_old", "failed", error="boom")
+            st2.log_dispatch("d_x", "incident", "checkout", "incident", 1, 1, "the firing payload")
+            r = await cx.post("/api/agents/builtin/fixer/runs/run_old/rerun")
+            ck("rerun -> 201 with a new run id",
+               r.status_code == 201 and r.json()["run_id"] != "run_old", r.text[:200])
+            rid = r.json()["run_id"]
+            rows = {x["id"]: x for x in st2.list_agent_runs("fixer")}
+            ck("the new run has the same trigger and key",
+               rid in rows and rows[rid]["trigger"] == "incident" and rows[rid]["key"] == "checkout",
+               str(rows.get(rid)))
+            ck("rerun of an unknown run -> 404",
+               (await cx.post("/api/agents/builtin/fixer/runs/run_nope/rerun")).status_code == 404)
+            st2.upsert_catalog_agent("other", "incident", "x")
+            ck("rerun under the wrong agent -> 404",
+               (await cx.post("/api/agents/builtin/other/runs/run_old/rerun")).status_code == 404)
+            st2.start_agent_run("run_live", "fixer", "incident", "d_y", "pay", "h")
+            r = await cx.post("/api/agents/builtin/fixer/runs/run_live/rerun")
+            ck("rerun of a running run -> 400", r.status_code == 400, r.text[:200])
+
     print(f"\n{P} passed, {F} failed")
 
 asyncio.run(main())

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -213,6 +213,18 @@ async def main():
             ck("finding is on the entity's timeline", FINDING in rd["payload"], rd["payload"][:200])
             ck("findings source contributes to the read", "findings" in rd["sources"], str(rd["sources"]))
 
+            # ── the next run opens with the previous finding (a head start) ──
+            await asyncio.sleep(1.2)   # past the trigger cooldown
+            for i in range(3):
+                await cx.post(f"{B}/ingest/evt", json={"service": "checkout", "msg": f"500 again #{i}"})
+            async def _ran_again():
+                rs = (await cx.get(f"{B}/api/agents/builtin/first-look/runs")).json()
+                return len(rs) >= 2 and rs[0]["status"] != "running"
+            ck("a second run completed", await _until(_ran_again), "no second run")
+            opening = str(_calls[-1]["messages"][0]["content"])
+            ck("the second run opens with the first run's finding",
+               "earlier run" in opening and FINDING in opening, opening[:300])
+
             srcs = {s["name"]: s for s in (await cx.get(f"{B}/api/sources")).json()}
             ck("findings source auto-provisioned", "findings" in srcs, str(list(srcs)))
 

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -167,6 +167,10 @@ export const api = {
   disableBuiltinAgent: (name: string) => request(`/api/agents/builtin/${name}/disable`, { method: "POST" }),
   builtinAgentRuns: (name: string, limit = 20) =>
     request<AgentRun[]>(`/api/agents/builtin/${name}/runs?limit=${limit}`),
+  rerunAgentRun: (name: string, runId: string) =>
+    request<{ ok: boolean; run_id: string }>(
+      `/api/agents/builtin/${encodeURIComponent(name)}/runs/${encodeURIComponent(runId)}/rerun`,
+      { method: "POST" }),
   // The cell's Anthropic spend meter: totals + per-day, split agent runs vs Ask.
   modelUsage: (days = 30) => request<ModelUsage>(`/api/usage/model?days=${days}`),
 

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -308,6 +308,22 @@ function RunsTable({ runs, runsError, agent, focusDispatch, focusRun, openRun, s
 function RunRow({ r, open, focused, onToggle }: {
   r: AgentRun; open: boolean; focused: boolean; onToggle: () => void;
 }) {
+  const navigate = useNavigate();
+  const [rerunBusy, setRerunBusy] = useState(false);
+  const [rerunErr, setRerunErr] = useState<string>();
+  const rerunnable = ["failed", "exhausted", "capped", "empty"].includes(r.status);
+  const rerun = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setRerunBusy(true); setRerunErr(undefined);
+    try {
+      const out = await api.rerunAgentRun(r.agent, r.id);
+      navigate(`/agents/${encodeURIComponent(r.agent)}?run=${encodeURIComponent(out.run_id)}`);
+    } catch (err) {
+      setRerunErr(String((err as Error).message ?? err));
+    } finally {
+      setRerunBusy(false);
+    }
+  };
   // A dash on an old run means unknown, not zero: usage was not recorded before cost tracking.
   const hasTokens = r.input_tokens != null || r.output_tokens != null;
   const cache = (r.cache_creation_input_tokens ?? 0) + (r.cache_read_input_tokens ?? 0);
@@ -364,6 +380,15 @@ function RunRow({ r, open, focused, onToggle }: {
                 </p>
               )}
               {exhaustedNote}
+              {rerunnable && (
+                <div className="btnrow" style={{ margin: "0 0 8px" }}>
+                  <button onClick={rerun} disabled={rerunBusy}
+                          title="run again with the same inputs: same trigger, same entity, and the firing's data if one woke it">
+                    {rerunBusy ? "starting…" : "Rerun"}
+                  </button>
+                  {rerunErr && <span className="help" style={{ color: "var(--err)" }}>{rerunErr}</span>}
+                </div>
+              )}
               {r.finding
                 ? <div className="md">
                     <ReactMarkdown remarkPlugins={[remarkGfm]}>{r.finding}</ReactMarkdown>


### PR DESCRIPTION
TR-214.

- `POST /api/agents/builtin/{name}/runs/{run_id}/rerun` runs the agent again with the same trigger, entity and firing payload; the agent definition (prompt, model, max rounds) is read fresh, so raising max rounds before a rerun takes effect. The agent page offers Rerun on runs that failed, ran out of rounds, were capped or came back empty.
- A run's opening message now starts with the agent's previous delivered finding for the same entity, so it builds on the earlier conclusion instead of rediscovering it.