### PR TITLE
rius_rca template: the proven RCA loop as one project (TR-223)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Backend — install + tests
         run: |
           pip install -e .
-          for t in test_labels test_normalize test_auth test_api_keys test_pricing test_agents test_catalog_sync test_cli test_status test_usage test_slack test_slack_verify test_slack_ask test_degraded test_loki test_projects test_ai_sre_demo test_seed test_session_flow test_challenger_workflow test_plugin_challenger; do
+          for t in test_labels test_normalize test_auth test_api_keys test_pricing test_agents test_catalog_sync test_cli test_status test_usage test_slack test_slack_verify test_slack_ask test_degraded test_loki test_projects test_rius_rca test_ai_sre_demo test_seed test_session_flow test_challenger_workflow test_plugin_challenger; do
             echo "== $t =="
             python "tests/$t.py"
           done

--- a/tares/daemon.py
+++ b/tares/daemon.py
@@ -217,6 +217,11 @@ def _degraded_app(reason: str) -> FastAPI:
 
     @app.get("/{path:path}", include_in_schema=False)
     async def ui(path: str):
+        # An unmatched /api/* or /ingest/* path must never answer with the SPA's HTML and a 200 —
+        # a client checking the status reads that as success and fails to parse (TR-226). The
+        # console never requests these prefixes, so nothing legitimate is lost.
+        if path == "api" or path.startswith(("api/", "ingest/")):
+            _err(KeyError(f"unknown API path /{path}"), 404)
         return _serve_ui(path)
 
     return app
@@ -256,7 +261,7 @@ class SourceIn(BaseModel):
 
 
 class ViewIn(BaseModel):
-    name: str
+    name: str = ""               # required on create; PUT fills it from the path (TR-226)
     key_field: str = ""          # optional: what the primary key means; labels make it non-essential
     sources: list[str]
     filters: list[dict] = []
@@ -287,7 +292,7 @@ class TriggerIn(BaseModel):
 
 
 class AgentIn(BaseModel):
-    name: str
+    name: str = ""               # required on create; PUT fills it from the path (TR-226)
     trigger: str
     prompt: str
     slack_webhook: str = ""      # legacy per-agent notification path (blank-to-keep on update)
@@ -1013,6 +1018,11 @@ def make_app() -> FastAPI:
                 "distinct_before": len({b for b, _ in pairs}),
                 "distinct_after": len({a for _, a in pairs})}
 
+    @app.get("/api/sources/discover", include_in_schema=False)
+    async def discover_source_get():
+        _err(ValueError("discover is POST-only: POST /api/sources/discover "
+                        "{connector, config}"), 405)
+
     @app.post("/api/sources/discover")
     async def discover_source(body: dict = Body(...)):
         from .connectors import REGISTRY
@@ -1513,6 +1523,8 @@ def make_app() -> FastAPI:
 
     @app.post("/api/views", status_code=201)
     async def create_view(body: ViewIn):
+        if not body.name:
+            _err(ValueError("name is required"), 400)
         if body.name in runtime.catalog.views:
             _err(ValueError(f"view {body.name!r} already exists"), 409)
         try:
@@ -1527,10 +1539,12 @@ def make_app() -> FastAPI:
     async def update_view(name: str, body: ViewIn):
         if name not in runtime.catalog.views:
             _err(KeyError(f"unknown view {name!r}"), 404)
-        if body.name != name:
+        # the path names the view; a body name is optional and only checked for a rename attempt
+        if body.name and body.name != name:
             _err(ValueError("renaming a view is not supported; delete and recreate"), 400)
         try:
-            validate_view_dict(body.model_dump(), set(runtime.catalog.sources))
+            validate_view_dict({**body.model_dump(), "name": name},
+                               set(runtime.catalog.sources))
         except CatalogError as e:
             _err(e)
         store.upsert_catalog_view(name, body.key_field, body.sources, body.filters,
@@ -1664,6 +1678,8 @@ def make_app() -> FastAPI:
 
     @app.post("/api/agents/builtin", status_code=201)
     async def create_builtin_agent(body: AgentIn):
+        if not body.name:
+            _err(ValueError("name is required"), 400)
         if store.get_catalog_agent(body.name) is not None:
             _err(ValueError(f"agent {body.name!r} already exists"), 409)
         _agent_payload(body)
@@ -1680,7 +1696,8 @@ def make_app() -> FastAPI:
         existing = store.get_catalog_agent(name)
         if existing is None:
             _err(KeyError(f"unknown agent {name!r}"), 404)
-        if body.name != name:
+        # the path names the agent; a body name is optional and only checked for a rename attempt
+        if body.name and body.name != name:
             _err(ValueError("renaming an agent is not supported; delete and recreate"), 400)
         _agent_payload(body)
         # blank-to-keep for the webhook, matching the connector-secret convention: the UI never
@@ -2304,6 +2321,11 @@ def make_app() -> FastAPI:
     # ── console UI (built SPA; catch-all registered last so API routes win) ──
     @app.get("/{path:path}", include_in_schema=False)
     async def ui(path: str):
+        # An unmatched /api/* or /ingest/* path must never answer with the SPA's HTML and a 200 —
+        # a client checking the status reads that as success and fails to parse (TR-226). The
+        # console never requests these prefixes, so nothing legitimate is lost.
+        if path == "api" or path.startswith(("api/", "ingest/")):
+            _err(KeyError(f"unknown API path /{path}"), 404)
         return _serve_ui(path)
 
     return app

--- a/tares/projects/__init__.py
+++ b/tares/projects/__init__.py
@@ -13,6 +13,7 @@ from . import shared_code_context as _shared_code_context  # noqa: F401  (regist
 from . import ai_sre_demo as _ai_sre_demo  # noqa: F401  (registers itself)
 from . import challenger_workflow as _challenger_workflow  # noqa: F401  (registers itself)
 from . import custom as _custom  # noqa: F401  (registers itself)
+from . import rius_rca as _rius_rca  # noqa: F401  (registers itself)
 
 __all__ = ["Engine", "PlannedObject", "Template", "ProjectError",
            "get_template", "list_templates", "register"]

--- a/tares/projects/rius_rca.py
+++ b/tares/projects/rius_rca.py
@@ -1,0 +1,161 @@
+"""The `rius_rca` template: the Tares half of the Rius RCA integration (TR-223).
+
+One project per Rius workspace, created remotely by rius-cp via POST /api/projects against the
+workspace's dedicated cell. When an alert fires in Rius, its region POSTs the alert context to
+this project's source; the trigger wakes the agent; the agent investigates over the Rius MCP
+server and the write-back webhook POSTs the finding to Rius's callback, keyed by the delivery id.
+
+Every knob here is the hand-built configuration proven on a live cell on 2026-09-01 (TR-223
+comment: run_7a954505c5c7 and friends — 4/4 green against staging Rius), with the five traps from
+that session baked in:
+  1. the KEY is stamped at ingest by the source's PRIMARY LABEL (delivery_id) — never rely on
+     view.key_field for it (TR-226/TR-228);
+  2. the prompt names the Rius tool chain and demands tool-grounded claims — it must not carry
+     the demo agents' "no live access" language, which makes an MCP-equipped agent refuse to
+     query;
+  3. the text_template is the agent's entire rendered evidence, so it carries every identifier
+     the agent needs to query on;
+  4. the agent is planned enabled;
+  5. max_rounds defaults to 10 (a real MCP chain used 3 rounds / 5 tool calls; the global
+     default of 6 is too tight for deep traces).
+"""
+from __future__ import annotations
+
+from .base import PlannedObject, ProjectError, Template
+from .registry import register
+
+SOURCE = "rius_alerts"
+VIEW = "rius_alerts_view"
+TRIGGER = "rius_alert_fired"
+AGENT = "rius_rca_agent"
+MCP = "rius"
+
+# The rendered line is all the agent sees of the payload; it must carry every identifier the
+# agent needs to query Rius on. The raw JSON is stored losslessly but reaches the agent only
+# through this template.
+TEXT_TEMPLATE = ("{rule} on {service}: {summary} "
+                 "[workspace={workspace_id} window={window_start}..{window_end} "
+                 "delivery={delivery_id}]")
+
+# The prompt proven in live testing. Overridable per project (PARAMS.prompt) so Rius can evolve
+# their tool names without waiting on a Tares release.
+PROMPT = """You are an SRE performing root-cause analysis for the Rius agent-observability platform.
+
+You are handed ONE alert firing from Rius. The firing payload carries identifiers, not bulk
+evidence: the delivery id, the alert, the affected workspace and service, and the window.
+
+You DO have live access to Rius through the `rius` MCP server. Use it. Start from
+`agent_traces_summary` and `workspace_metrics_overview` for the window, narrow with
+`list_agent_traces` (status "Error"), then pull the specific failures with `get_agent_trace`,
+passing include_content=true when you need to see what a span actually said or returned.
+
+Produce a short incident note in markdown:
+1. **What is failing** and since when.
+2. **Most likely root cause**, tied to specific evidence you fetched (name the trace, the span,
+   the error, the numbers).
+3. **Suggested next action.**
+
+Ground every claim in something a tool actually returned. If a query comes back empty, say so
+rather than speculating. No em dashes."""
+
+
+class RiusRca(Template):
+    key = "rius_rca"
+    title = "Rius RCA"
+    description = ("Root-cause analysis for a Rius workspace: alert firings flow in, the agent "
+                   "investigates over the Rius MCP server, and the report posts back to Rius.")
+    tags = ("partner",)
+    # Hidden from the console's template gallery: this template is created by the Rius control
+    # plane over the API, not picked by a person browsing cards.
+    hidden = True
+
+    PARAMS = {
+        "mcp_url": {"type": "string", "required": True, "label": "Rius MCP URL",
+                    "help": "the workspace's MCP endpoint the agent reads traces from"},
+        "mcp_token": {"type": "string", "required": True, "secret": True, "label": "MCP token",
+                      "help": "read-only, workspace-scoped; sent as Authorization: Bearer"},
+        "callback_url": {"type": "string", "required": True, "label": "Callback URL",
+                         "help": "where the finding is POSTed when a run concludes"},
+        "callback_token": {"type": "string", "required": True, "secret": True,
+                           "label": "Callback token",
+                           "help": "bearer token for the callback POST"},
+        "budget_usd": {"type": "number", "default": None, "label": "Budget (USD)",
+                       "help": "lifetime spend cap for the agent; empty = no cap"},
+        "max_rounds": {"type": "number", "default": 10, "label": "Max rounds",
+                       "help": "model rounds per run; a real MCP investigation uses 3 to 5"},
+        "model": {"type": "string", "default": "", "label": "Model",
+                  "help": "empty = the instance default"},
+        "prompt": {"type": "string", "default": "", "label": "Prompt override",
+                   "help": "replaces the built-in RCA prompt when set"},
+    }
+
+    def validate(self, params: dict) -> dict:
+        p = super().validate(params)
+        for k in ("mcp_url", "callback_url"):
+            if not str(p[k]).startswith(("http://", "https://")):
+                raise ProjectError(f"{self.key}: {k} must start with http:// or https://")
+        if p.get("budget_usd") not in (None, ""):
+            p["budget_usd"] = float(p["budget_usd"])
+            if p["budget_usd"] <= 0:
+                raise ProjectError(f"{self.key}: budget_usd must be positive")
+        else:
+            p["budget_usd"] = None
+        p["max_rounds"] = int(p.get("max_rounds") or 10)
+        return p
+
+    def plan(self, params: list) -> list[PlannedObject]:
+        p = self.validate(params)
+        objs = [
+            PlannedObject("source", "alerts", {
+                "name": SOURCE, "connector": "webhook", "poll": "5s",
+                "config": {
+                    "event_type": "alert_firing",
+                    "text_template": TEXT_TEMPLATE,
+                    # The primary label stamps the stored key at ingest — the axis the trigger
+                    # cools down per, and the `key` the callback carries back to Rius.
+                    "labels": [
+                        {"name": "delivery_id", "field": "delivery_id", "primary": True},
+                        {"name": "service", "field": "service"},
+                        {"name": "workspace_id", "field": "workspace_id"},
+                        {"name": "alert_id", "field": "alert_id"},
+                    ],
+                }}),
+            PlannedObject("view", "view", {
+                "name": VIEW, "key_field": "delivery_id", "sources": [SOURCE]}),
+            PlannedObject("trigger", "trigger", {
+                "name": TRIGGER, "view": VIEW,
+                "condition": {"aggregate": "count", "predicate": "> 0", "window": "5m"},
+                "cooldown": "30s"}),
+            PlannedObject("mcp_server", "mcp", {
+                "name": MCP, "url": p["mcp_url"], "auth_header": "Authorization",
+                "auth_value": f"Bearer {p['mcp_token']}"}),
+        ]
+        agent = {"name": AGENT, "trigger": TRIGGER,
+                 "prompt": p.get("prompt") or PROMPT,
+                 "mcp_servers": [MCP],
+                 "webhook_url": p["callback_url"], "webhook_token": p["callback_token"],
+                 "max_rounds": p["max_rounds"], "enabled": True}
+        if p.get("budget_usd") is not None:
+            agent["budget_usd"] = p["budget_usd"]
+        if p.get("model"):
+            agent["model"] = p["model"]
+        objs.append(PlannedObject("agent", "agent", agent))
+        return objs
+
+    def summary(self, instance: dict, store) -> dict:
+        out = super().summary(instance, store)
+        params = instance.get("params") or {}
+        ingest = next((s.get("ingest_key") for s in store.list_catalog_sources()
+                       if s.get("name") == SOURCE), None)
+        out["panels"] = [{
+            "title": "Wiring",
+            "rows": [
+                {"label": "alerts land at", "value": f"/ingest/{ingest}" if ingest else "unknown",
+                 "mono": True},
+                {"label": "agent reads", "value": params.get("mcp_url", ""), "mono": True},
+                {"label": "reports go to", "value": params.get("callback_url", ""), "mono": True},
+            ]}]
+        return out
+
+
+register(RiusRca())

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -127,6 +127,24 @@ async def main():
                   r.json().get("apps") == ["ui", "api"] and
                   any(l["action"] == "created" for l in r.json()["log"]), r.text[:300])
 
+            print("== TR-226 API traps ==")
+            r = await cx.get("/api/agents/builtin/t_agent")   # a path that has never existed
+            check("unknown /api path -> JSON 404, not the SPA",
+                  r.status_code == 404 and "unknown API path" in r.text, f"{r.status_code} {r.text[:80]}")
+            r = await cx.get("/api/nope/deeper")
+            check("another unknown /api path -> 404", r.status_code == 404, r.text[:80])
+            r = await cx.get("/api/sources/discover")
+            check("GET discover -> 405 with the hint",
+                  r.status_code == 405 and "POST-only" in r.text, f"{r.status_code} {r.text[:80]}")
+            r = await cx.put("/api/views/t_view", json={
+                "key_field": "app", "sources": ["t_ui", "t_api"]})
+            check("PUT view without body name works", r.status_code == 200, r.text[:120])
+            r = await cx.put("/api/views/t_view", json={
+                "name": "other", "key_field": "app", "sources": ["t_ui"]})
+            check("rename attempt still 400", r.status_code == 400, r.text[:120])
+            r = await cx.post("/api/views", json={"key_field": "app", "sources": ["t_ui"]})
+            check("create view without name -> 400", r.status_code == 400, r.text[:120])
+
             print("== customized protection ==")
             body = {**views["t_view"], "sources": ["t_ui"]}
             r = await cx.put("/api/views/t_view", json={"name": "t_view", "key_field": "app",

--- a/tests/test_rius_rca.py
+++ b/tests/test_rius_rca.py
@@ -1,0 +1,139 @@
+"""The rius_rca template (TR-223): the whole loop shape, minus the real Rius endpoints.
+
+Run: .venv/bin/python tests/test_rius_rca.py   (no external services needed)
+
+Asserts the five traps from the live hand-build (TR-223 comment) stay fixed: the ingest key is
+stamped by the source's primary label, the agent is born enabled with max_rounds 10 and the
+callback configured, the text template carries the query identifiers, and the prompt permits
+live MCP access.
+"""
+import asyncio
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+DB = "/tmp/tares-rius-rca-test.duckdb"
+CATALOG = "/tmp/tares-rius-rca-test.catalog.yaml"
+os.environ["TARES_DB"] = DB
+os.environ["TARES_CATALOG"] = CATALOG
+
+import httpx
+
+PASS = FAIL = 0
+
+
+def check(label, cond, detail=""):
+    global PASS, FAIL
+    if cond:
+        PASS += 1; print(f"  ok   {label}")
+    else:
+        FAIL += 1; print(f"  FAIL {label}  {detail}")
+
+
+PARAMS = {
+    "mcp_url": "https://mcp.rius.invalid/mcp",
+    "mcp_token": "gf_test_token",
+    "callback_url": "https://ingest.rius.invalid/v1/rca/reports",
+    "callback_token": "cb_test_token",
+    "budget_usd": 5,
+}
+
+
+async def main():
+    for p in (DB, DB + ".wal", CATALOG):
+        if os.path.exists(p):
+            os.remove(p)
+
+    from tares.daemon import make_app
+    app = make_app()
+
+    async with app.router.lifespan_context(app):
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as cx:
+
+            print("== template registration ==")
+            r = await cx.get("/api/projects/templates")
+            keys = [x["key"] for x in r.json()["templates"]]
+            check("hidden: not in the gallery", "rius_rca" not in keys, str(keys))
+
+            print("== validation ==")
+            r = await cx.post("/api/projects", json={"template": "rius_rca", "name": "r1",
+                                                     "params": {}})
+            check("missing params -> 400", r.status_code == 400, r.text)
+            bad = dict(PARAMS, mcp_url="not-a-url")
+            r = await cx.post("/api/projects", json={"template": "rius_rca", "name": "r1",
+                                                     "params": bad})
+            check("bad mcp_url -> 400", r.status_code == 400, r.text)
+            bad = dict(PARAMS, budget_usd=-1)
+            r = await cx.post("/api/projects", json={"template": "rius_rca", "name": "r1",
+                                                     "params": bad})
+            check("negative budget -> 400", r.status_code == 400, r.text)
+
+            print("== create ==")
+            r = await cx.post("/api/projects", json={"template": "rius_rca",
+                                                     "name": "rca acme", "params": PARAMS})
+            check("create -> 201", r.status_code == 201, r.text[:300])
+            inst = r.json(); uid = inst["id"]
+            kinds = sorted(o["kind"] for o in inst["objects"])
+            check("five objects", kinds == ["agent", "mcp_server", "source", "trigger", "view"],
+                  str(kinds))
+
+            print("== the five traps stay fixed ==")
+            srcs = {s["name"]: s for s in (await cx.get("/api/sources")).json()}
+            src = srcs.get("rius_alerts") or {}
+            labels = {l["name"]: l for l in (src.get("config") or {}).get("labels", [])}
+            check("primary label stamps the key",
+                  labels.get("delivery_id", {}).get("primary") is True, str(labels))
+            tmpl = (src.get("config") or {}).get("text_template", "")
+            check("text template carries the query identifiers",
+                  all(k in tmpl for k in ("{delivery_id}", "{workspace_id}", "{service}",
+                                          "{window_start}")), tmpl)
+            ag = {a["name"]: a for a in
+                  (await cx.get("/api/agents/builtin")).json()["agents"]}["rius_rca_agent"]
+            check("agent enabled", ag["enabled"] is True)
+            check("max_rounds 10", ag["max_rounds"] == 10, str(ag.get("max_rounds")))
+            check("budget passed through", ag["budget_usd"] == 5.0, str(ag.get("budget_usd")))
+            check("callback wired", ag["webhook_url"] == PARAMS["callback_url"]
+                  and ag["webhook_token_configured"] is True, str(ag.get("webhook_url")))
+            check("mcp server attached", ag["mcp_servers"] == ["rius"], str(ag.get("mcp_servers")))
+            check("prompt allows live access", "live access" in ag["prompt"]
+                  and "no live access" not in ag["prompt"])
+            mcp = {m["name"]: m for m in
+                   (await cx.get("/api/mcp-servers")).json()["servers"]}["rius"]
+            check("mcp auth configured, not echoed",
+                  mcp["auth_value_configured"] is True and not mcp.get("auth_value"),
+                  str(mcp)[:200])
+
+            print("== ingest stamps the delivery id as the key ==")
+            body = {"delivery_id": "dlv-test-001", "alert_id": "al-1", "workspace_id": "ws-1",
+                    "service": "canary-raw", "rule": "error rate > 25%",
+                    "summary": "error rate 48% over 24h",
+                    "window_start": "2026-09-02T00:00:00Z", "window_end": "2026-09-02T01:00:00Z"}
+            r = await cx.post(f"/ingest/{src['ingest_key']}", json=body)
+            check("alert ingests -> 202", r.status_code == 202, r.text)
+            ev = (await cx.get("/api/sources/rius_alerts/events", params={"limit": 1})).json()
+            check("stored key is the delivery id", ev and ev[0]["key"] == "dlv-test-001",
+                  str(ev)[:200])
+            check("rendered line carries identifiers", ev and "dlv-test-001" in ev[0]["text"]
+                  and "canary-raw" in ev[0]["text"], str(ev and ev[0]["text"]))
+
+            print("== summary wiring panel ==")
+            s = (await cx.get(f"/api/projects/{uid}/summary")).json()
+            rows = {row["label"]: row["value"] for p_ in s.get("panels", [])
+                    for row in p_["rows"]}
+            check("panel shows ingest path and endpoints",
+                  str(rows.get("alerts land at", "")).startswith("/ingest/")
+                  and rows.get("agent reads") == PARAMS["mcp_url"]
+                  and rows.get("reports go to") == PARAMS["callback_url"], str(rows))
+
+            print("== delete releases nothing weird ==")
+            r = await cx.delete(f"/api/projects/{uid}", params={"purge": "true"})
+            check("delete -> 200", r.status_code == 200, r.text[:200])
+            names = {s["name"] for s in (await cx.get("/api/sources")).json()}
+            check("source gone", "rius_alerts" not in names, str(names))
+
+    print(f"\n{PASS} passed, {FAIL} failed")
+    sys.exit(1 if FAIL else 0)
+
+
+asyncio.run(main())


### PR DESCRIPTION
The Tares half of the Rius RCA integration, transcribed from the configuration hand-built and proven on a live cell (ws-rius-test-1, 4/4 green runs against staging Rius). One POST /api/projects with {mcp_url, mcp_token, callback_url, callback_token, budget_usd, ...} plans:

- the webhook source (event_type alert_firing) whose PRIMARY delivery_id label stamps the stored key, with service/workspace_id/alert_id labels and a text_template carrying every identifier the agent queries on
- the view (key_field delivery_id, a declared label, per TR-228's rule), the per-delivery trigger (count > 0 over 5m, cooldown 30s)
- the rius MCP server (Authorization: Bearer from params)
- the RCA agent: enabled, max_rounds 10, budget_usd from params, the proven tool-chain prompt (overridable via params), findings delivered by the write-back webhook to the callback

Hidden from the console gallery (created by rius-cp over the API); the shell renders it via a declared Wiring panel (ingest path, MCP URL, callback URL). The five traps from the live session are pinned by tests (21 checks, including a real ingest asserting the stored key is the delivery id). Added to CI.

Contract documented in the "Rius ↔ Tares API contract (v1)" Linear doc, section 4, including the ingest-endpoint read, the expected payload fields, the params-echo caveat, and three open items settled (run_id semantics, budget readability at rest, the 1 MiB ingest cap).