### PR TITLE
Rerun on every finished run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 Notable changes to Tares (formerly NavFlow). Format follows [Keep a Changelog](https://keepachangelog.com/);
 the project follows [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Changed
+- Rerun is offered on every finished agent run, not only ones that failed. An agent that uses
+  all its rounds can still conclude with a partial "how far I got" report, which counts as ok;
+  the rerun opens with that report and continues from it.
+
 ## [1.15.0] - 2026-08-31
 
 ### Added

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -312,7 +312,10 @@ function RunRow({ r, open, focused, onToggle }: {
   const navigate = useNavigate();
   const [rerunBusy, setRerunBusy] = useState(false);
   const [rerunErr, setRerunErr] = useState<string>();
-  const rerunnable = ["failed", "exhausted", "capped", "empty"].includes(r.status);
+  // Any finished run: an agent can use every round and still conclude with a "how far I got"
+  // report, which lands as status ok. Whether a run is worth redoing is the reader's call; since
+  // runs open with the previous finding, a rerun continues from that report instead of starting over.
+  const rerunnable = r.status !== "running";
   const rerun = async (e: React.MouseEvent) => {
     e.stopPropagation();
     setRerunBusy(true); setRerunErr(undefined);


### PR DESCRIPTION
A run that uses all its rounds can conclude with a graceful partial report, which lands as status ok, so the Rerun button (limited to failed/exhausted/capped/empty) never appeared for the case it was built for. Rerun now shows on every finished run; since runs open with the agent's previous finding, a rerun of a partial run continues from its own "what to do next".