### PR TITLE
Custom project page: delete in place; firings link to details

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -43,7 +43,7 @@ const NAV_GROUPS: { section: string; items: NavItem[] }[] = [
     { to: "/triggers", label: "Triggers", icon: Bolt },
     { to: "/agents", label: "Tares agents", icon: Chat },
     { to: "/mcp-servers", label: "MCP servers", icon: Terminal },
-    { to: "/deliveries", label: "Deliveries", icon: Filter },
+    { to: "/firings", label: "Firings", icon: Filter },
   ] },
   { section: "Agent access", items: [
     { to: "/connect", label: "Connect", icon: Terminal },
@@ -57,7 +57,7 @@ const SECTION_LABEL: Record<string, string> = {
   views: "Views",
   triggers: "Triggers",
   agents: "Tares agents",
-  deliveries: "Deliveries",
+  firings: "Firings",
   connect: "Connect",
   reads: "Reads",
   catalog: "Catalog",

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -40,7 +40,7 @@ function ActivityRedirect() {
   const q = new URLSearchParams(window.location.search);
   if (q.get("tab") === "queries") return <Navigate to="/reads" replace />;
   const agent = q.get("agent");
-  return <Navigate to={agent ? `/deliveries?agent=${encodeURIComponent(agent)}` : "/deliveries"} replace />;
+  return <Navigate to={agent ? `/agents?agent=${encodeURIComponent(agent)}` : "/firings"} replace />;
 }
 
 /** /usecases* was the name of /projects* before 1.14; bookmarks and old links still land. */
@@ -79,7 +79,9 @@ const router = createBrowserRouter([
       { path: "triggers/:name", element: <TriggerDetail /> },
       { path: "connect", element: <ConnectPage /> },
       { path: "reads", element: <AgentActivity /> },
-      { path: "deliveries", element: <Deliveries /> },
+      { path: "firings", element: <Deliveries /> },
+      // /deliveries was this page's name before the firing/delivery/dispatch words settled
+      { path: "deliveries", element: <Navigate to="/firings" replace /> },
       // TR-137 renames: /activity split into /reads + /deliveries (dispatches live with their
       // subscribers now); /security is /settings.
       { path: "activity", element: <ActivityRedirect /> },

--- a/ui/src/pages/Activity.tsx
+++ b/ui/src/pages/Activity.tsx
@@ -3,7 +3,7 @@ import { Link, useNavigate, useSearchParams } from "react-router-dom";
 
 import { api, auth } from "../api";
 import { Search } from "../components/icons";
-import { TimeAgo, usePolling } from "../components/bits";
+import { Picker, TimeAgo, usePolling } from "../components/bits";
 import type { DispatchLogEntry } from "../types";
 
 // Two pages share this module: Connect (how an agent hooks up — one tab per integration mode)
@@ -569,43 +569,75 @@ function Queries() {
   );
 }
 
-function deliveryBadge(d: DispatchLogEntry) {
-  if (d.subscribers === 0) return <span className="badge starting">no subscribers</span>;
-  const cls = d.delivered === d.subscribers ? "ok" : "error";
-  return <span className={`badge ${cls}`}>{d.delivered}/{d.subscribers} delivered</span>;
-}
-
 export function Dispatches() {
   const nav = useNavigate();
   const { data, error } = usePolling(() => api.dispatches(150));
+  const { data: roster } = usePolling(() => api.agents(), 15000);
+  const { data: slack } = usePolling(() => api.slackChannels(), 60000);
   const [q, setQ] = useState("");
+  const [trigger, setTrigger] = useState("all");
+
+  const triggerOptions = useMemo(
+    () => Array.from(new Set((data ?? []).map((d) => d.trigger))).sort(), [data]);
+  const channelLabel = (raw: string) => {
+    const cid = raw.replace(/^#/, "");
+    const hit = (slack?.channels ?? []).find((c) => c.id === cid);
+    return hit ? (hit.is_private ? `🔒 ${hit.name}` : `#${hit.name}`) : raw;
+  };
+  const recipients = (t: string) => (roster?.agents ?? []).filter((a) => a.triggers.includes(t));
 
   const shown = useMemo(() => {
     const needle = q.trim().toLowerCase();
     return (data ?? []).filter((d) =>
-      !needle || d.trigger.toLowerCase().includes(needle) || d.key.toLowerCase().includes(needle) ||
-      d.kind.toLowerCase().includes(needle));
-  }, [data, q]);
+      (trigger === "all" || d.trigger === trigger) &&
+      (!needle || d.trigger.toLowerCase().includes(needle) || d.key.toLowerCase().includes(needle)));
+  }, [data, q, trigger]);
 
   if (error) return <div className="alert error">{error}</div>;
   if (!data?.length) return <div className="empty">no trigger firings yet</div>;
   return (
     <>
-      <Toolbar q={q} setQ={setQ} placeholder="Filter by trigger, key, kind…" shown={shown.length} total={data.length} />
+      <div className="toolbar">
+        <div className="search-box">
+          <Search />
+          <input type="text" className="search" placeholder="Filter by trigger or entity…" value={q} onChange={(e) => setQ(e.target.value)} />
+        </div>
+        <Picker value={trigger} onChange={setTrigger} ariaLabel="filter by trigger"
+                style={{ width: 220 }}
+                options={["all", ...triggerOptions]}
+                labels={{ all: "All triggers" }} />
+        <span className="grow" />
+        <span className="count">{shown.length} of {data.length}</span>
+      </div>
       <table>
-        <thead><tr><th>fired</th><th>trigger</th><th>key</th><th>kind</th><th>delivery</th></tr></thead>
+        <thead><tr><th>fired</th><th>trigger</th><th>entity</th><th>delivered to</th></tr></thead>
         <tbody>
-          {shown.map((d) => (
-            <tr key={d.dispatch_id} className="clickable"
-                onClick={() => nav(`/dispatches/${encodeURIComponent(d.dispatch_id)}`)}>
-              <td style={{ whiteSpace: "nowrap" }}><TimeAgo ts={d.fired_at} /></td>
-              <td className="mono"><Link to={`/dispatches/${encodeURIComponent(d.dispatch_id)}`}>{d.trigger}</Link></td>
-              <td className="mono">{d.key}</td>
-              <td className="mono">{d.kind}</td>
-              <td>{deliveryBadge(d)}</td>
-            </tr>
-          ))}
-          {!shown.length && <tr><td colSpan={5} className="dim" style={{ textAlign: "center", padding: 24 }}>no dispatches match “{q}”</td></tr>}
+          {shown.map((d) => {
+            const partial = d.subscribers > 0 && d.delivered < d.subscribers;
+            const names = recipients(d.trigger);
+            return (
+              <tr key={d.dispatch_id} className="clickable"
+                  onClick={() => nav(`/dispatches/${encodeURIComponent(d.dispatch_id)}`)}>
+                <td style={{ whiteSpace: "nowrap" }}><Link to={`/dispatches/${encodeURIComponent(d.dispatch_id)}`}><TimeAgo ts={d.fired_at} /></Link></td>
+                <td className="mono">{d.trigger}</td>
+                <td className="mono">{d.key}</td>
+                <td>
+                  {d.subscribers === 0
+                    ? <span className="badge error">nobody subscribed</span>
+                    : names.length === 0
+                    ? <span className={`badge ${partial ? "error" : "ok"}`}>{d.delivered}/{d.subscribers} delivered</span>
+                    : names.map((a) => (
+                        <span key={a.name} className="chip mono"
+                              title={partial ? (d.error ?? "not every delivery succeeded") : "delivered"}
+                              style={{ marginRight: 4, color: partial ? "var(--err)" : "var(--ok, #2e7d43)" }}>
+                          {a.kind === "slack" ? channelLabel(a.name) : a.name}
+                        </span>
+                      ))}
+                </td>
+              </tr>
+            );
+          })}
+          {!shown.length && <tr><td colSpan={4} className="dim" style={{ textAlign: "center", padding: 24 }}>no firings match the filter</td></tr>}
         </tbody>
       </table>
     </>

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -56,7 +56,7 @@ export default function AgentDetail() {
     return (
       <div className="alert error">
         no Tares agent named <span className="mono">{name}</span>. Connected (external) agents are
-        listed under <Link to="/deliveries">Deliveries</Link>. See <Link to="/agents">Agents</Link>.
+        listed under External subscribers on <Link to="/agents">Agents</Link>.
       </div>
     );
   }

--- a/ui/src/pages/Agents.tsx
+++ b/ui/src/pages/Agents.tsx
@@ -1,6 +1,7 @@
 import { Link, useNavigate } from "react-router-dom";
 
 import { api } from "../api";
+import { AgentsRoster } from "./Activity";
 import { TimeAgo, fmtCost, usePolling } from "../components/bits";
 import type { AgentRun } from "../types";
 
@@ -77,6 +78,9 @@ export default function Agents() {
             </tbody>
           </table>
         )}
+
+      <h2 style={{ marginTop: 28 }}>External subscribers</h2>
+      <AgentsRoster only="connected" />
     </>
   );
 }

--- a/ui/src/pages/Deliveries.tsx
+++ b/ui/src/pages/Deliveries.tsx
@@ -1,26 +1,11 @@
-import { Link } from "react-router-dom";
+import { Dispatches } from "./Activity";
 
-import { AgentsRoster, Dispatches } from "./Activity";
-
-// Deliveries: the runtime side of triggers. Who is subscribed (external webhooks and Slack
-// channels, with delivery health) and every firing. Tares agents are authored things and live on
-// their own page; a subscriber is a destination, not an agent (TR-137, and the TR-138 confusion).
-export default function Deliveries() {
+// Firings: every time a trigger fired, newest first, with who it was delivered to. One firing's
+// full story (payload, per-recipient outcomes) is its own page. Subscribers live with the agents.
+export default function Firings() {
   return (
     <>
-      <h1>Deliveries</h1>
-      <p className="subtitle">
-        where trigger firings go: every subscriber with its delivery health, and every firing
-      </p>
-
-      <h2>Subscribers</h2>
-      <p className="help" style={{ margin: "0 0 10px", whiteSpace: "normal" }}>
-        external agents (webhooks) and Slack channels subscribed to a trigger. Wire one from a{" "}
-        <Link to="/triggers">trigger's</Link> page.
-      </p>
-      <AgentsRoster only="connected" />
-
-      <h2 style={{ marginTop: 28 }}>Trigger firings</h2>
+      <h1>Firings</h1>
       <Dispatches />
     </>
   );

--- a/ui/src/pages/DispatchDetail.tsx
+++ b/ui/src/pages/DispatchDetail.tsx
@@ -16,7 +16,7 @@ export default function DispatchDetail() {
     return (
       <div className="alert error">
         {/unknown dispatch/i.test(error) ? <>no dispatch <span className="mono">{id}</span></> : error}
-        {" "}· see <Link to="/deliveries">Deliveries</Link>
+        {" "}· see <Link to="/firings">Firings</Link>
       </div>
     );
   }

--- a/ui/src/pages/DispatchDetail.tsx
+++ b/ui/src/pages/DispatchDetail.tsx
@@ -1,14 +1,16 @@
 import { Link, useParams } from "react-router-dom";
 
 import { api } from "../api";
+import ProjectBadge from "../components/ProjectBadge";
 import { TimeAgo, usePolling } from "../components/bits";
 
-// One firing, deep — the page behind a dispatch_id. Fetched by id so links from the Agents tab
-// (or anywhere) always resolve, unlike the capped dispatches list. Shows the per-subscriber
-// delivery attempts (who got it, who failed and why) plus the full payload the agent received.
+// One firing, deep — the page behind a dispatch_id. Fetched by id so links from anywhere always
+// resolve, unlike the capped dispatches list. One facts box (trigger, project, what it fired for,
+// how delivery went, each recipient with its outcome), then the payload the subscribers received.
 export default function DispatchDetail() {
   const { id = "" } = useParams();
   const { data: d, error } = usePolling(() => api.dispatch(id), 10000);
+  const { data: triggers } = usePolling(() => api.triggers(), 30000);
 
   if (error) {
     return (
@@ -20,7 +22,9 @@ export default function DispatchDetail() {
   }
   if (!d) return <div className="dim">loading…</div>;
 
-  const failed = d.subscribers > d.delivered;
+  const trig = (triggers ?? []).find((t) => t.name === d.trigger);
+  const pending = d.deliveries.filter((dv) => dv.ok === null).length;
+  const failed = d.deliveries.filter((dv) => dv.ok === false).length;
   let payload = d.payload;
   try { payload = JSON.stringify(JSON.parse(d.payload), null, 2); } catch { /* keep raw */ }
 
@@ -28,67 +32,66 @@ export default function DispatchDetail() {
     <>
       <div className="pagehead">
         <div>
-          <p className="subtitle" style={{ marginBottom: 4 }}>
-            <Link to="/deliveries">Deliveries</Link> ›
-          </p>
-          <h1>
-            <Link to={`/triggers/${encodeURIComponent(d.trigger)}`} className="mono">{d.trigger}</Link>
-          </h1>
-          <p className="subtitle">
-            fired for <span className="mono">{d.key}</span> · <TimeAgo ts={d.fired_at} />
-          </p>
+          <h1><span className="mono">{d.trigger}</span> <span className="badge">firing</span></h1>
         </div>
       </div>
 
-      <div className="kv" style={{ marginBottom: 18 }}>
-        <span className="k">kind</span><span className="mono">{d.kind}</span>
-        <span className="k">delivery</span>
-        <span>
-          {d.subscribers === 0
-            ? <span className="badge starting">no subscribers</span>
-            : <span className={`badge ${failed ? "error" : "ok"}`}>{d.delivered}/{d.subscribers} delivered</span>}
-        </span>
-        {d.error && <><span className="k">error</span><span className="mono" style={{ color: "var(--err)" }}>{d.error}</span></>}
-        <span className="k">dispatch id</span><span className="mono">{d.dispatch_id}</span>
-      </div>
-
-      <h2>Deliveries</h2>
-      {d.deliveries.length === 0 ? (
-        <p className="help" style={{ whiteSpace: "normal" }}>
-          no subscribers were attached when this fired; nothing was delivered (the firing is still
-          logged; wire an agent on the <Link to={`/triggers/${encodeURIComponent(d.trigger)}`}>trigger</Link>).
-        </p>
-      ) : (
-        <table style={{ marginBottom: 18 }}>
-          <thead><tr><th>agent</th><th>endpoint</th><th>status</th><th>when</th></tr></thead>
+      <div className="panel">
+        <table>
           <tbody>
-            {/* Each kind links to where its story continues: a Tares agent to its run for THIS
-                firing, an external agent to its roster row. A Slack channel gets no link — the
-                message went to Slack; there is nothing more to show here. */}
-            {d.deliveries.map((dv, i) => (
-              <tr key={i}>
-                <td>{dv.kind === "tares"
-                  ? <Link to={`/agents/${encodeURIComponent(dv.agent)}?dispatch=${encodeURIComponent(d.dispatch_id)}`}><strong>{dv.agent}</strong></Link>
-                  : dv.kind === "webhook"
-                  ? <Link to={`/agents?agent=${encodeURIComponent(dv.agent)}`}><strong>{dv.agent}</strong></Link>
-                  : <strong>{dv.agent}</strong>}</td>
-                <td className="mono">{dv.endpoint}</td>
+            <tr><td className="help" style={{ width: 150 }}>trigger</td>
+                <td><Link to={`/triggers/${encodeURIComponent(d.trigger)}`} className="chip mono">{d.trigger}</Link></td></tr>
+            {trig?.owned_by && (
+              <tr><td className="help">part of</td>
+                  <td><ProjectBadge ownedBy={trig.owned_by} customized={trig.customized} compact /></td></tr>
+            )}
+            <tr><td className="help">fired for</td>
+                <td className="mono">{d.key}</td></tr>
+            <tr><td className="help">fired</td>
+                <td><TimeAgo ts={d.fired_at} /></td></tr>
+            <tr><td className="help">delivery</td>
                 <td>
-                  {dv.ok
-                    ? <span className="badge ok">delivered</span>
-                    : <span className="badge error" title={dv.error ?? undefined}>failed{dv.error ? `: ${dv.error}` : ""}</span>}
+                  {d.subscribers === 0
+                    ? <span className="badge starting">no subscribers</span>
+                    : failed > 0
+                    ? <span className="badge error">{failed} of {d.subscribers} failed</span>
+                    : pending > 0
+                    ? <span className="badge starting">running</span>
+                    : <span className="badge ok">delivered to all {d.subscribers}</span>}
+                </td></tr>
+            {d.deliveries.length === 0 ? (
+              <tr><td className="help">delivered to</td>
+                  <td className="help" style={{ whiteSpace: "normal" }}>
+                    nobody was subscribed when this fired; the firing is still logged. Wire an agent
+                    on the <Link to={`/triggers/${encodeURIComponent(d.trigger)}`}>trigger</Link>.
+                  </td></tr>
+            ) : d.deliveries.map((dv, i) => (
+              <tr key={i}>
+                <td className="help">{i === 0 ? "delivered to" : ""}</td>
+                <td>
+                  {dv.kind === "tares"
+                    ? <Link to={`/agents/${encodeURIComponent(dv.agent)}?dispatch=${encodeURIComponent(d.dispatch_id)}`}><strong>{dv.agent}</strong></Link>
+                    : dv.kind === "webhook"
+                    ? <Link to={`/deliveries?agent=${encodeURIComponent(dv.agent)}`}><strong>{dv.agent}</strong></Link>
+                    : <strong>{dv.agent}</strong>}
+                  <span className="chip" style={{ margin: "0 8px" }}>
+                    {dv.kind === "tares" ? "Tares agent" : dv.kind === "slack" ? "Slack" : "webhook"}</span>
+                  {/* ok is tri-state: null is a Tares run still going — not a failure */}
+                  {dv.ok === true && <span className="badge ok">delivered</span>}
+                  {dv.ok === null && <span className="badge starting">running</span>}
+                  {dv.ok === false && <span className="badge error" title={dv.error ?? undefined}>failed{dv.error ? `: ${dv.error.slice(0, 80)}` : ""}</span>}
+                  {dv.delivered_at && <span className="help"> · <TimeAgo ts={dv.delivered_at} /></span>}
+                  {dv.kind === "tares" && (
+                    <span className="help"> · <Link to={`/agents/${encodeURIComponent(dv.agent)}?dispatch=${encodeURIComponent(d.dispatch_id)}`}>open the run</Link></span>
+                  )}
                 </td>
-                <td style={{ whiteSpace: "nowrap" }}><TimeAgo ts={dv.delivered_at} /></td>
               </tr>
             ))}
           </tbody>
         </table>
-      )}
+      </div>
 
-      <h2>Payload</h2>
-      <p className="help" style={{ margin: "0 0 6px", whiteSpace: "normal" }}>
-        the timeline POSTed to each subscriber; the agent boots holding this.
-      </p>
+      <h2>What subscribers received</h2>
       <pre className="payload">{payload}</pre>
     </>
   );

--- a/ui/src/pages/Home.tsx
+++ b/ui/src/pages/Home.tsx
@@ -74,7 +74,7 @@ export default function Home() {
           <div className="v">{u ? u.agent_runs.toLocaleString() : <span className="dim">—</span>}</div>
         </div>
         <div className="card">
-          <div className="k">dispatch deliveries</div>
+          <div className="k">deliveries</div>
           <div className="v">
             {u ? u.dispatch_deliveries.toLocaleString() : <span className="dim">—</span>}
           </div>

--- a/ui/src/pages/Home.tsx
+++ b/ui/src/pages/Home.tsx
@@ -48,9 +48,6 @@ export default function Home() {
       <div className="pagehead">
         <div>
           <h1>Overview</h1>
-          <p className="subtitle">
-            what this instance holds; <em>and how much room is left</em>
-          </p>
         </div>
       </div>
 
@@ -129,10 +126,6 @@ function ModelSpendPanel({ usage, error, reload }: {
   return (
     <div className="panel">
       <h2 style={{ marginTop: 0 }}>Model spend</h2>
-      <p className="help" style={{ marginTop: 0 }}>
-        What this instance has spent on its Anthropic key; Tares agent runs plus Ask. External
-        agents run on their own keys and are not counted here.
-      </p>
 
       {error && <ErrorState error={error} what="model spend" onRetry={reload} />}
       {!m && !error && <div className="muted">loading…</div>}
@@ -191,10 +184,6 @@ function StoragePanel({ usage, error, reload, onDisk, pct }: {
   return (
     <div className="panel">
       <h2 style={{ marginTop: 0 }}>Storage</h2>
-      <p className="help" style={{ marginTop: 0 }}>
-        What this instance is using on disk; the DuckDB file plus its write-ahead log. Nothing is
-        pruned today, so agent runs and dispatch deliveries grow with every firing.
-      </p>
 
       {error && <ErrorState error={error} what="storage usage" onRetry={reload} />}
       {!u && !error && <div className="muted">loading…</div>}

--- a/ui/src/pages/ProjectCustom.tsx
+++ b/ui/src/pages/ProjectCustom.tsx
@@ -25,6 +25,7 @@ export default function ProjectCustom({ s, id, reload }: {
   const navigate = useNavigate();
   const [tab, setTab] = useState<"setup" | "events" | "firings" | "agents">("setup");
   const [focusDispatch, setFocusDispatch] = useState<string>();
+  const [openEvent, setOpenEvent] = useState<number>();
   const [actionError, setActionError] = useState<string>();
   const [confirmDel, setConfirmDel] = useState(false);
   const [purge, setPurge] = useState(false);
@@ -48,6 +49,17 @@ export default function ProjectCustom({ s, id, reload }: {
   const myTriggers = (triggers ?? []).filter((x) => names("trigger").includes(x.name));
   const triggerNames = new Set(myTriggers.map((t) => t.name));
   const firings = (dispatches ?? []).filter((d) => triggerNames.has(d.trigger));
+  // Consecutive firings of the same trigger that reached nobody collapse into one row: dozens of
+  // identical "0 of 0" lines say one thing — nobody is subscribed — so say it once, with a count.
+  const firingRows: (typeof firings[number] & { repeats?: number })[] = [];
+  for (const d of firings) {
+    const prev = firingRows[firingRows.length - 1];
+    if (prev && prev.trigger === d.trigger && prev.subscribers === 0 && d.subscribers === 0) {
+      prev.repeats = (prev.repeats ?? 1) + 1;
+    } else {
+      firingRows.push({ ...d });
+    }
+  }
 
   // Who a trigger delivers to, from the roster (kind + subscribed triggers). The slack id is
   // resolved to a channel name when the bot still sees it, like the trigger page does.
@@ -147,15 +159,26 @@ export default function ProjectCustom({ s, id, reload }: {
           <table>
             <thead><tr><th style={{ width: 110 }}>when</th><th>source</th><th>entity</th><th>type</th><th>event</th></tr></thead>
             <tbody>
-              {recent.map((e, i) => (
-                <tr key={i}>
-                  <td style={{ whiteSpace: "nowrap" }}><TimeAgo ts={e.ingest_time} /></td>
-                  <td><Link to={`/sources/${encodeURIComponent(e.source)}`} className="mono">{e.source}</Link></td>
-                  <td className="mono">{e.key}</td>
-                  <td><span className="chip">{e.event_type}</span></td>
-                  <td className="mono" style={{ whiteSpace: "pre-wrap", overflowWrap: "anywhere" }}>{e.text.slice(0, 200)}</td>
-                </tr>
-              ))}
+              {recent.map((e, i) => {
+                const long = e.text.length > 160;
+                const open = openEvent === i;
+                return (
+                  <tr key={i} className={long ? "clickable" : undefined}
+                      onClick={() => long && setOpenEvent(open ? undefined : i)}
+                      title={long && !open ? "click for the whole event" : undefined}>
+                    <td style={{ whiteSpace: "nowrap", verticalAlign: "top" }}><TimeAgo ts={e.ingest_time} /></td>
+                    <td style={{ verticalAlign: "top" }} onClick={(ev) => ev.stopPropagation()}>
+                      <Link to={`/sources/${encodeURIComponent(e.source)}`} className="mono">{e.source}</Link></td>
+                    <td className="mono" style={{ verticalAlign: "top" }}>{e.key}</td>
+                    <td style={{ verticalAlign: "top" }}><span className="chip">{e.event_type}</span></td>
+                    <td className="mono" style={{ whiteSpace: "pre-wrap", overflowWrap: "anywhere" }}>
+                      {open || !long ? e.text : e.text.slice(0, 160)}
+                      {long && !open && <span className="dim"> … ▸</span>}
+                      {open && <span className="dim"> ▾</span>}
+                    </td>
+                  </tr>
+                );
+              })}
             </tbody>
           </table>
         ) : <p className="help">nothing ingested yet across this project's sources</p>
@@ -168,7 +191,7 @@ export default function ProjectCustom({ s, id, reload }: {
             <table>
               <thead><tr><th>when</th><th>trigger</th><th>entity</th><th>delivered</th><th>agent</th><th>Slack</th></tr></thead>
               <tbody>
-                {firings.map((d) => {
+                {firingRows.map((d) => {
                   const subs = subscribers(d.trigger);
                   const tares = subs.filter((a) => a.kind === "tares");
                   const chans = subs.filter((a) => a.kind === "slack");
@@ -182,15 +205,18 @@ export default function ProjectCustom({ s, id, reload }: {
                              onClick={(e) => { e.preventDefault(); showTrigger(d.trigger); }}>{d.trigger}</a>
                         : <span className="mono">{d.trigger}</span>}</td>
                       <td className="mono">{d.key}</td>
-                      <td>{d.delivered} of {d.subscribers}
-                        {d.error && <span className="help" title={d.error}> · {d.error.slice(0, 60)}</span>}</td>
+                      <td>{d.subscribers === 0
+                        ? <><span className="badge error">nobody subscribed</span>
+                            {(d.repeats ?? 1) > 1 && <span className="help"> · {d.repeats} firings like this</span>}</>
+                        : <>{d.delivered} of {d.subscribers}
+                            {d.error && <span className="help" title={d.error}> · {d.error.slice(0, 60)}</span>}</>}</td>
                       <td>{tares.length
                         ? tares.map((a) => (
                             <a key={a.name} href="#agents" onClick={(e) => { e.preventDefault(); openInAgents(d.dispatch_id); }}
                                className="mono" title="open this firing's run below">{a.name}</a>))
                         : <span className="dim">—</span>}</td>
                       <td>{chans.length
-                        ? chans.map((a) => <span key={a.name} className="chip">{channelLabel(a.endpoint || a.name)}</span>)
+                        ? chans.map((a) => <span key={a.name} className="chip">{channelLabel(a.name)}</span>)
                         : <span className="dim">—</span>}</td>
                     </tr>
                   );

--- a/ui/src/pages/ProjectCustom.tsx
+++ b/ui/src/pages/ProjectCustom.tsx
@@ -124,7 +124,10 @@ export default function ProjectCustom({ s, id, reload }: {
           ) : <p className="help">none in this project</p>}
 
           <h2 style={{ marginTop: 24 }}>Views</h2>
-          {myViews.map((v) => <ViewPanel key={v.name} v={v} sourceNames={(sources ?? []).map((x) => x.name)} onSaved={() => { reloadViews(); reload(); }} />)}
+          {myViews.map((v) => (
+            <ViewPanel key={v.name} v={v} sourceNames={(sources ?? []).map((x) => x.name)}
+                       watchers={(triggers ?? []).filter((t) => t.view === v.name).length}
+                       onSaved={() => { reloadViews(); reload(); }} />))}
           {!myViews.length && <p className="help">none in this project</p>}
 
           <h2 style={{ marginTop: 24 }}>Triggers</h2>
@@ -171,8 +174,13 @@ export default function ProjectCustom({ s, id, reload }: {
                   const chans = subs.filter((a) => a.kind === "slack");
                   return (
                     <tr key={d.dispatch_id}>
-                      <td style={{ whiteSpace: "nowrap" }}><TimeAgo ts={d.fired_at} /></td>
-                      <td className="mono">{d.trigger}</td>
+                      <td style={{ whiteSpace: "nowrap" }}>
+                        <Link to={`/dispatches/${encodeURIComponent(d.dispatch_id)}`} title="the firing's detail page">
+                          <TimeAgo ts={d.fired_at} /></Link></td>
+                      <td>{triggerNames.has(d.trigger)
+                        ? <a href={`#trigger-${d.trigger}`} className="mono" title="the trigger, on the Setup tab"
+                             onClick={(e) => { e.preventDefault(); showTrigger(d.trigger); }}>{d.trigger}</a>
+                        : <span className="mono">{d.trigger}</span>}</td>
                       <td className="mono">{d.key}</td>
                       <td>{d.delivered} of {d.subscribers}
                         {d.error && <span className="help" title={d.error}> · {d.error.slice(0, 60)}</span>}</td>
@@ -224,10 +232,12 @@ export default function ProjectCustom({ s, id, reload }: {
 
 // One view, as its own page shows it (key field, sources, filters, author, usage), with the same
 // in-place editor. "+ trigger" preselects this view on the trigger form.
-function ViewPanel({ v, sourceNames, onSaved }: {
-  v: import("../types").View; sourceNames: string[]; onSaved: () => void;
+function ViewPanel({ v, sourceNames, watchers, onSaved }: {
+  v: import("../types").View; sourceNames: string[]; watchers: number; onSaved: () => void;
 }) {
   const [editing, setEditing] = useState(false);
+  const [confirmDel, setConfirmDel] = useState(false);
+  const [err, setErr] = useState<string>();
   return (
     <div className="panel" id={`view-${v.name}`} style={{ marginBottom: 12, scrollMarginTop: 16 }}>
       <div className="pagehead" style={{ marginBottom: 8 }}>
@@ -240,8 +250,23 @@ function ViewPanel({ v, sourceNames, onSaved }: {
         <span className="btnrow">
           <Link className="btn" to={`/triggers/new?view=${encodeURIComponent(v.name)}`}>+ trigger</Link>
           {!editing && <button className="primary" onClick={() => setEditing(true)}>Edit</button>}
+          {!editing && <button className="danger" onClick={() => setConfirmDel(true)}>Delete</button>}
         </span>
       </div>
+      {err && <div className="alert error">{err}</div>}
+      {confirmDel && (
+        <ConfirmDialog title={`Delete view ${v.name}?`}
+          message={watchers
+            ? `${watchers} trigger(s) watch this view and will stop working. Agents querying it will start failing.`
+            : "Agents querying this view will start failing. This can't be undone."}
+          confirmLabel="Delete" danger
+          onConfirm={async () => {
+            try { await api.deleteView(v.name); onSaved(); }
+            catch (e) { setErr(String((e as Error).message ?? e)); }
+            setConfirmDel(false);
+          }}
+          onCancel={() => setConfirmDel(false)} />
+      )}
       {editing ? (
         <ViewEditor initial={v} sourceNames={sourceNames}
                     onSaved={() => { setEditing(false); onSaved(); }}
@@ -276,6 +301,8 @@ function TriggerPanel({ t, viewInProject, lastFired, onSaved }: {
   t: import("../types").Trigger; viewInProject: boolean; lastFired: string | null; onSaved: () => void;
 }) {
   const [editing, setEditing] = useState(false);
+  const [confirmDel, setConfirmDel] = useState(false);
+  const [err, setErr] = useState<string>();
   return (
     <div className="panel" id={`trigger-${t.name}`} style={{ marginBottom: 12, scrollMarginTop: 16 }}>
       <div className="pagehead" style={{ marginBottom: 8 }}>
@@ -287,8 +314,21 @@ function TriggerPanel({ t, viewInProject, lastFired, onSaved }: {
         </div>
         <span className="btnrow">
           {!editing && <button className="primary" onClick={() => setEditing(true)}>Edit</button>}
+          {!editing && <button className="danger" onClick={() => setConfirmDel(true)}>Delete</button>}
         </span>
       </div>
+      {err && <div className="alert error">{err}</div>}
+      {confirmDel && (
+        <ConfirmDialog title={`Delete trigger ${t.name}?`}
+          message="Nothing will fire on this condition any more; its subscribers stop being woken. This can't be undone."
+          confirmLabel="Delete" danger
+          onConfirm={async () => {
+            try { await api.deleteTrigger(t.name); onSaved(); }
+            catch (e) { setErr(String((e as Error).message ?? e)); }
+            setConfirmDel(false);
+          }}
+          onCancel={() => setConfirmDel(false)} />
+      )}
       {editing ? (
         <TriggerEditor initial={t}
                        onSaved={() => { setEditing(false); onSaved(); }}

--- a/ui/src/pages/ProjectCustom.tsx
+++ b/ui/src/pages/ProjectCustom.tsx
@@ -269,9 +269,6 @@ function ViewPanel({ v, sourceNames, watchers, onSaved }: {
       <div className="pagehead" style={{ marginBottom: 8 }}>
         <div>
           <h3 style={{ margin: 0 }}><span className="mono">{v.name}</span></h3>
-          <p className="subtitle" style={{ margin: "2px 0 0" }}>
-            one read returns the correlated timeline of a <span className="mono">{v.key_field}</span>
-          </p>
         </div>
         <span className="btnrow">
           <Link className="btn" to={`/triggers/new?view=${encodeURIComponent(v.name)}`}>+ trigger</Link>

--- a/ui/src/pages/Sources.tsx
+++ b/ui/src/pages/Sources.tsx
@@ -38,13 +38,31 @@ export default function Sources() {
   // Host capabilities gate local-only actions: hide Auto-discover where Docker isn't reachable
   // (a hosted cell, or a local box without Docker). Shown until known false.
   const { data: caps } = usePolling(() => api.capabilities());
+  // for the project filter: id -> name, and which ids own a source at all
+  const { data: projectList } = usePolling(() => api.projects(), 30000);
 
   const [q, setQ] = useState("");
   const [status, setStatus] = useState("all");
+  const [connector, setConnector] = useState("all");
+  const [project, setProject] = useState("all");
 
   const statuses = useMemo(
     () => Array.from(new Set((sources ?? []).map((s) => s.health?.status ?? "starting"))).sort(),
     [sources],
+  );
+  const connectors = useMemo(
+    () => Array.from(new Set((sources ?? []).map((s) => s.connector))).sort(),
+    [sources],
+  );
+  const projectName = useMemo(() => {
+    const m: Record<string, string> = {};
+    for (const p of projectList?.projects ?? []) m[p.id] = p.name;
+    return m;
+  }, [projectList]);
+  const owningProjects = useMemo(
+    () => Array.from(new Set((sources ?? []).map((s) => s.owned_by).filter((x): x is string => !!x))).sort(
+      (a, b) => (projectName[a] ?? a).localeCompare(projectName[b] ?? b)),
+    [sources, projectName],
   );
 
   const shown = useMemo(() => {
@@ -52,9 +70,11 @@ export default function Sources() {
     return (sources ?? []).filter((s) => {
       const st = s.health?.status ?? "starting";
       return (status === "all" || st === status) &&
+        (connector === "all" || s.connector === connector) &&
+        (project === "all" || (project === "none" ? !s.owned_by : s.owned_by === project)) &&
         (!needle || s.name.toLowerCase().includes(needle) || s.connector.toLowerCase().includes(needle));
     });
-  }, [sources, q, status]);
+  }, [sources, q, status, connector, project]);
 
   return (
     <>
@@ -102,6 +122,17 @@ export default function Sources() {
                     style={{ width: 150 }}
                     options={["all", ...statuses]}
                     labels={{ all: "All statuses" }} />
+            <Picker value={connector} onChange={setConnector} ariaLabel="filter by connector"
+                    style={{ width: 160 }}
+                    options={["all", ...connectors]}
+                    labels={{ all: "All connectors" }} />
+            {owningProjects.length > 0 && (
+              <Picker value={project} onChange={setProject} ariaLabel="filter by project"
+                      style={{ width: 180 }}
+                      options={["all", "none", ...owningProjects]}
+                      labels={{ all: "All projects", none: "No project",
+                                ...Object.fromEntries(owningProjects.map((id) => [id, projectName[id] ?? id])) }} />
+            )}
             <span className="grow" />
             <span className="count">{shown.length} of {sources.length}</span>
           </div>

--- a/ui/src/pages/TriggerDetail.tsx
+++ b/ui/src/pages/TriggerDetail.tsx
@@ -166,7 +166,7 @@ export default function TriggerDetail() {
                     // channel list is already loaded on this page, so resolve it when we can and fall
                     // back to the id when the bot has since been removed from the channel.
                     ? <strong>{channelLabel(a.name)}</strong>
-                    : <Link to={`/deliveries?agent=${encodeURIComponent(a.name)}`}><strong>{a.name}</strong></Link>}
+                    : <Link to={`/agents?agent=${encodeURIComponent(a.name)}`}><strong>{a.name}</strong></Link>}
                   <span className="chip" style={{ marginLeft: 8 }}>
                     {a.kind === "tares" ? "Tares agent" : a.kind === "slack" ? "Slack" : "webhook"}</span>
                   {a.kind === "connected" && <span className="mono dim" style={{ marginLeft: 8 }}>{a.endpoint}</span>}
@@ -328,7 +328,7 @@ export default function TriggerDetail() {
           </tbody>
         </table>
         {firings.length > 5 && (
-          <p className="help">the last 5 of {firings.length} recent · every firing is on <Link to="/deliveries">Deliveries</Link></p>
+          <p className="help">the last 5 of {firings.length} recent · every firing is on <Link to="/firings">Firings</Link></p>
         )}
         </>
       )}

--- a/ui/src/pages/TriggerDetail.tsx
+++ b/ui/src/pages/TriggerDetail.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { Link, useNavigate, useParams, useSearchParams } from "react-router-dom";
 
 import { api, type SlackChannels } from "../api";
-import type { AgentInfo } from "../types";
+import type { AgentInfo, DispatchDetail } from "../types";
 import ConfirmDialog from "../components/ConfirmDialog";
 import ProjectBadge from "../components/ProjectBadge";
 import TriggerEditor from "../components/TriggerEditor";
@@ -25,6 +25,21 @@ export default function TriggerDetail() {
   // stake, and a failed load would otherwise silently read as "nothing depends on this".
   const { data: agents, error: agentsError, reload: reloadAgents } = usePolling(() => api.agents(), 10000);
   const { data: dispatches, error: dispatchesError } = usePolling(() => api.dispatches(100), 10000);
+  const { data: views } = usePolling(() => api.views(), 30000);
+  // Per-firing recipients with outcomes: the list endpoint carries only counts, the detail has
+  // names; five small fetches for the five rows shown.
+  const [details, setDetails] = useState<Record<string, DispatchDetail>>({});
+  useEffect(() => {
+    let live = true;
+    const ids = (dispatches ?? []).filter((d) => d.trigger === name).slice(0, 5).map((d) => d.dispatch_id);
+    Promise.all(ids.map((id) => api.dispatch(id).catch(() => null))).then((rows) => {
+      if (!live) return;
+      const m: Record<string, DispatchDetail> = {};
+      for (const r of rows) if (r) m[r.dispatch_id] = r;
+      setDetails(m);
+    });
+    return () => { live = false; };
+  }, [dispatches, name]);
   // Which "add a subscriber" form is open, if any. The forms are closed by default: this page
   // is first a view of the running system (who receives this trigger, is it healthy, what fired),
   // and setup gets in the way when it is always on screen (TR-138).
@@ -82,9 +97,6 @@ export default function TriggerDetail() {
       <div className="pagehead">
         <div>
           <h1><span className="mono">{trigger.name}</span></h1>
-          <p className="subtitle">
-            fires when the condition trips, delivering to every subscriber
-          </p>
         </div>
         {!editing && (
           <span className="btnrow">
@@ -107,8 +119,7 @@ export default function TriggerDetail() {
           <table>
             <tbody>
               <tr><td className="help" style={{ width: 150 }}>watches</td>
-                  <td><Link to={`/views/${encodeURIComponent(trigger.view)}`} className="mono">{trigger.view}</Link>
-                      <span className="help"> · the view whose events the condition reads</span></td></tr>
+                  <td><Link to={`/views/${encodeURIComponent(trigger.view)}`} className="mono">{trigger.view}</Link></td></tr>
               {trigger.owned_by && (
                 <tr><td className="help">part of</td>
                     <td><ProjectBadge ownedBy={trigger.owned_by} customized={trigger.customized} compact /></td></tr>
@@ -119,11 +130,9 @@ export default function TriggerDetail() {
                     {trigger.condition.predicate} over {trigger.condition.window}
                   </td></tr>
               <tr><td className="help">context window</td>
-                  <td className="mono">{String(trigger.emit?.context_window ?? "15m")}
-                      <span className="help"> · timeline the woken agent receives</span></td></tr>
+                  <td className="mono">{String(trigger.emit?.context_window ?? "15m")}</td></tr>
               <tr><td className="help">cooldown</td>
-                  <td className="mono">{trigger.cooldown}
-                      <span className="help"> · minimum gap between firings per entity</span></td></tr>
+                  <td className="mono">{trigger.cooldown}</td></tr>
             </tbody>
           </table>
         </div>
@@ -145,32 +154,29 @@ export default function TriggerDetail() {
       </div>
       {wired.length > 0 ? (
         <table style={{ marginBottom: 10 }}>
-          <thead><tr><th>subscriber</th><th>kind</th><th>endpoint</th><th className="num">delivered (24h)</th><th className="num">failed (24h)</th><th>status</th><th aria-label="actions" /></tr></thead>
+          <thead><tr><th>subscriber</th><th>delivered</th><th>status</th><th aria-label="actions" /></tr></thead>
           <tbody>
             {wired.map((a) => (
               <tr key={a.name}>
-                <td>{a.kind === "tares"
-                  ? <Link to={`/agents/${encodeURIComponent(a.name)}`}><strong>{a.name}</strong></Link>
-                  : a.kind === "slack"
-                  // A raw C0BNV121CRX is the identity Slack uses, not one a human recognises. The
-                  // channel list is already loaded on this page, so resolve it when we can and fall
-                  // back to the id when the bot has since been removed from the channel.
-                  ? <strong>{channelLabel(a.name)}</strong>
-                  : <Link to={`/deliveries?agent=${encodeURIComponent(a.name)}`}><strong>{a.name}</strong></Link>}</td>
-                <td>{a.kind === "tares"
-                  ? <span className="badge">Tares</span>
-                  : a.kind === "slack"
-                  ? <span className="badge">Slack</span>
-                  : <span className="badge push">connected</span>}</td>
-                <td className="mono">{a.endpoint}</td>
-                <td className="num" title={`${a.delivered_ok_total} delivered all time`}>
-                  {a.delivered_ok_24h}
-                  {a.delivered_ok_total !== a.delivered_ok_24h && <span className="dim"> / {a.delivered_ok_total}</span>}
+                <td>
+                  {a.kind === "tares"
+                    ? <Link to={`/agents/${encodeURIComponent(a.name)}`}><strong>{a.name}</strong></Link>
+                    : a.kind === "slack"
+                    // A raw C0BNV121CRX is the identity Slack uses, not one a human recognises. The
+                    // channel list is already loaded on this page, so resolve it when we can and fall
+                    // back to the id when the bot has since been removed from the channel.
+                    ? <strong>{channelLabel(a.name)}</strong>
+                    : <Link to={`/deliveries?agent=${encodeURIComponent(a.name)}`}><strong>{a.name}</strong></Link>}
+                  <span className="chip" style={{ marginLeft: 8 }}>
+                    {a.kind === "tares" ? "Tares agent" : a.kind === "slack" ? "Slack" : "webhook"}</span>
+                  {a.kind === "connected" && <span className="mono dim" style={{ marginLeft: 8 }}>{a.endpoint}</span>}
                 </td>
-                <td className="num" style={a.delivered_fail_24h ? { color: "var(--err)" } : undefined}
-                    title={`${a.delivered_fail_total} failed all time`}>
-                  {a.delivered_fail_24h}
-                  {a.delivered_fail_total !== a.delivered_fail_24h && <span className="dim"> / {a.delivered_fail_total}</span>}
+                <td style={{ whiteSpace: "nowrap" }}
+                    title={a.delivered_fail_total ? `${a.delivered_fail_total} failed all time` : undefined}>
+                  {a.delivered_ok_total
+                    ? <>{a.delivered_ok_total} · last <TimeAgo ts={a.last_woken} /></>
+                    : <span className="dim">none yet</span>}
+                  {a.delivered_fail_total > 0 && <span style={{ color: "var(--err)" }}> · {a.delivered_fail_total} failed</span>}
                 </td>
                 <td>
                   {a.pending
@@ -289,23 +295,42 @@ export default function TriggerDetail() {
       {dispatchesError && <ErrorState error={dispatchesError} what="recent firings" />}
       {!dispatchesError && firings.length === 0 && <p className="help">none yet</p>}
       {firings.length > 0 && (
+        <>
         <table>
-          <thead><tr><th>fired</th><th>entity</th><th className="num">subscribers</th><th className="num">delivered</th><th>error</th></tr></thead>
+          <thead><tr><th style={{ width: 110 }}>fired</th>
+            <th>{(views ?? []).find((v) => v.name === trigger.view)?.key_field || "entity"}</th>
+            <th>delivered to</th></tr></thead>
           <tbody>
-            {firings.map((d) => {
-              const failed = d.subscribers > d.delivered;
+            {firings.slice(0, 5).map((d) => {
+              const dvs = details[d.dispatch_id]?.deliveries;
               return (
-              <tr key={d.dispatch_id} className="clickable"
-                  onClick={() => nav(`/dispatches/${encodeURIComponent(d.dispatch_id)}`)}>
-                <td style={{ whiteSpace: "nowrap" }}><Link to={`/dispatches/${encodeURIComponent(d.dispatch_id)}`}><TimeAgo ts={d.fired_at} /></Link></td>
-                <td className="mono">{d.key}</td>
-                <td className="num">{d.subscribers}</td>
-                <td className="num" style={failed ? { color: "var(--err)" } : undefined}>{d.delivered}</td>
-                <td className="mono" style={{ color: "var(--err)" }} title={d.error ?? undefined}>{failed ? (d.error ?? "delivery failed") : ""}</td>
-              </tr>
-            ); })}
+                <tr key={d.dispatch_id} className="clickable"
+                    onClick={() => nav(`/dispatches/${encodeURIComponent(d.dispatch_id)}`)}>
+                  <td style={{ whiteSpace: "nowrap" }}><Link to={`/dispatches/${encodeURIComponent(d.dispatch_id)}`}><TimeAgo ts={d.fired_at} /></Link></td>
+                  <td className="mono">{d.key}</td>
+                  <td>
+                    {dvs === undefined
+                      ? (d.subscribers === 0 ? <span className="dim">nobody was subscribed</span> : <span className="dim">…</span>)
+                      : dvs.length === 0
+                      ? <span className="dim">nobody was subscribed</span>
+                      : dvs.map((dv, i) => (
+                          <span key={i} className="chip mono"
+                                title={dv.ok === false ? (dv.error ?? "delivery failed") : dv.ok === null ? "still running" : "delivered"}
+                                style={{ marginRight: 4,
+                                         color: dv.ok === false ? "var(--err)" : dv.ok === null ? undefined : "var(--ok, #2e7d43)" }}>
+                            {dv.kind === "slack" ? channelLabel(dv.agent) : dv.agent}
+                          </span>
+                        ))}
+                  </td>
+                </tr>
+              );
+            })}
           </tbody>
         </table>
+        {firings.length > 5 && (
+          <p className="help">the last 5 of {firings.length} recent · every firing is on <Link to="/deliveries">Deliveries</Link></p>
+        )}
+        </>
       )}
 
       {unsub && (

--- a/ui/src/pages/ViewDetail.tsx
+++ b/ui/src/pages/ViewDetail.tsx
@@ -39,10 +39,6 @@ export default function ViewDetail() {
       <div className="pagehead">
         <div>
           <h1><span className="mono">{view.name}</span></h1>
-          <p className="subtitle">
-            one read returns the correlated timeline of a <span className="mono">{view.key_field}</span>
-            {view.owned_by && <> · <ProjectBadge ownedBy={view.owned_by} customized={view.customized} /></>}
-          </p>
         </div>
         <span className="btnrow">
           <Link className="btn" to={`/triggers/new?view=${encodeURIComponent(view.name)}`}>+ trigger</Link>
@@ -63,6 +59,10 @@ export default function ViewDetail() {
       <div className="panel">
         <table>
           <tbody>
+            {view.owned_by && (
+              <tr><td className="help" style={{ width: 140 }}>part of</td>
+                  <td><ProjectBadge ownedBy={view.owned_by} customized={view.customized} compact /></td></tr>
+            )}
             <tr><td className="help" style={{ width: 140 }}>key field</td>
                 <td className="mono">{view.key_field}</td></tr>
             <tr><td className="help">sources</td>

--- a/ui/src/pages/ViewsTriggers.tsx
+++ b/ui/src/pages/ViewsTriggers.tsx
@@ -253,7 +253,7 @@ function TriggersSection({ triggers, viewNames, dispatches, loadError, onChange 
                   </td>
                 </tr>
               ))}
-              {!shown.length && <tr><td colSpan={5} className="dim" style={{ textAlign: "center", padding: 24 }}>no triggers match “{q}”</td></tr>}
+              {!shown.length && <tr><td colSpan={6} className="dim" style={{ textAlign: "center", padding: 24 }}>no triggers match the filter</td></tr>}
             </tbody>
           </table>
         </>

--- a/ui/src/pages/ViewsTriggers.tsx
+++ b/ui/src/pages/ViewsTriggers.tsx
@@ -26,13 +26,14 @@ export function ViewsPage() {
 export function TriggersPage() {
   const { data: triggers, error, reload } = usePolling(() => api.triggers(), 10000);
   const { data: views, error: viewsError } = usePolling(() => api.views(), 10000);
+  const { data: dispatches } = usePolling(() => api.dispatches(100), 15000);
 
   return (
     <>
       <h1>Triggers</h1>
-      <p className="subtitle">conditions that <em>wake an agent</em> with a timeline</p>
       {/* Either fetch failing is enough to make "no triggers" / "no views yet" a lie. */}
       <TriggersSection triggers={triggers ?? []} viewNames={(views ?? []).map((v) => v.name)}
+                       dispatches={dispatches ?? []}
                        loadError={error ?? viewsError} onChange={reload} />
     </>
   );
@@ -157,8 +158,12 @@ function ViewsSection({ views, triggers, loadError, onChange }:
 
 // ── triggers ─────────────────────────────────────────────────────────────────
 
-function TriggersSection({ triggers, viewNames, loadError, onChange }:
-  { triggers: Trigger[]; viewNames: string[]; loadError?: string; onChange: () => void }) {
+function TriggersSection({ triggers, viewNames, dispatches, loadError, onChange }:
+  { triggers: Trigger[]; viewNames: string[]; dispatches: import("../types").DispatchLogEntry[];
+    loadError?: string; onChange: () => void }) {
+  // newest first, so the first hit per trigger is its latest firing; older than the fetched
+  // window shows as a dash, which for a trigger list reads correctly as "not lately"
+  const lastFired = (name: string) => dispatches.find((d) => d.trigger === name)?.fired_at ?? null;
   const [error, setError] = useState<string>();
   const [q, setQ] = useState("");
   const [view, setView] = useState("all");
@@ -224,7 +229,7 @@ function TriggersSection({ triggers, viewNames, loadError, onChange }:
             <span className="count">{shown.length} of {triggers.length}</span>
           </div>
           <table>
-            <thead><tr><th>name</th><th>view</th><th>condition</th><th>cooldown</th><th></th></tr></thead>
+            <thead><tr><th>name</th><th>view</th><th>condition</th><th>cooldown</th><th>last fired</th><th></th></tr></thead>
             <tbody>
               {shown.map((t) => (
                 <tr key={t.name} style={t.paused ? { opacity: 0.55 } : undefined}>
@@ -237,6 +242,7 @@ function TriggersSection({ triggers, viewNames, loadError, onChange }:
                     {t.condition.aggregate}({t.condition.field ?? "*"}) {t.condition.predicate} over {t.condition.window}
                   </td>
                   <td className="mono">{t.cooldown}</td>
+                  <td style={{ whiteSpace: "nowrap" }}><TimeAgo ts={lastFired(t.name)} /></td>
                   <td style={{ textAlign: "right", whiteSpace: "nowrap" }}>
                     <span className="btnrow" style={{ justifyContent: "flex-end", flexWrap: "nowrap" }}>
                       <Link className="btn" to={`/triggers/${encodeURIComponent(t.name)}`}>agents</Link>

--- a/ui/src/pages/ViewsTriggers.tsx
+++ b/ui/src/pages/ViewsTriggers.tsx
@@ -185,7 +185,7 @@ function TriggersSection({ triggers, viewNames, dispatches, roster, slackChannel
             ? <Link key={a.name} to={`/agents/${encodeURIComponent(a.name)}`} className="chip mono">{a.name}</Link>
             : a.kind === "slack"
               ? <span key={a.name} className="chip">{channelLabel(a.name)}</span>
-              : <Link key={a.name} to={`/deliveries?agent=${encodeURIComponent(a.name)}`} className="chip mono">{a.name}</Link>)}
+              : <Link key={a.name} to={`/agents?agent=${encodeURIComponent(a.name)}`} className="chip mono">{a.name}</Link>)}
         {subs.length > 2 && (
           <span className="chip dim" title={subs.slice(2).map((a) => a.name).join(", ")}>
             +{subs.length - 2} more</span>

--- a/ui/src/pages/ViewsTriggers.tsx
+++ b/ui/src/pages/ViewsTriggers.tsx
@@ -38,22 +38,6 @@ export function TriggersPage() {
   );
 }
 
-/** Search-box + count toolbar (matches the other crisp tables). */
-function FilterBar({ q, setQ, placeholder, shown, total }: {
-  q: string; setQ: (s: string) => void; placeholder: string; shown: number; total: number;
-}) {
-  return (
-    <div className="toolbar">
-      <div className="search-box">
-        <Search />
-        <input type="text" className="search" placeholder={placeholder} value={q} onChange={(e) => setQ(e.target.value)} />
-      </div>
-      <span className="grow" />
-      <span className="count">{shown} of {total}</span>
-    </div>
-  );
-}
-
 // ── views ────────────────────────────────────────────────────────────────────
 
 function ViewsSection({ views, triggers, loadError, onChange }:
@@ -177,15 +161,18 @@ function TriggersSection({ triggers, viewNames, loadError, onChange }:
   { triggers: Trigger[]; viewNames: string[]; loadError?: string; onChange: () => void }) {
   const [error, setError] = useState<string>();
   const [q, setQ] = useState("");
+  const [view, setView] = useState("all");
   const [confirmDelName, setConfirmDelName] = useState<string | null>(null);
+
+  const viewOptions = useMemo(
+    () => Array.from(new Set(triggers.map((t) => t.view))).sort(), [triggers]);
 
   const shown = useMemo(() => {
     const needle = q.trim().toLowerCase();
-    return triggers.filter((t) => !needle ||
-      t.name.toLowerCase().includes(needle) ||
-      t.view.toLowerCase().includes(needle) ||
-      `${t.condition.aggregate}${t.condition.field ?? ""}${t.condition.predicate}`.toLowerCase().includes(needle));
-  }, [triggers, q]);
+    return triggers.filter((t) =>
+      (view === "all" || t.view === view) &&
+      (!needle || t.name.toLowerCase().includes(needle)));
+  }, [triggers, q, view]);
 
   const del = async (name: string) => {
     setError(undefined);
@@ -224,7 +211,18 @@ function TriggersSection({ triggers, viewNames, loadError, onChange }:
       )}
       {!!triggers.length && (
         <>
-          <FilterBar q={q} setQ={setQ} placeholder="Filter by name, view, condition…" shown={shown.length} total={triggers.length} />
+          <div className="toolbar">
+            <div className="search-box">
+              <Search />
+              <input type="text" className="search" placeholder="Filter by name…" value={q} onChange={(e) => setQ(e.target.value)} />
+            </div>
+            <Picker value={view} onChange={setView} ariaLabel="filter by view"
+                    style={{ width: 200 }}
+                    options={["all", ...viewOptions]}
+                    labels={{ all: "All views" }} />
+            <span className="grow" />
+            <span className="count">{shown.length} of {triggers.length}</span>
+          </div>
           <table>
             <thead><tr><th>name</th><th>view</th><th>condition</th><th>cooldown</th><th></th></tr></thead>
             <tbody>

--- a/ui/src/pages/ViewsTriggers.tsx
+++ b/ui/src/pages/ViewsTriggers.tsx
@@ -27,6 +27,8 @@ export function TriggersPage() {
   const { data: triggers, error, reload } = usePolling(() => api.triggers(), 10000);
   const { data: views, error: viewsError } = usePolling(() => api.views(), 10000);
   const { data: dispatches } = usePolling(() => api.dispatches(100), 15000);
+  const { data: roster } = usePolling(() => api.agents(), 15000);
+  const { data: slack } = usePolling(() => api.slackChannels(), 60000);
 
   return (
     <>
@@ -34,6 +36,7 @@ export function TriggersPage() {
       {/* Either fetch failing is enough to make "no triggers" / "no views yet" a lie. */}
       <TriggersSection triggers={triggers ?? []} viewNames={(views ?? []).map((v) => v.name)}
                        dispatches={dispatches ?? []}
+                       roster={roster?.agents ?? []} slackChannels={slack?.channels ?? []}
                        loadError={error ?? viewsError} onChange={reload} />
     </>
   );
@@ -158,9 +161,38 @@ function ViewsSection({ views, triggers, loadError, onChange }:
 
 // ── triggers ─────────────────────────────────────────────────────────────────
 
-function TriggersSection({ triggers, viewNames, dispatches, loadError, onChange }:
+function TriggersSection({ triggers, viewNames, dispatches, roster, slackChannels, loadError, onChange }:
   { triggers: Trigger[]; viewNames: string[]; dispatches: import("../types").DispatchLogEntry[];
+    roster: import("../types").AgentInfo[];
+    slackChannels: { id: string; name: string; is_private: boolean }[];
     loadError?: string; onChange: () => void }) {
+  const channelLabel = (raw: string) => {
+    const cid = raw.replace(/^#/, "");
+    const hit = slackChannels.find((c) => c.id === cid);
+    return hit ? (hit.is_private ? `🔒 ${hit.name}` : `#${hit.name}`) : raw;
+  };
+  // Everything subscribed to a trigger, from the same roster the Deliveries page shows. Active
+  // trigger + nobody = the warning; a paused trigger has its subscriptions parked by design.
+  const subscribers = (name: string) => roster.filter((a) => a.triggers.includes(name));
+  const SubscriberCell = ({ t }: { t: Trigger }) => {
+    if (t.paused) return <span className="dim">paused</span>;
+    const subs = subscribers(t.name);
+    if (!subs.length) return <span className="badge error">nobody</span>;
+    return (
+      <>
+        {subs.slice(0, 2).map((a) =>
+          a.kind === "tares"
+            ? <Link key={a.name} to={`/agents/${encodeURIComponent(a.name)}`} className="chip mono">{a.name}</Link>
+            : a.kind === "slack"
+              ? <span key={a.name} className="chip">{channelLabel(a.name)}</span>
+              : <Link key={a.name} to={`/deliveries?agent=${encodeURIComponent(a.name)}`} className="chip mono">{a.name}</Link>)}
+        {subs.length > 2 && (
+          <span className="chip dim" title={subs.slice(2).map((a) => a.name).join(", ")}>
+            +{subs.length - 2} more</span>
+        )}
+      </>
+    );
+  };
   // newest first, so the first hit per trigger is its latest firing; older than the fetched
   // window shows as a dash, which for a trigger list reads correctly as "not lately"
   const lastFired = (name: string) => dispatches.find((d) => d.trigger === name)?.fired_at ?? null;
@@ -229,7 +261,7 @@ function TriggersSection({ triggers, viewNames, dispatches, loadError, onChange 
             <span className="count">{shown.length} of {triggers.length}</span>
           </div>
           <table>
-            <thead><tr><th>name</th><th>view</th><th>condition</th><th>cooldown</th><th>last fired</th><th></th></tr></thead>
+            <thead><tr><th>name</th><th>view</th><th>condition</th><th>cooldown</th><th>last fired</th><th>subscribers</th><th></th></tr></thead>
             <tbody>
               {shown.map((t) => (
                 <tr key={t.name} style={t.paused ? { opacity: 0.55 } : undefined}>
@@ -243,6 +275,7 @@ function TriggersSection({ triggers, viewNames, dispatches, loadError, onChange 
                   </td>
                   <td className="mono">{t.cooldown}</td>
                   <td style={{ whiteSpace: "nowrap" }}><TimeAgo ts={lastFired(t.name)} /></td>
+                  <td><SubscriberCell t={t} /></td>
                   <td style={{ textAlign: "right", whiteSpace: "nowrap" }}>
                     <span className="btnrow" style={{ justifyContent: "flex-end", flexWrap: "nowrap" }}>
                       <Link className="btn" to={`/triggers/${encodeURIComponent(t.name)}`}>agents</Link>
@@ -253,7 +286,7 @@ function TriggersSection({ triggers, viewNames, dispatches, loadError, onChange 
                   </td>
                 </tr>
               ))}
-              {!shown.length && <tr><td colSpan={6} className="dim" style={{ textAlign: "center", padding: 24 }}>no triggers match the filter</td></tr>}
+              {!shown.length && <tr><td colSpan={7} className="dim" style={{ textAlign: "center", padding: 24 }}>no triggers match the filter</td></tr>}
             </tbody>
           </table>
         </>

--- a/ui/src/pages/ViewsTriggers.tsx
+++ b/ui/src/pages/ViewsTriggers.tsx
@@ -4,7 +4,7 @@ import { Link } from "react-router-dom";
 import { api } from "../api";
 import ConfirmDialog from "../components/ConfirmDialog";
 import { Search } from "../components/icons";
-import { EmptyState, ErrorState, TimeAgo, usePolling } from "../components/bits";
+import { EmptyState, ErrorState, Picker, TimeAgo, usePolling } from "../components/bits";
 import type { Trigger, View } from "../types";
 
 // Views and Triggers are two acts of "serve to agents": a view is a saved read; a trigger wakes
@@ -12,12 +12,13 @@ import type { Trigger, View } from "../types";
 
 export function ViewsPage() {
   const { data: views, error, reload } = usePolling(() => api.views(), 10000);
+  const { data: triggers } = usePolling(() => api.triggers(), 15000);
 
   return (
     <>
       <h1>Views</h1>
       <p className="subtitle">saved reads; <em>the queries you hand agents</em></p>
-      <ViewsSection views={views ?? []} loadError={error} onChange={reload} />
+      <ViewsSection views={views ?? []} triggers={triggers ?? []} loadError={error} onChange={reload} />
     </>
   );
 }
@@ -55,29 +56,30 @@ function FilterBar({ q, setQ, placeholder, shown, total }: {
 
 // ── views ────────────────────────────────────────────────────────────────────
 
-function AuthorBadge({ createdBy }: { createdBy?: string }) {
-  const isAgent = (createdBy ?? "human").startsWith("agent");
-  return (
-    <span className={`badge ${isAgent ? "agent" : "starting"}`}
-          title={isAgent ? `proposed by an agent via derive() (${createdBy})` : "authored by a human"}>
-      {isAgent ? "agent" : "human"}
-    </span>
-  );
-}
-
-function ViewsSection({ views, loadError, onChange }:
-  { views: View[]; loadError?: string; onChange: () => void }) {
+function ViewsSection({ views, triggers, loadError, onChange }:
+  { views: View[]; triggers: Trigger[]; loadError?: string; onChange: () => void }) {
   const [error, setError] = useState<string>();
   const [q, setQ] = useState("");
+  const [source, setSource] = useState("all");
+  const [trigger, setTrigger] = useState("all");
   const [confirmDelName, setConfirmDelName] = useState<string | null>(null);
+
+  const sourceOptions = useMemo(
+    () => Array.from(new Set(views.flatMap((v) => v.sources))).sort(), [views]);
+  const triggerOptions = useMemo(
+    () => Array.from(new Set(triggers.map((t) => t.name))).sort(), [triggers]);
+  const watchedBy = useMemo(() => {
+    const t = triggers.find((x) => x.name === trigger);
+    return t?.view;
+  }, [triggers, trigger]);
 
   const shown = useMemo(() => {
     const needle = q.trim().toLowerCase();
-    return views.filter((v) => !needle ||
-      v.name.toLowerCase().includes(needle) ||
-      v.key_field.toLowerCase().includes(needle) ||
-      v.sources.join(" ").toLowerCase().includes(needle));
-  }, [views, q]);
+    return views.filter((v) =>
+      (source === "all" || v.sources.includes(source)) &&
+      (trigger === "all" || v.name === watchedBy) &&
+      (!needle || v.name.toLowerCase().includes(needle)));
+  }, [views, q, source, trigger, watchedBy]);
 
   const del = async (name: string) => {
     setError(undefined);
@@ -99,16 +101,36 @@ function ViewsSection({ views, loadError, onChange }:
       )}
       {!!views.length && (
         <>
-          <FilterBar q={q} setQ={setQ} placeholder="Filter by name, key, source…" shown={shown.length} total={views.length} />
+          <div className="toolbar">
+            <div className="search-box">
+              <Search />
+              <input type="text" className="search" placeholder="Filter by name…" value={q} onChange={(e) => setQ(e.target.value)} />
+            </div>
+            <Picker value={source} onChange={setSource} ariaLabel="filter by source"
+                    style={{ width: 180 }}
+                    options={["all", ...sourceOptions]}
+                    labels={{ all: "All sources" }} />
+            <Picker value={trigger} onChange={setTrigger} ariaLabel="filter by trigger"
+                    style={{ width: 180 }}
+                    options={["all", ...triggerOptions]}
+                    labels={{ all: "All triggers" }} />
+            <span className="grow" />
+            <span className="count">{shown.length} of {views.length}</span>
+          </div>
           <table>
-            <thead><tr><th>name</th><th>author</th><th>key field</th><th>sources</th><th>filters</th><th>usage</th><th></th></tr></thead>
+            <thead><tr><th>name</th><th>key field</th><th>sources</th><th>filters</th><th>usage</th><th></th></tr></thead>
             <tbody>
               {shown.map((v) => (
                 <tr key={v.name}>
                   <td className="mono"><Link to={`/views/${encodeURIComponent(v.name)}`}>{v.name}</Link></td>
-                  <td><AuthorBadge createdBy={v.created_by} /></td>
                   <td className="mono">{v.key_field}</td>
-                  <td>{v.sources.map((s) => <span className="chip" key={s}>{s}</span>)}</td>
+                  <td>
+                    {v.sources.slice(0, 2).map((s) => <span className="chip" key={s}>{s}</span>)}
+                    {v.sources.length > 2 && (
+                      <span className="chip dim" title={v.sources.slice(2).join(", ")}>
+                        +{v.sources.length - 2} more</span>
+                    )}
+                  </td>
                   <td className="mono">
                     {(v.filters ?? []).map((f, i) => (
                       <span className="chip" key={i}>{f.field} {f.op} {String(f.value)}</span>
@@ -130,7 +152,7 @@ function ViewsSection({ views, loadError, onChange }:
                   </td>
                 </tr>
               ))}
-              {!shown.length && <tr><td colSpan={7} className="dim" style={{ textAlign: "center", padding: 24 }}>no views match “{q}”</td></tr>}
+              {!shown.length && <tr><td colSpan={6} className="dim" style={{ textAlign: "center", padding: 24 }}>no views match the filter</td></tr>}
             </tbody>
           </table>
         </>


### PR DESCRIPTION
Follow-up from testing on glassflow-web. The view and trigger cards get a Delete button (same confirm semantics as their standalone pages: the view warns how many triggers stop working). On the Firings tab, the time links to the existing dispatch detail page and the trigger name jumps to its card on Setup. UI only.