### PR TITLE
Deleting a trigger removes its subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 Notable changes to Tares (formerly NavFlow). Format follows [Keep a Changelog](https://keepachangelog.com/);
 the project follows [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- Deleting a trigger also removes its subscriptions. They could never fire again, but they
+  showed up on Deliveries as subscribers waking on triggers that no longer exist. Rows left
+  behind by earlier releases: remove them on the Deliveries page.
+
 ## [1.16.0] - 2026-08-31
 
 ### Added

--- a/tares/daemon.py
+++ b/tares/daemon.py
@@ -1588,6 +1588,7 @@ def make_app() -> FastAPI:
         if name not in {t.name for t in runtime.catalog.triggers}:
             _err(KeyError(f"unknown trigger {name!r}"), 404)
         store.delete_catalog_trigger(name)
+        store.remove_subscriptions_by_trigger(name)
         runtime.reload_catalog()
         return {"ok": True}
 

--- a/tares/projects/engine.py
+++ b/tares/projects/engine.py
@@ -429,6 +429,7 @@ class Engine:
                     s.delete_catalog_agent(o.name)
                 elif kind == "trigger":
                     s.delete_catalog_trigger(o.name)
+                    s.remove_subscriptions_by_trigger(o.name)
                 elif kind == "view":
                     s.delete_catalog_view(o.name)
                 elif kind == "source":

--- a/tares/store.py
+++ b/tares/store.py
@@ -1828,6 +1828,15 @@ class Store:
                 "WHERE dispatch_id = ? AND subscription_id = ?",
                 [ok, error, now_utc(), dispatch_id, subscription_id])
 
+    def remove_subscriptions_by_trigger(self, trigger: str) -> int:
+        """Drop every subscription to this trigger — called when the trigger is deleted, so no
+        subscriber keeps 'waking on' a trigger that no longer exists."""
+        with self._lock:
+            n = self.con.execute("SELECT COUNT(*) FROM subscriptions WHERE trigger = ?",
+                                 [trigger]).fetchone()[0]
+            self.con.execute("DELETE FROM subscriptions WHERE trigger = ?", [trigger])
+        return int(n)
+
     def all_subscriptions(self) -> list[dict]:
         with self._lock:
             rows = self.con.execute(

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -391,6 +391,18 @@ async def main():
                "budget of $2.00" in (rs[0].get("error") or "") and "Configuration" in rs[0]["error"],
                str(rs[0].get("error")))
             ck("the capped run cost nothing", not rs[0].get("cost_usd"), str(rs[0].get("cost_usd")))
+            # deleting a trigger takes its subscriptions with it
+            r = await cx.post("/api/catalog/import", json={"yaml": (
+                "triggers:\n  - name: doomed\n    view: svc2\n"
+                "    condition: {aggregate: count, predicate: '>= 2', window: 1m, group_by: [key_value]}\n"
+                "    cooldown: 1s\n")})
+            r = await cx.post("/subscribe", json={"trigger": "doomed", "url": "https://x.example/hook"})
+            ck("webhook subscribed to the doomed trigger", r.status_code in (200, 201), r.text[:200])
+            r = await cx.delete("/api/triggers/doomed")
+            ck("trigger deleted", r.status_code == 200, r.text[:200])
+            ghosts = {a["name"] for a in (await cx.get("/api/agents")).json()["agents"]
+                      if "doomed" in a.get("triggers", [])}
+            ck("no subscriber wakes on the deleted trigger", ghosts == set(), str(ghosts))
             y_r = await cx.get("/api/catalog/export")
             ck("the budget rides in the catalog export", "budget_usd: 2" in y_r.text, y_r.text[-300:])
 


### PR DESCRIPTION
Subscriptions to a deleted trigger lingered (they could never fire again) and showed on Deliveries as subscribers waking on triggers that no longer exist — as seen on glassflow-web (#alerts on docs-404-surge / docs-commit-burst). The delete route and the project engine now drop them with the trigger. No sweep for pre-existing rows by design; those two can be removed on the Deliveries page.