### PR TITLE
Project page polish: no How it works, aligned change history

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -22,28 +22,24 @@ type NavItem = {
   kbd?: string;     // keyboard-shortcut hint, e.g. "⌘K"
 };
 
-// One layer, three named groups (TR-137): the confusion was naming and grouping, not depth.
-// Overview and Ask sit above the groups: where you land, and the global assistant (⌘K).
+// Two named groups. Projects are the product, so they sit at the top with Overview and Ask;
+// everything a project is made of is one flat Catalog group ordered along the pipeline
+// (sources feed views, views wake triggers, triggers run agents, agents leave firings).
+// The old Data / Automate split was mechanism vocabulary and is gone.
 const NAV_GROUPS: { section: string; items: NavItem[] }[] = [
   { section: "", items: [
     { to: "/", end: true, label: "Overview", icon: Grid },
+    { to: "/projects", label: "Projects", icon: Zap },
     { to: "/ask", label: "Ask", icon: Chat, kbd: "⌘K" },
   ] },
-  // Projects sit above the primitives: the opinionated entry point (pick one, answer a few
-  // questions, Start) that creates ordinary sources, views, triggers and agents below it.
-  { section: "Projects", items: [
-    { to: "/projects", label: "Projects", icon: Zap },
-  ] },
-  { section: "Data", items: [
+  { section: "Catalog", items: [
     { to: "/sources", label: "Sources", icon: Database },
-    { to: "/explore", label: "Explore", icon: Activity },
     { to: "/views", label: "Views", icon: Book },
-  ] },
-  { section: "Automate", items: [
     { to: "/triggers", label: "Triggers", icon: Bolt },
     { to: "/agents", label: "Tares agents", icon: Chat },
-    { to: "/mcp-servers", label: "MCP servers", icon: Terminal },
     { to: "/firings", label: "Firings", icon: Filter },
+    { to: "/mcp-servers", label: "MCP servers", icon: Terminal },
+    { to: "/explore", label: "Explore", icon: Activity },
   ] },
   { section: "Agent access", items: [
     { to: "/connect", label: "Connect", icon: Terminal },

--- a/ui/src/pages/ProjectShell.tsx
+++ b/ui/src/pages/ProjectShell.tsx
@@ -19,36 +19,6 @@ import type { ProjectSummary, Template, RecipeActionOption } from "../types";
 // like the agent's own page), and Sessions when the template reports them. Template-specific
 // content arrives as data (actions, facts, panels, cards), never as template-specific markup.
 
-const HOW_IT_WORKS: Record<string, string[]> = {
-  shared_code_context: [
-    "Each source repo is a commits source keyed by repo; the view puts every repo on its own timeline.",
-    "The trigger fires when commits land, once per repo per cooldown, with the recent commits attached.",
-    "The agent reads each diff through the GitHub MCP server, updates the context repo, and writes a finding on the timeline.",
-    "Pause stops the trigger and agent; sources keep ingesting so the timeline stays complete.",
-  ],
-  ai_sre_demo: [
-    "Three sources keyed by service: Prometheus metrics, the api-server's container logs, and the alerts Prometheus's own rules fire.",
-    "The service_timeline view merges them on one clock; Explore shows exactly what an agent reads.",
-    "The incident trigger fires when an alert event lands (Prometheus keeps owning alerting; nothing is re-thresholded).",
-    "incident-first-look wakes with the correlated timeline and writes an incident note back onto it. Cause an incident above and watch it happen.",
-  ],
-  challenger_workflow: [
-    "In Claude Code, /tares:challenger marks the session; the plugin then runs Codex on the plan when you leave plan mode and on every commit, and blocks on P1/P2 findings until fixed or waived.",
-    "The plugin streams the session, with every Codex review, into the claude_code source, keyed by session.",
-    "When the session ends, the trigger fires and the summarizer reads the whole session and writes a summary with memory proposals.",
-    "Accept a proposal on the Sessions tab to store it as memory for the repo; the plugin gives it to Claude at the start of the next session in that repo.",
-  ],
-  custom: [
-    "You assembled this project from objects that already existed; nothing was created for it.",
-    "Runs are the runs of its agents; the trigger cards come from its triggers.",
-    "Edit adds or removes objects. Removing one from the project, or deleting the project, leaves the object in place.",
-    "Pause stops its triggers and agents; sources keep ingesting so the timeline stays complete.",
-  ],
-  default: [
-    "The project created ordinary sources, views, triggers and agents; every object is on this page and on its own page.",
-    "Pause stops the trigger and agent; sources keep ingesting so the timeline stays complete.",
-  ],
-};
 
 const fmtCond = (t: { condition: { aggregate: string; field?: string | null; predicate: string; window: string } }) =>
   `${t.condition.aggregate}(${t.condition.field || "*"}) ${t.condition.predicate} over ${t.condition.window}`;
@@ -298,13 +268,6 @@ export default function ProjectShell({ s, id, reload, template }: {
         </InfoDialog>
       )}
 
-      <details className="panel uc-how" style={{ marginBottom: 8 }}>
-        <summary>How it works</summary>
-        <ol className="help" style={{ margin: "8px 0 0", paddingLeft: 20 }}>
-          {(HOW_IT_WORKS[s.template] ?? HOW_IT_WORKS.default).map((t) => <li key={t}>{t}</li>)}
-        </ol>
-      </details>
-
       <div className="tabs" style={{ marginTop: 6 }}>
         {s.sessions && <button className={tab === "sessions" ? "active" : ""} onClick={() => setTab("sessions")}>Sessions</button>}
         <button className={tab === "setup" ? "active" : ""} onClick={() => setTab("setup")}>Setup</button>
@@ -484,15 +447,15 @@ export default function ProjectShell({ s, id, reload, template }: {
           )}
 
           {s.log && s.log.length > 0 && (
-            <details className="panel uc-how" style={{ marginTop: 20 }}>
-              <summary>Change history</summary>
-              <table style={{ marginTop: 8 }}>
+            <details style={{ marginTop: 24 }}>
+              <summary style={{ cursor: "pointer" }}><h2 style={{ display: "inline", marginLeft: 6 }}>Change history</h2></summary>
+              <table style={{ marginTop: 10 }}>
                 <tbody>
                   {s.log.map((l, i) => (
                     <tr key={i}>
-                      <td style={{ whiteSpace: "nowrap" }}><TimeAgo ts={l.at} /></td>
-                      <td className="mono">{l.action}</td>
-                      <td className="help">{l.detail}</td>
+                      <td style={{ whiteSpace: "nowrap", width: 90, verticalAlign: "top" }}><TimeAgo ts={l.at} /></td>
+                      <td className="mono" style={{ whiteSpace: "nowrap", width: 90, verticalAlign: "top" }}>{l.action}</td>
+                      <td className="help" style={{ overflowWrap: "anywhere" }}>{l.detail}</td>
                     </tr>
                   ))}
                 </tbody>


### PR DESCRIPTION
Removes the How it works box (what the project is lives on the creation page) and aligns Change history with the other Setup sections: a plain heading and a regular table instead of an inset panel.