### PR TITLE
Custom project page: delivered-to column and a Subscribers box

### DIFF
--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -28,6 +28,7 @@ import McpServers from "./pages/McpServers";
 import Sources from "./pages/Sources";
 import { TriggersPage, ViewsPage } from "./pages/ViewsTriggers";
 import Projects from "./pages/Projects";
+import ProjectNew from "./pages/ProjectNew";
 import ProjectDetail from "./pages/ProjectDetail";
 import ProjectNewCustom from "./pages/ProjectNewCustom";
 import ProjectNewGeneric from "./pages/ProjectNewGeneric";
@@ -58,6 +59,7 @@ const router = createBrowserRouter([
       // here, so a customer arrives at the instance at a glance rather than at a table.
       { index: true, element: <Home /> },
       { path: "projects", element: <Projects /> },
+      { path: "projects/new", element: <ProjectNew /> },
       { path: "projects/new/shared_code_context", element: <ProjectNewSharedContext /> },
       { path: "projects/new/custom", element: <ProjectNewCustom /> },
       { path: "projects/new/:template", element: <ProjectNewGeneric /> },

--- a/ui/src/pages/ProjectCustom.tsx
+++ b/ui/src/pages/ProjectCustom.tsx
@@ -5,7 +5,7 @@ import { api } from "../api";
 import ConfirmDialog from "../components/ConfirmDialog";
 import TriggerEditor from "../components/TriggerEditor";
 import ViewEditor from "../components/ViewEditor";
-import { ErrorState, TimeAgo, usePolling } from "../components/bits";
+import { Picker, ErrorState, TimeAgo, usePolling } from "../components/bits";
 import AgentForm from "../components/AgentForm";
 import { RunsTable } from "./AgentDetail";
 import type { ProjectSummary } from "../types";
@@ -69,6 +69,31 @@ export default function ProjectCustom({ s, id, reload }: {
     return hit ? (hit.is_private ? `🔒 ${hit.name}` : `#${hit.name}`) : raw;
   };
   const subscribers = (trigger: string) => (roster?.agents ?? []).filter((a) => a.triggers.includes(trigger));
+
+  // subscriber management for the project's triggers (Slack, webhooks; Tares agents wire via
+  // their own creation flow). One row per subscription, so remove is exact.
+  const [adding, setAdding] = useState<null | "webhook" | "slack">(null);
+  const [subTrigger, setSubTrigger] = useState("");
+  const [subUrl, setSubUrl] = useState("");
+  const [subChannel, setSubChannel] = useState("");
+  const [subBusy, setSubBusy] = useState(false);
+  const [subMsg, setSubMsg] = useState<string>();
+  const [unsub, setUnsub] = useState<{ id: string; label: string } | null>(null);
+  const { reload: reloadRoster } = usePolling(() => api.agents(), 3600000);
+  const channels = slack?.channels ?? [];
+  const subRows = (roster?.agents ?? []).flatMap((a) =>
+    a.subscriptions.filter((sub) => triggerNames.has(sub.trigger))
+      .map((sub) => ({ a, sub })));
+  const addSubscription = async (url: string) => {
+    const t = subTrigger || myTriggers[0]?.name;
+    if (!t) return;
+    setSubBusy(true); setSubMsg(undefined);
+    try {
+      await api.subscribe(t, url);
+      setSubUrl(""); setSubChannel(""); setAdding(null); reload();
+    } catch (e) { setSubMsg(String((e as Error).message ?? e)); }
+    setSubBusy(false);
+  };
 
   const act = (fn: () => Promise<unknown>) => async () => {
     setActionError(undefined);
@@ -150,6 +175,95 @@ export default function ProjectCustom({ s, id, reload }: {
                           onSaved={() => { reloadTriggers(); reload(); }} />
           ))}
           {!myTriggers.length && <p className="help">none in this project</p>}
+
+          <div className="pagehead" style={{ marginTop: 24 }}>
+            <h2 style={{ margin: 0 }}>Subscribers</h2>
+            <span className="btnrow">
+              <Link className="btn" to={`/agents/new?trigger=${encodeURIComponent(subTrigger || myTriggers[0]?.name || "")}`}>Add a Tares agent</Link>
+              <button type="button" onClick={() => { setAdding(adding === "slack" ? null : "slack"); setSubMsg(undefined); }}>Add Slack channel</button>
+              <button type="button" onClick={() => { setAdding(adding === "webhook" ? null : "webhook"); setSubMsg(undefined); }}>Add webhook</button>
+            </span>
+          </div>
+          {subRows.length ? (
+            <table>
+              <thead><tr><th>subscriber</th><th>wakes on</th><th>delivered</th><th aria-label="actions" /></tr></thead>
+              <tbody>
+                {subRows.map(({ a, sub }) => (
+                  <tr key={sub.subscription_id}>
+                    <td>
+                      {a.kind === "tares"
+                        ? <Link to={`/agents/${encodeURIComponent(a.name)}`}><strong>{a.name}</strong></Link>
+                        : a.kind === "slack"
+                        ? <strong>{channelLabel(a.name)}</strong>
+                        : <strong>{a.name}</strong>}
+                      <span className="chip" style={{ marginLeft: 8 }}>
+                        {a.kind === "tares" ? "Tares agent" : a.kind === "slack" ? "Slack" : "webhook"}</span>
+                      {a.kind === "connected" && <span className="mono dim" style={{ marginLeft: 8 }}>{a.endpoint}</span>}
+                    </td>
+                    <td>
+                      <a href={`#trigger-${sub.trigger}`} className="chip mono"
+                         onClick={(e) => { e.preventDefault(); document.getElementById(`trigger-${sub.trigger}`)?.scrollIntoView({ behavior: "smooth", block: "start" }); }}>{sub.trigger}</a>
+                    </td>
+                    <td style={{ whiteSpace: "nowrap" }}>
+                      {a.delivered_ok_total
+                        ? <>{a.delivered_ok_total} · last <TimeAgo ts={a.last_woken} /></>
+                        : <span className="dim">none yet</span>}
+                      {a.delivered_fail_total > 0 && <span style={{ color: "var(--err)" }}> · {a.delivered_fail_total} failed</span>}
+                    </td>
+                    <td style={{ textAlign: "right" }}>
+                      <button className="danger"
+                              onClick={() => setUnsub({ id: sub.subscription_id, label: a.kind === "slack" ? channelLabel(a.name) : a.name })}>
+                        remove</button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          ) : <p className="help">nobody is subscribed to this project's triggers yet</p>}
+          {adding && (
+            <div className="panel" style={{ marginTop: 10 }}>
+              {myTriggers.length > 1 && (
+                <label className="field">
+                  <span className="lbl">trigger</span>
+                  <Picker value={subTrigger || myTriggers[0]?.name || ""} onChange={setSubTrigger}
+                          ariaLabel="trigger to subscribe to"
+                          options={myTriggers.map((t) => t.name)} />
+                </label>
+              )}
+              {adding === "webhook" ? (
+                <label className="field">
+                  <span className="lbl">webhook URL</span>
+                  <input type="text" className="mono" autoFocus placeholder="https://your-agent.example.com/hook"
+                         value={subUrl} onChange={(e) => setSubUrl(e.target.value)} />
+                  <span className="help">your agent's endpoint; it gets POSTed the timeline on every firing · <Link to="/connect?tab=push">what it receives</Link></span>
+                </label>
+              ) : (
+                <label className="field">
+                  <span className="lbl">channel</span>
+                  {channels.length > 0 ? (
+                    <Picker value={subChannel} onChange={setSubChannel} ariaLabel="Slack channel"
+                            options={["", ...channels.map((c) => c.id)]}
+                            labels={{ "": "choose a channel…",
+                                      ...Object.fromEntries(channels.map((c) => [c.id, c.is_private ? `🔒 ${c.name}` : `#${c.name}`])) }} />
+                  ) : (
+                    <input type="text" className="mono" autoFocus placeholder="C0123456789, or the channel's lowercase name"
+                           value={subChannel} onChange={(e) => setSubChannel(e.target.value)} />
+                  )}
+                  <span className="help">the workspace bot posts every firing there; add the bot to the channel in Slack first</span>
+                </label>
+              )}
+              <div className="btnrow">
+                <button className="primary" disabled={subBusy || (adding === "webhook" ? !subUrl.trim() : !subChannel.trim())}
+                        onClick={() => addSubscription(adding === "webhook"
+                          ? subUrl.trim()
+                          : `slack://channel/${(channels.length ? subChannel : subChannel.trim().replace(/^#/, ""))}`)}>
+                  {subBusy ? "…" : "Subscribe"}
+                </button>
+                <button type="button" onClick={() => setAdding(null)}>Cancel</button>
+              </div>
+              {subMsg && <p className="help" style={{ margin: "6px 0 0" }}>{subMsg}</p>}
+            </div>
+          )}
         </>
       )}
 
@@ -235,6 +349,18 @@ export default function ProjectCustom({ s, id, reload }: {
                           onShowTrigger={showTrigger} />))}
           {!names("agent").length && <p className="help">no agents in this project</p>}
         </>
+      )}
+
+      {unsub && (
+        <ConfirmDialog title={`Stop delivering to ${unsub.label}?`}
+          message="This trigger stops delivering to it; anything else it is subscribed to is unaffected, and its delivery history is kept."
+          confirmLabel="Remove" danger
+          onConfirm={async () => {
+            const u = unsub; setUnsub(null);
+            try { await api.unsubscribe(u.id); reloadRoster(); reload(); }
+            catch (e) { setActionError(String((e as Error).message ?? e)); }
+          }}
+          onCancel={() => setUnsub(null)} />
       )}
 
       {confirmDel && (

--- a/ui/src/pages/ProjectCustom.tsx
+++ b/ui/src/pages/ProjectCustom.tsx
@@ -189,12 +189,11 @@ export default function ProjectCustom({ s, id, reload }: {
           {dispatchesError && <ErrorState error={dispatchesError} what="the firings" />}
           {firings.length ? (
             <table>
-              <thead><tr><th>when</th><th>trigger</th><th>entity</th><th>delivered</th><th>agent</th><th>Slack</th></tr></thead>
+              <thead><tr><th>when</th><th>trigger</th><th>entity</th><th>delivered to</th></tr></thead>
               <tbody>
                 {firingRows.map((d) => {
                   const subs = subscribers(d.trigger);
-                  const tares = subs.filter((a) => a.kind === "tares");
-                  const chans = subs.filter((a) => a.kind === "slack");
+                  const partial = d.subscribers > 0 && d.delivered < d.subscribers;
                   return (
                     <tr key={d.dispatch_id}>
                       <td style={{ whiteSpace: "nowrap" }}>
@@ -208,16 +207,17 @@ export default function ProjectCustom({ s, id, reload }: {
                       <td>{d.subscribers === 0
                         ? <><span className="badge error">nobody subscribed</span>
                             {(d.repeats ?? 1) > 1 && <span className="help"> · {d.repeats} firings like this</span>}</>
-                        : <>{d.delivered} of {d.subscribers}
-                            {d.error && <span className="help" title={d.error}> · {d.error.slice(0, 60)}</span>}</>}</td>
-                      <td>{tares.length
-                        ? tares.map((a) => (
-                            <a key={a.name} href="#agents" onClick={(e) => { e.preventDefault(); openInAgents(d.dispatch_id); }}
-                               className="mono" title="open this firing's run below">{a.name}</a>))
-                        : <span className="dim">—</span>}</td>
-                      <td>{chans.length
-                        ? chans.map((a) => <span key={a.name} className="chip">{channelLabel(a.name)}</span>)
-                        : <span className="dim">—</span>}</td>
+                        : subs.length === 0
+                        ? <span className={`badge ${partial ? "error" : "ok"}`}>{d.delivered} of {d.subscribers}</span>
+                        : subs.map((a) => a.kind === "tares"
+                            ? <a key={a.name} href="#agents" className="chip mono"
+                                 onClick={(e) => { e.preventDefault(); openInAgents(d.dispatch_id); }}
+                                 title={partial ? (d.error ?? "not every delivery succeeded") : "delivered · open this firing's run below"}
+                                 style={{ marginRight: 4, color: partial ? "var(--err)" : "var(--ok, #2e7d43)" }}>{a.name}</a>
+                            : <span key={a.name} className="chip"
+                                    title={partial ? (d.error ?? "not every delivery succeeded") : "delivered"}
+                                    style={{ marginRight: 4, color: partial ? "var(--err)" : "var(--ok, #2e7d43)" }}>
+                                {a.kind === "slack" ? channelLabel(a.name) : a.name}</span>)}</td>
                     </tr>
                   );
                 })}

--- a/ui/src/pages/ProjectCustom.tsx
+++ b/ui/src/pages/ProjectCustom.tsx
@@ -101,6 +101,11 @@ export default function ProjectCustom({ s, id, reload }: {
   };
 
   const openInAgents = (dispatchId: string) => { setFocusDispatch(dispatchId); setTab("agents"); };
+  // a project agent's home is the Agents tab of this page; switch there and scroll to it
+  const openAgentTab = (name: string) => {
+    setFocusDispatch(undefined); setTab("agents");
+    setTimeout(() => document.getElementById(`agent-${name}`)?.scrollIntoView({ behavior: "smooth", block: "start" }), 60);
+  };
   // the trigger card lives on the Setup tab; switch there, then scroll once it is rendered
   const showTrigger = (name: string) => {
     setTab("setup");
@@ -192,7 +197,9 @@ export default function ProjectCustom({ s, id, reload }: {
                   <tr key={sub.subscription_id}>
                     <td>
                       {a.kind === "tares"
-                        ? <Link to={`/agents/${encodeURIComponent(a.name)}`}><strong>{a.name}</strong></Link>
+                        ? names("agent").includes(a.name)
+                          ? <a href="#agents" onClick={(e) => { e.preventDefault(); openAgentTab(a.name); }}><strong>{a.name}</strong></a>
+                          : <Link to={`/agents/${encodeURIComponent(a.name)}`}><strong>{a.name}</strong></Link>
                         : a.kind === "slack"
                         ? <strong>{channelLabel(a.name)}</strong>
                         : <strong>{a.name}</strong>}
@@ -530,7 +537,7 @@ function AgentSection({ name, focusDispatch, triggerInProject, onShowTrigger }: 
     } catch (e) { setErr(String((e as Error).message ?? e)); }
   };
   return (
-    <div style={{ marginBottom: 28 }}>
+    <div style={{ marginBottom: 28 }} id={`agent-${name}`}>
       <div className="pagehead" style={{ marginBottom: 8 }}>
         <div>
           <h2 style={{ margin: 0 }}><span className="mono">{agent.name}</span>{" "}<span className="badge">Tares agent</span></h2>

--- a/ui/src/pages/ProjectNew.tsx
+++ b/ui/src/pages/ProjectNew.tsx
@@ -1,0 +1,106 @@
+import { useNavigate } from "react-router-dom";
+
+import { api } from "../api";
+import { ErrorState, usePolling } from "../components/bits";
+import type { Template } from "../types";
+
+// The gallery behind "Create new" on /projects: one card per way to start a project. Templates
+// the console knows how to set up with a dedicated wizard; anything else the API lists still gets
+// a card, routed to the generic (params-driven) form.
+const WIZARDS: Record<string, string> = {
+  shared_code_context: "/projects/new/shared_code_context",
+};
+
+// What each template wires up, in the user's words. The daemon's describe() may carry mode-aware
+// facts (ai_sre_demo says different things against a hosted stack than against local docker);
+// this map is the fallback for templates that don't, and for older daemons.
+const TEMPLATE_FACTS: Record<string, { you: string[]; tares: string[] }> = {
+  ai_sre_demo: {
+    you: ["start the demo stack with docker compose", "give the agent an Anthropic key", "cause an incident from the project page"],
+    tares: ["three sources keyed by service: Prometheus metrics, the api-server's logs, the alerts Prometheus fires", "one timeline per service to explore", "a trigger that wakes the agent when an alert fires", "an agent that writes the first incident note back onto the timeline"],
+  },
+  shared_code_context: {
+    you: ["pick the code repos to watch", "pick the repo that holds the shared context", "choose when it runs and how it writes"],
+    tares: ["a source for each repo, so its commits flow into Tares", "a timeline per repo you can explore and query", "a trigger that wakes the agent when new commits land", "an agent that reads each change and updates the context repo, opening a pull request"],
+  },
+};
+
+function TemplateCard({ r }: { r: Template }) {
+  const navigate = useNavigate();
+  const to = WIZARDS[r.key] ?? `/projects/new/${encodeURIComponent(r.key)}`;
+  const facts = r.facts ?? TEMPLATE_FACTS[r.key];
+  return (
+    <div className="panel uc-card">
+      <div className="uc-card-main">
+        <div className="uc-card-title">
+          {r.title}
+          {(r.tags ?? []).map((t) => <span key={t} className="badge" style={{ marginLeft: 8, verticalAlign: "middle" }}>{t}</span>)}
+        </div>
+        <div className="help" style={{ marginTop: 2 }}>Tares template</div>
+        <p className="help uc-card-desc">
+          {r.description}
+          {r.guide && <> Follows the <a href={r.guide.url} target="_blank" rel="noreferrer">{r.guide.label}</a>.</>}
+        </p>
+        {facts && (
+          <div className="uc-card-facts">
+            <div>
+              <div className="lbl">you</div>
+              <ul>{facts.you.map((t) => <li key={t}>{t}</li>)}</ul>
+            </div>
+            <div>
+              <div className="lbl">Tares sets up</div>
+              <ul>{facts.tares.map((t) => <li key={t}>{t}</li>)}</ul>
+            </div>
+          </div>
+        )}
+      </div>
+      <div className="uc-card-side">
+        <button className="primary" onClick={() => navigate(to)}>Set up</button>
+      </div>
+    </div>
+  );
+}
+
+export default function ProjectNew() {
+  const navigate = useNavigate();
+  const { data: rec, error: recError, reload: reloadRec } = usePolling(() => api.templates(), 60000);
+  const templates = rec?.templates ?? [];
+
+  return (
+    <>
+      <div className="pagehead">
+        <div>
+          <h1>New project</h1>
+          <p className="subtitle">
+            start from a Tares template: answer a few questions and Tares creates the objects
+            behind it, each visible and editable on its own page. Or assemble one from objects
+            you already have.
+          </p>
+        </div>
+      </div>
+
+      {recError && <ErrorState error={recError} what="the project catalog" onRetry={reloadRec} />}
+      {!rec && !recError && <div className="dim">loading…</div>}
+      {rec && templates.length === 0 && (
+        <div className="empty">No templates are registered on this instance yet.</div>
+      )}
+      <div className="uc-cards">
+        {templates.map((r) => <TemplateCard key={r.key} r={r} />)}
+        {rec && (
+          <div className="panel uc-card">
+            <div className="uc-card-main">
+              <div className="uc-card-title">From existing objects</div>
+              <p className="help uc-card-desc">
+                Assemble a project from sources, views, triggers, agents and MCP servers you already have.
+                Nothing is created; the project page shows their runs and firings.
+              </p>
+            </div>
+            <div className="uc-card-side">
+              <button className="primary" onClick={() => navigate("/projects/new/custom")}>Assemble</button>
+            </div>
+          </div>
+        )}
+      </div>
+    </>
+  );
+}

--- a/ui/src/pages/Projects.tsx
+++ b/ui/src/pages/Projects.tsx
@@ -1,18 +1,11 @@
-import { Link, useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
 
 import { api } from "../api";
 import { ErrorState, TimeAgo, usePolling } from "../components/bits";
-import type { Template, Project } from "../types";
+import type { Project } from "../types";
 
-// Projects are the opinionated entry point: pick one, answer a few questions, click Start, and
-// Tares creates the sources, view, trigger and agent for you. Everything it creates is an ordinary
-// object on its normal page; this page and the instance page are the combined view.
-
-// Templates the console knows how to set up with a dedicated wizard. Anything else the API lists
-// still gets a card, routed to the generic (params-driven) form.
-const WIZARDS: Record<string, string> = {
-  shared_code_context: "/projects/new/shared_code_context",
-};
+// Projects are the opinionated entry point: a named set of sources, views, triggers and agents
+// with one page. This page lists them; Create new (/projects/new) holds the template gallery.
 
 function statusClass(s: Project["status"]) {
   return s === "active" ? "ok" : s === "paused" ? "paused" : "error";
@@ -24,61 +17,8 @@ export function projectKindCounts(u: Project) {
   return c;
 }
 
-// What each template wires up, in the user's words. The daemon's describe() may carry mode-aware
-// facts (ai_sre_demo says different things against a hosted stack than against local docker);
-// this map is the fallback for templates that don't, and for older daemons.
-const TEMPLATE_FACTS: Record<string, { you: string[]; tares: string[] }> = {
-  ai_sre_demo: {
-    you: ["start the demo stack with docker compose", "give the agent an Anthropic key", "cause an incident from the project page"],
-    tares: ["three sources keyed by service: Prometheus metrics, the api-server's logs, the alerts Prometheus fires", "one timeline per service to explore", "a trigger that wakes the agent when an alert fires", "an agent that writes the first incident note back onto the timeline"],
-  },
-  shared_code_context: {
-    you: ["pick the code repos to watch", "pick the repo that holds the shared context", "choose when it runs and how it writes"],
-    tares: ["a source for each repo, so its commits flow into Tares", "a timeline per repo you can explore and query", "a trigger that wakes the agent when new commits land", "an agent that reads each change and updates the context repo, opening a pull request"],
-  },
-};
-
-function TemplateCard({ r }: { r: Template }) {
-  const navigate = useNavigate();
-  const to = WIZARDS[r.key] ?? `/projects/new/${encodeURIComponent(r.key)}`;
-  const facts = r.facts ?? TEMPLATE_FACTS[r.key];
-  return (
-    <div className="panel uc-card">
-      <div className="uc-card-main">
-        <div className="uc-card-title">
-          {r.title}
-          {(r.tags ?? []).map((t) => <span key={t} className="badge" style={{ marginLeft: 8, verticalAlign: "middle" }}>{t}</span>)}
-        </div>
-        <div className="help" style={{ marginTop: 2 }}>Tares template</div>
-        <p className="help uc-card-desc">
-          {r.description}
-          {r.guide && <> Follows the <a href={r.guide.url} target="_blank" rel="noreferrer">{r.guide.label}</a>.</>}
-        </p>
-        {facts && (
-          <div className="uc-card-facts">
-            <div>
-              <div className="lbl">you</div>
-              <ul>{facts.you.map((t) => <li key={t}>{t}</li>)}</ul>
-            </div>
-            <div>
-              <div className="lbl">Tares sets up</div>
-              <ul>{facts.tares.map((t) => <li key={t}>{t}</li>)}</ul>
-            </div>
-          </div>
-        )}
-      </div>
-      <div className="uc-card-side">
-        <button className="primary" onClick={() => navigate(to)}>Set up</button>
-      </div>
-    </div>
-  );
-}
-
 export default function Projects() {
-  const navigate = useNavigate();
-  const { data: rec, error: recError, reload: reloadRec } = usePolling(() => api.templates(), 60000);
   const { data: inst, error: instError, reload: reloadInst } = usePolling(() => api.projects(), 10000);
-  const templates = rec?.templates ?? [];
   const projects = inst?.projects ?? [];
 
   return (
@@ -87,18 +27,27 @@ export default function Projects() {
         <div>
           <h1>Projects</h1>
           <p className="subtitle">
-            what you set up and look after in Tares: a named set of sources, views, triggers and agents with one
-            page. Start one from a Tares template: answer a few questions and Tares creates the objects behind it,
-            each visible and editable on its own page.
+            what you set up and look after in Tares: a named set of sources, views, triggers and
+            agents with one page.
           </p>
         </div>
+        <span className="btnrow">
+          <Link className="btn primary" to="/projects/new">Create new</Link>
+        </span>
       </div>
 
-      {recError && <ErrorState error={recError} what="the project catalog" onRetry={reloadRec} />}
       {instError && <ErrorState error={instError} what="your projects" onRetry={reloadInst} />}
+      {!inst && !instError && <div className="dim">loading…</div>}
 
-      {inst && projects.length > 0 && (
-        <table style={{ marginBottom: 24 }}>
+      {inst && projects.length === 0 && (
+        <div className="empty">
+          no projects yet · <Link to="/projects/new">create one</Link> from a template or from
+          objects you already have
+        </div>
+      )}
+
+      {projects.length > 0 && (
+        <table>
           <thead>
             <tr>
               <th>name</th><th>project</th><th>status</th><th>objects</th><th>updated</th>
@@ -134,29 +83,6 @@ export default function Projects() {
           </tbody>
         </table>
       )}
-
-      <h2 style={{ marginTop: projects.length > 0 ? 8 : 18 }}>{projects.length > 0 ? "Start another" : "Templates"}</h2>
-      {!rec && !recError && <div className="dim">loading…</div>}
-      {rec && templates.length === 0 && (
-        <div className="empty">No templates are registered on this instance yet.</div>
-      )}
-      <div className="uc-cards">
-        {templates.map((r) => <TemplateCard key={r.key} r={r} />)}
-        {rec && (
-          <div className="panel uc-card">
-            <div className="uc-card-main">
-              <div className="uc-card-title">From existing objects</div>
-              <p className="help uc-card-desc">
-                Assemble a project from sources, views, triggers, agents and MCP servers you already have.
-                Nothing is created; the project page shows their runs and firings.
-              </p>
-            </div>
-            <div className="uc-card-side">
-              <button className="primary" onClick={() => navigate("/projects/new/custom")}>Assemble</button>
-            </div>
-          </div>
-        )}
-      </div>
     </>
   );
 }


### PR DESCRIPTION
On the custom project page, tested on glassflow-web:

- Firings tab: the delivered "2 of 2" plus separate agent and Slack columns become one "delivered to" column with the actual recipients, colored by outcome (green when everything landed, red when something failed).
- Setup tab gets a Subscribers box: one row per subscription on the project's triggers (Tares agents, Slack channels, webhooks) with what each received and a remove button, plus add actions for a Tares agent, a Slack channel and a webhook.
- A project agent in that box links to the Agents tab of the page; agents outside the project keep linking to their own page.