### PR TITLE
Deleting a project with purge also deletes its triggers' firings

### DIFF
--- a/tares/projects/engine.py
+++ b/tares/projects/engine.py
@@ -252,10 +252,13 @@ class Engine:
             return {"ok": True, "deleted": [], "released": [f"{o.kind}:{o.name}" for o in objs],
                     "purged_events": purged}
         purged = self._delete_objects(objs, purge_events=purge_events)
+        # firings go with the events: a purged project leaves no history behind its triggers
+        purged_firings = sum(self.store.purge_dispatches(o.name)
+                             for o in objs if o.kind == "trigger") if purge_events else 0
         self.store.delete_project(uid)
         self._do_reload()
         return {"ok": True, "deleted": [f"{o.kind}:{o.name}" for o in objs],
-                "purged_events": purged}
+                "purged_events": purged, "purged_firings": purged_firings}
 
     async def detect(self, template_key: str) -> dict:
         template = get_template(template_key)

--- a/tares/store.py
+++ b/tares/store.py
@@ -1748,6 +1748,26 @@ class Store:
         ).fetchall()
         return [{"value": r[0], "events": r[1], "last_ingest": r[2]} for r in rows]
 
+    def purge_dispatches(self, trigger: str) -> int:
+        """Delete a trigger's firing history: its dispatch_log rows, their per-recipient
+        deliveries, and its cooldown state. Used when a project is deleted with purge, so a
+        re-created demo does not open on last week's firings."""
+        with self._lock:
+            n = self.con.execute(
+                "SELECT COUNT(*) FROM dispatch_log WHERE trigger = ?", [trigger]).fetchone()[0]
+            self.con.execute("BEGIN TRANSACTION")
+            try:
+                self.con.execute(
+                    "DELETE FROM dispatch_deliveries WHERE dispatch_id IN "
+                    "(SELECT dispatch_id FROM dispatch_log WHERE trigger = ?)", [trigger])
+                self.con.execute("DELETE FROM dispatch_log WHERE trigger = ?", [trigger])
+                self.con.execute("DELETE FROM trigger_state WHERE trigger = ?", [trigger])
+                self.con.execute("COMMIT")
+            except Exception:
+                self.con.execute("ROLLBACK")
+                raise
+        return int(n)
+
     def purge_events(self, source: str) -> int:
         with self._lock:
             n = self.con.execute(

--- a/ui/src/pages/ProjectShell.tsx
+++ b/ui/src/pages/ProjectShell.tsx
@@ -611,7 +611,9 @@ export default function ProjectShell({ s, id, reload, template }: {
           onCancel={() => setConfirmDel(false)}>
           <label style={{ display: "block", marginTop: 8 }}>
             <input type="checkbox" checked={purge} onChange={(e) => setPurge(e.target.checked)} />{" "}
-            also purge the events its sources ingested
+            {custom
+              ? "also purge the events its sources ingested"
+              : "also purge the events its sources ingested and its triggers' firings"}
           </label>
         </ConfirmDialog>
       )}


### PR DESCRIPTION
Deleting a demo project with purge removed the events but left every firing on /firings, pointing at a trigger that no longer exists. With purge checked, a template project's delete now also removes its triggers' dispatch log, the per-recipient deliveries, and the cooldown state; the dialog says so. Custom projects are unchanged: their triggers live on, so their history stays.