### PR TITLE
A per-agent budget; the hosted demo agent is born with $2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 Notable changes to Tares (formerly NavFlow). Format follows [Keep a Changelog](https://keepachangelog.com/);
 the project follows [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+- **A per-agent budget.** `budget_usd` on a Tares agent caps its lifetime spend, counted from
+  its run log; once reached, runs are capped before any model call and the run says where to
+  raise or clear it (Configuration, Advanced). In the catalog YAML and the API alike.
+- On a hosted demo stack, the AI SRE demo's agent is born with a $2 budget: the shared stack
+  fires around the clock, and an idle trial cell would otherwise burn its whole credit over a
+  weekend.
+
 ## [1.14.0] - 2026-08-31
 
 ### Added

--- a/tares/builtin_agents.py
+++ b/tares/builtin_agents.py
@@ -335,6 +335,14 @@ class AgentRunner:
             msg = f"cap of {DAILY_RUN_CAP} runs in the last 24h reached for this agent"
             self.store.finish_agent_run(run_id, "capped", error=msg)
             return "capped", msg
+        # The agent's own budget, when set: lifetime spend from the run log. Checked before any
+        # model call, so a capped run costs nothing; the message says where to raise it.
+        budget = agent.get("budget_usd")
+        if budget and self.store.agent_cost_total(agent["name"]) >= float(budget):
+            msg = (f"budget of ${float(budget):.2f} for this agent reached; "
+                   f"raise or clear it under Configuration, Advanced")
+            self.store.finish_agent_run(run_id, "capped", error=msg)
+            return "capped", msg
 
         # Usage accumulates in a mutable dict rather than the loop's return value, so a run that
         # dies mid-loop still records the tokens it already paid for (the finally below).

--- a/tares/config.py
+++ b/tares/config.py
@@ -130,6 +130,7 @@ class AgentCfg:
     webhook_token: str = ""   # optional bearer token for the write-back (a secret)
     mcp_servers: list = dc_field(default_factory=list)   # registry names this agent may use
     max_rounds: int | None = None   # model rounds per run; None = default for the agent's shape
+    budget_usd: float | None = None  # lifetime spend cap in USD; None = no budget
     enabled: bool = False
 
 
@@ -236,6 +237,7 @@ def _agent_from_dict(a: dict, enabled: bool = False) -> AgentCfg:
         webhook_token=a.get("webhook_token") or "",
         mcp_servers=list(a.get("mcp_servers") or []),
         max_rounds=(int(a["max_rounds"]) if a.get("max_rounds") not in (None, "") else None),
+        budget_usd=(float(a["budget_usd"]) if a.get("budget_usd") not in (None, "") else None),
         enabled=bool(a.get("enabled", enabled)),
     )
 
@@ -361,6 +363,8 @@ def import_catalog_dict(store, raw: dict, engine=None) -> dict:
                                    a.get("webhook_url"), a.get("webhook_token"),
                                    a.get("mcp_servers"),
                                    (int(a["max_rounds"]) if a.get("max_rounds") not in (None, "")
+                                    else None),
+                                   (float(a["budget_usd"]) if a.get("budget_usd") not in (None, "")
                                     else None))
         # enabled ⟺ a subscription to the trigger. Reflect the document's state so an enabled agent
         # round-trips: add the internal subscription if enabled, remove it if not.
@@ -488,6 +492,7 @@ def export_db_to_yaml(store, sources: list | None = None, include_secrets: bool 
          **({"webhook_url": a["webhook_url"]} if a.get("webhook_url") else {}),
          **({"mcp_servers": a["mcp_servers"]} if a.get("mcp_servers") else {}),
          **({"max_rounds": a["max_rounds"]} if a.get("max_rounds") else {}),
+         **({"budget_usd": a["budget_usd"]} if a.get("budget_usd") else {}),
          **({"slack_webhook": a["slack_webhook"]}
             if include_secrets and a.get("slack_webhook") else {}),
          **({"webhook_token": a["webhook_token"]}
@@ -789,6 +794,15 @@ def validate_agent_dict(a: dict, trigger_names: set, triggers: dict | None = Non
         if not 1 <= mr <= MAX_AGENT_ROUNDS:
             raise CatalogError(f"agent {a['name']!r}: max_rounds must be between 1 and "
                                f"{MAX_AGENT_ROUNDS} (or empty for the default)")
+    b = a.get("budget_usd")
+    if b not in (None, ""):
+        try:
+            b = float(b)
+        except (TypeError, ValueError):
+            raise CatalogError(f"agent {a['name']!r}: budget_usd must be a number")
+        if b <= 0:
+            raise CatalogError(f"agent {a['name']!r}: budget_usd must be above zero "
+                               "(or empty for no budget)")
 
     # Loop guard: a Tares agent writes a finding into the `findings` source. If its trigger
     # watches a view containing that source, the finding re-fires the trigger, which runs the agent

--- a/tares/daemon.py
+++ b/tares/daemon.py
@@ -298,6 +298,7 @@ class AgentIn(BaseModel):
     slack_webhook_clear: bool = False   # blank means keep (it is a secret), so clearing is explicit
     mcp_servers: list[str] = []  # registry names this agent may use
     max_rounds: int | None = None   # model rounds per run; None = default (6, or 12 with MCP servers)
+    budget_usd: float | None = None  # lifetime spend cap in USD; None = no budget
 
 
 class ImportReq(BaseModel):
@@ -1647,6 +1648,7 @@ def make_app() -> FastAPI:
                          "webhook_token_configured": bool(a.get("webhook_token")),
                          "mcp_servers": a.get("mcp_servers") or [],
                          "max_rounds": a.get("max_rounds"),
+                         "budget_usd": a.get("budget_usd"),
                          "effective_max_rounds": effective_max_rounds(a),
                          "enabled": _agent_enabled(a["name"]), "updated_at": a.get("updated_at"),
                          "owned_by": a.get("owned_by"), "customized": bool(a.get("customized")),
@@ -1667,7 +1669,7 @@ def make_app() -> FastAPI:
         store.upsert_catalog_agent(body.name, body.trigger, body.prompt, body.slack_webhook,
                                    body.model, body.slack_channel,
                                    body.webhook_url, body.webhook_token, body.mcp_servers,
-                                   body.max_rounds)
+                                   body.max_rounds, body.budget_usd)
         runtime.reload_catalog()
         return {"ok": True, "enabled": False,
                 "note": "agents start disabled; enable it to run on the next firing"}
@@ -1690,7 +1692,8 @@ def make_app() -> FastAPI:
         # so what the body says is what the user wants — including blank (removed).
         store.upsert_catalog_agent(name, body.trigger, body.prompt, hook,
                                    body.model, body.slack_channel,
-                                   body.webhook_url, wtoken, body.mcp_servers, body.max_rounds)
+                                   body.webhook_url, wtoken, body.mcp_servers, body.max_rounds,
+                                   body.budget_usd)
         store.mark_customized("agent", name)
         # if the trigger changed while enabled, re-point the subscription so the agent fires on the
         # new trigger (the subscription, not the definition, is what the dispatcher reads).

--- a/tares/projects/ai_sre_demo.py
+++ b/tares/projects/ai_sre_demo.py
@@ -261,6 +261,11 @@ class AiSreDemo(Template):
         agent = {"name": "incident-first-look", "trigger": "incident", "enabled": True, "prompt": PROMPT}
         if params.get("model"):
             agent["model"] = params["model"]
+        if _hosted():
+            # The hosted demo stack is shared and fires around the clock, so an idle cell would
+            # keep running the agent every cooldown until its trial credit was gone. $2 covers a
+            # real look at the demo; the run that hits the cap says where to raise it.
+            agent["budget_usd"] = 2.0
         objs.append(PlannedObject("agent", "agent", agent))
         return objs
 

--- a/tares/store.py
+++ b/tares/store.py
@@ -262,6 +262,7 @@ _MIGRATIONS = [
     "ALTER TABLE catalog_agents ADD COLUMN IF NOT EXISTS mcp_servers JSON",
     "ALTER TABLE agent_runs ADD COLUMN IF NOT EXISTS external_tools JSON",
     "ALTER TABLE catalog_agents ADD COLUMN IF NOT EXISTS max_rounds INTEGER",
+    "ALTER TABLE catalog_agents ADD COLUMN IF NOT EXISTS budget_usd DOUBLE",
     "ALTER TABLE agent_runs ADD COLUMN IF NOT EXISTS max_rounds INTEGER",
     # extra, non-secret headers an MCP server wants on every request (toolset selection, read-only
     # mode); the auth header stays its own column because it is the secret
@@ -943,30 +944,32 @@ class Store:
                              slack_channel: str | None = None, webhook_url: str | None = None,
                              webhook_token: str | None = None,
                              mcp_servers: list[str] | None = None,
-                             max_rounds: int | None = None) -> None:
+                             max_rounds: int | None = None,
+                             budget_usd: float | None = None) -> None:
         ts = now_utc()
         with self._lock:
             self.con.execute(
                 "INSERT INTO catalog_agents "
                 "(name, trigger, prompt, slack_webhook, model, slack_channel, "
-                "webhook_url, webhook_token, mcp_servers, max_rounds, created_at, updated_at) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
+                "webhook_url, webhook_token, mcp_servers, max_rounds, budget_usd, created_at, updated_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
                 "ON CONFLICT (name) DO UPDATE SET trigger = excluded.trigger, "
                 "prompt = excluded.prompt, slack_webhook = excluded.slack_webhook, "
                 "model = excluded.model, slack_channel = excluded.slack_channel, "
                 "webhook_url = excluded.webhook_url, webhook_token = excluded.webhook_token, "
                 "mcp_servers = excluded.mcp_servers, max_rounds = excluded.max_rounds, "
+                "budget_usd = excluded.budget_usd, "
                 "updated_at = excluded.updated_at",
                 [name, trigger, prompt, slack_webhook or "", model or "",
                  slack_channel or "", webhook_url or "", webhook_token or "",
-                 json.dumps(mcp_servers or []), max_rounds, ts, ts],
+                 json.dumps(mcp_servers or []), max_rounds, budget_usd, ts, ts],
             )
 
     def list_catalog_agents(self) -> list[dict]:
         with self._lock:
             rows = self.con.execute(
                 "SELECT name, trigger, prompt, slack_webhook, model, slack_channel, "
-                "webhook_url, webhook_token, mcp_servers, updated_at, max_rounds, owned_by, customized "
+                "webhook_url, webhook_token, mcp_servers, updated_at, max_rounds, budget_usd, owned_by, customized "
                 "FROM catalog_agents ORDER BY name"
             ).fetchall()
         return [
@@ -974,7 +977,7 @@ class Store:
              "model": r[4] or "", "slack_channel": r[5] or "",
              "webhook_url": r[6] or "", "webhook_token": r[7] or "",
              "mcp_servers": json.loads(r[8]) if r[8] else [], "updated_at": r[9],
-             "max_rounds": r[10], "owned_by": r[11], "customized": bool(r[12])}
+             "max_rounds": r[10], "budget_usd": r[11], "owned_by": r[12], "customized": bool(r[13])}
             for r in rows
         ]
 
@@ -1149,6 +1152,13 @@ class Store:
         if row is None:
             return None
         return next((r for r in self.list_agent_runs(row[0], limit=100000) if r["id"] == run_id), None)
+
+    def agent_cost_total(self, agent: str) -> float:
+        """Lifetime spend of one agent, from the run log (the budget_usd cap counts against it)."""
+        with self._lock:
+            r = self.con.execute("SELECT COALESCE(SUM(cost_usd), 0) FROM agent_runs "
+                                 "WHERE agent = ?", [agent]).fetchone()
+        return float(r[0] or 0)
 
     def agent_runs_today(self, agent: str, exclude_run_id: str | None = None) -> int:
         """Runs started in the last 24h — the cost ceiling's counter. `exclude_run_id` leaves out the

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -358,6 +358,42 @@ async def main():
             r = await cx.post("/api/agents/builtin/fixer/runs/run_live/rerun")
             ck("rerun of a running run -> 400", r.status_code == 400, r.text[:200])
 
+            # ── budget_usd: a lifetime spend cap enforced before any model call ──
+            os.environ["ANTHROPIC_API_KEY"] = "sk-test-budget"   # so runs get past the key check
+            r = await cx.post("/api/catalog/import", json={"yaml": (
+                "sources:\n  - name: evt2\n    connector: webhook\n    poll: 5s\n"
+                "    config: {event_type: log, text_template: '{msg}', labels: [{name: service, const: checkout, primary: true}]}\n"
+                "views:\n  - name: svc2\n    key_field: service\n    sources: [evt2]\n"
+                "triggers:\n  - name: incident2\n    view: svc2\n"
+                "    condition: {aggregate: count, predicate: '>= 2', window: 1m, group_by: [key_value]}\n"
+                "    cooldown: 1s\n")})
+            ck("budget fixture catalog imported", r.status_code == 200, r.text[:200])
+            r = await cx.post("/api/agents/builtin", json={
+                "name": "thrifty", "trigger": "incident2", "prompt": "x", "budget_usd": -1})
+            ck("negative budget -> 400", r.status_code == 400 and "budget_usd" in r.text, r.text[:200])
+            r = await cx.post("/api/agents/builtin", json={
+                "name": "thrifty", "trigger": "incident2", "prompt": "x", "budget_usd": 2})
+            ck("agent with a budget created", r.status_code == 201, r.text[:200])
+            ag = next(x for x in (await cx.get("/api/agents/builtin")).json()["agents"]
+                      if x["name"] == "thrifty")
+            ck("the budget is reported", ag["budget_usd"] == 2, str(ag.get("budget_usd")))
+            st2.start_agent_run("run_b1", "thrifty", "incident2", "d_b", "checkout", "h")
+            st2.finish_agent_run("run_b1", "failed", error="boom")
+            st2.record_run_usage("run_b1", "claude-sonnet-4-6", 100, 50, 0, 0, 2.50)
+            r = await cx.post("/api/agents/builtin/thrifty/runs/run_b1/rerun")
+            ck("rerun starts (the cap is checked inside the run)", r.status_code == 201, r.text[:200])
+            async def _capped():
+                rs = (await cx.get("/api/agents/builtin/thrifty/runs")).json()
+                return rs and rs[0]["status"] == "capped"
+            ck("over budget: the run is capped before any model call", await _until(_capped))
+            rs = (await cx.get("/api/agents/builtin/thrifty/runs")).json()
+            ck("the capped run says where to raise the budget",
+               "budget of $2.00" in (rs[0].get("error") or "") and "Configuration" in rs[0]["error"],
+               str(rs[0].get("error")))
+            ck("the capped run cost nothing", not rs[0].get("cost_usd"), str(rs[0].get("cost_usd")))
+            y_r = await cx.get("/api/catalog/export")
+            ck("the budget rides in the catalog export", "budget_usd: 2" in y_r.text, y_r.text[-300:])
+
     print(f"\n{P} passed, {F} failed")
 
 asyncio.run(main())

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -157,10 +157,10 @@ export const api = {
               default_max_rounds: number; default_max_rounds_with_mcp: number;
               max_rounds_limit: number;
               presets: AgentPreset[] }>("/api/agents/builtin"),
-  createBuiltinAgent: (body: { name: string; trigger: string; prompt: string; slack_webhook?: string; slack_webhook_clear?: boolean; model?: string; slack_channel?: string; webhook_url?: string; webhook_token?: string; mcp_servers?: string[]; max_rounds?: number | null }) =>
+  createBuiltinAgent: (body: { name: string; trigger: string; prompt: string; slack_webhook?: string; slack_webhook_clear?: boolean; model?: string; slack_channel?: string; webhook_url?: string; webhook_token?: string; mcp_servers?: string[]; max_rounds?: number | null; budget_usd?: number | null }) =>
     request<{ ok: boolean; enabled: boolean }>("/api/agents/builtin",
       { method: "POST", body: JSON.stringify(body) }),
-  updateBuiltinAgent: (name: string, body: { name: string; trigger: string; prompt: string; slack_webhook?: string; slack_webhook_clear?: boolean; model?: string; slack_channel?: string; webhook_url?: string; webhook_token?: string; mcp_servers?: string[]; max_rounds?: number | null }) =>
+  updateBuiltinAgent: (name: string, body: { name: string; trigger: string; prompt: string; slack_webhook?: string; slack_webhook_clear?: boolean; model?: string; slack_channel?: string; webhook_url?: string; webhook_token?: string; mcp_servers?: string[]; max_rounds?: number | null; budget_usd?: number | null }) =>
     request(`/api/agents/builtin/${name}`, { method: "PUT", body: JSON.stringify(body) }),
   deleteBuiltinAgent: (name: string) => request(`/api/agents/builtin/${name}`, { method: "DELETE" }),
   enableBuiltinAgent: (name: string) => request(`/api/agents/builtin/${name}/enable`, { method: "POST" }),

--- a/ui/src/components/AgentForm.tsx
+++ b/ui/src/components/AgentForm.tsx
@@ -88,7 +88,9 @@ export default function AgentForm({ initial, presetTrigger, triggers, presets, m
   // "" = default (6 rounds, or 12 once the agent uses external MCP servers).
   const [maxRounds, setMaxRounds] = useState<string>(
     initial?.max_rounds ? String(initial.max_rounds) : "");
-  const [advancedOpen, setAdvancedOpen] = useState(!!initial?.max_rounds);
+  const [budget, setBudget] = useState<string>(
+    initial?.budget_usd ? String(initial.budget_usd) : "");
+  const [advancedOpen, setAdvancedOpen] = useState(!!initial?.max_rounds || !!initial?.budget_usd);
 
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string>();
@@ -134,6 +136,7 @@ export default function AgentForm({ initial, presetTrigger, triggers, presets, m
       webhook_token: writebackOn ? webhookToken.trim() : "",
       mcp_servers: mcpSel,
       max_rounds: maxRounds.trim() ? Number(maxRounds) : null,
+      budget_usd: budget.trim() ? Number(budget) : null,
     };
     try {
       if (isNew) await api.createBuiltinAgent(body);

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -109,6 +109,7 @@ export default function AgentDetail() {
           <div className="k">total cost</div>
           <div className="v">{fmtCost(stats?.cost_usd)}
             {!!stats?.uncosted_runs && <small title="runs from before cost tracking, or on a model without a known price">+{stats.uncosted_runs} uncosted</small>}
+            {!!agent?.budget_usd && <small title="the agent's budget; runs are capped once lifetime spend reaches it"> of ${agent.budget_usd} budget</small>}
           </div>
         </div>
         <div className="card"><div className="k">runs</div><div className="v">{stats?.runs ?? 0}</div></div>

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -245,6 +245,7 @@ export interface BuiltinAgent {
   webhook_token_configured: boolean;   // the token itself is never sent to the client
   mcp_servers: string[];       // registry names this agent may use
   max_rounds: number | null;   // model rounds per run; null = the default for its shape
+  budget_usd?: number | null;  // lifetime spend cap in USD; null = no budget
   effective_max_rounds: number;   // the cap its next run will be held to
   updated_at?: string;
   last_run?: AgentRun | null;


### PR DESCRIPTION
Fixes TR-216.

`budget_usd` on a Tares agent caps its lifetime spend, counted from the run log. Once reached, runs are capped before any model call (they cost nothing) with an error saying where to raise or clear it (Configuration, Advanced). In catalog YAML, the API and the console form; the agent page shows the budget next to total cost.

On a hosted demo stack, the AI SRE demo plans its agent with a $2 budget: the shared stack fires around the clock, and an idle trial cell would otherwise burn its $10 credit over a weekend. Local docker demos are unchanged (no budget).