### PR TITLE
Pause a project with its sources, optionally (TR-241)

### DIFF
--- a/tares/daemon.py
+++ b/tares/daemon.py
@@ -2195,9 +2195,11 @@ def make_app() -> FastAPI:
             _uc_err(e)
 
     @app.post("/api/projects/{uid}/pause")
-    async def pause_project(uid: str):
+    async def pause_project(uid: str, body: dict | None = Body(default=None)):
+        """Body {"sources": true} also pauses the project's sources, so nothing accumulates while
+        it is paused (the AI SRE demo's traffic, for one). Default: sources keep ingesting."""
         try:
-            return projects.pause(uid)
+            return projects.pause(uid, sources=bool((body or {}).get("sources")))
         except Exception as e:
             _uc_err(e)
 

--- a/tares/projects/engine.py
+++ b/tares/projects/engine.py
@@ -179,7 +179,11 @@ class Engine:
             f"{k}: {', '.join(v)}" for k, v in report.items() if v) or "no changes")
         return {**self.get(uid), "report": report}
 
-    def pause(self, uid: str) -> dict:
+    def pause(self, uid: str, sources: bool = False) -> dict:
+        """Triggers off, agents unsubscribed; sources keep ingesting unless `sources` is set, in
+        which case the project's sources that are running are paused too (polling stops, pushes
+        are refused) and remembered, so resume brings back exactly those: a source paused by hand
+        before stays paused."""
         inst = self._require(uid)
         objects = self._live_objects(uid)
         if _is_custom(inst["template"]) and inst["status"] != "paused":
@@ -196,8 +200,18 @@ class Engine:
                 self.store.set_trigger_paused(o["name"], True)
             elif o["kind"] == "agent":
                 self.store.remove_subscription_by_url(agent_url(o["name"]))
+        paused_sources: list[str] = []
+        if sources:
+            running = {s["name"] for s in self.store.list_catalog_sources() if not s["paused"]}
+            paused_sources = [o["name"] for o in objects if o["kind"] == "source" and o["name"] in running]
+            for name in paused_sources:
+                self.store.set_source_paused(name, True)
+            inst = self._require(uid)   # params may have just been rewritten above
+            self.store.update_project(uid, params={**inst["params"], "paused_sources": paused_sources})
         self.store.update_project(uid, status="paused")
-        self.store.log_project(uid, "paused", "triggers paused, agents unsubscribed; sources keep ingesting")
+        n = len(paused_sources)
+        self.store.log_project(uid, "paused", "triggers paused, agents unsubscribed; "
+                               + (f"{n} source{'s' if n != 1 else ''} paused" if sources else "sources keep ingesting"))
         self._do_reload()
         return self.get(uid)
 
@@ -223,11 +237,22 @@ class Engine:
                     if not self.store.subscription_by_url(url):
                         self.store.add_subscription("sub_" + uuid.uuid4().hex[:8],
                                                     agent["trigger"], url, created_by="tares")
-        if custom:
+        # the sources this pause stopped come back; one paused by hand before is left alone
+        paused_sources = list(inst["params"].get("paused_sources") or [])
+        live_sources = {o["name"] for o in self._live_objects(uid) if o["kind"] == "source"}
+        for name in paused_sources:
+            if name in live_sources:
+                self.store.set_source_paused(name, False)
+        if custom or paused_sources:
+            drop = ("resume_agents", "resume_triggers") if custom else ()
             self.store.update_project(uid, params={k: v for k, v in inst["params"].items()
-                                                   if k not in ("resume_agents", "resume_triggers")})
+                                                   if k not in drop and k != "paused_sources"})
         self.store.update_project(uid, status="active")
-        self.store.log_project(uid, "resumed")
+        if paused_sources:
+            n = len(paused_sources)
+            self.store.log_project(uid, "resumed", f"{n} source{'s' if n != 1 else ''} resumed")
+        else:
+            self.store.log_project(uid, "resumed")
         self._do_reload()
         return self.get(uid)
 

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -189,6 +189,20 @@ async def main():
             t = {t["name"]: t for t in (await cx.get("/api/triggers")).json()}["t_trigger"]
             check("resume -> active, trigger running",
                   r.json()["status"] == "active" and t["paused"] is False)
+            check("plain pause leaves sources running", not any(x["paused"] for x in (await cx.get("/api/sources")).json()))
+            # a source paused by hand before stays paused across pause+sources / resume
+            await cx.post("/api/sources/t_web/pause")
+            r = await cx.post(f"/api/projects/{uid}/pause", json={"sources": True})
+            src = {x["name"]: x for x in (await cx.get("/api/sources")).json()}
+            check("pause with sources pauses the project's running sources",
+                  r.json()["status"] == "paused" and src["t_ui"]["paused"] is True and src["t_web"]["paused"] is True
+                  and r.json()["params"].get("paused_sources") == ["t_ui"], r.text[:300])
+            r = await cx.post(f"/api/projects/{uid}/resume")
+            src = {x["name"]: x for x in (await cx.get("/api/sources")).json()}
+            check("resume brings back only what pause stopped",
+                  r.json()["status"] == "active" and src["t_ui"]["paused"] is False and src["t_web"]["paused"] is True
+                  and "paused_sources" not in r.json()["params"], r.text[:300])
+            await cx.post("/api/sources/t_web/resume")
 
             print("== all-or-nothing create ==")
             before = {s["name"] for s in (await cx.get("/api/sources")).json()}

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -279,8 +279,8 @@ export const api = {
     request<{ ok: boolean; deleted?: string[]; released?: string[]; purged_events?: number }>(
       `/api/projects/${encodeURIComponent(id)}${purgeEvents ? "?purge_events=true" : ""}`,
       { method: "DELETE" }),
-  pauseProject: (id: string) =>
-    request<Project>(`/api/projects/${encodeURIComponent(id)}/pause`, { method: "POST" }),
+  pauseProject: (id: string, sources = false) =>
+    request<Project>(`/api/projects/${encodeURIComponent(id)}/pause`, { method: "POST", body: JSON.stringify({ sources }) }),
   resumeProject: (id: string) =>
     request<Project>(`/api/projects/${encodeURIComponent(id)}/resume`, { method: "POST" }),
   detectRecipe: (key: string) =>

--- a/ui/src/pages/ProjectShell.tsx
+++ b/ui/src/pages/ProjectShell.tsx
@@ -28,6 +28,8 @@ export default function ProjectShell({ s, id, reload, template }: {
 }) {
   const navigate = useNavigate();
   const custom = s.template === "custom";
+  const sourceCount = (s.objects ?? []).filter((o) => o.kind === "source" && !o.missing).length;
+  const pausedSources = ((s.params as Record<string, unknown> | undefined)?.paused_sources as string[] | undefined) ?? [];
   // ?tab= deep links win; otherwise a project with sessions opens on them
   const [tab, setTab] = useState<"setup" | "events" | "firings" | "agents" | "sessions">(() => {
     const t = new URLSearchParams(window.location.search).get("tab");
@@ -44,9 +46,11 @@ export default function ProjectShell({ s, id, reload, template }: {
   const [actionError, setActionError] = useState<string>();
   const [confirmDel, setConfirmDel] = useState(false);
   const [purge, setPurge] = useState(false);
+  const [confirmPause, setConfirmPause] = useState(false);
+  const [pauseSources, setPauseSources] = useState(false);
 
   const names = (kind: string) => s.objects.filter((o) => o.kind === kind).map((o) => o.name);
-  const { data: sources } = usePolling(() => api.sources(), 10000);
+  const { data: sources, reload: reloadSources } = usePolling(() => api.sources(), 10000);
   const { data: views, reload: reloadViews } = usePolling(() => api.views(), 10000);
   const { data: triggers, reload: reloadTriggers } = usePolling(() => api.triggers(), 10000);
   const { data: dispatches, error: dispatchesError } = usePolling(() => api.dispatches(100), 10000);
@@ -111,7 +115,8 @@ export default function ProjectShell({ s, id, reload, template }: {
 
   const act = (fn: () => Promise<unknown>) => async () => {
     setActionError(undefined);
-    try { await fn(); reload(); } catch (e) { setActionError(String((e as Error).message ?? e)); }
+    // pause/resume flip source and trigger state too; refresh those tables now, not at the next poll
+    try { await fn(); reload(); reloadSources(); reloadTriggers(); } catch (e) { setActionError(String((e as Error).message ?? e)); }
   };
   const opts = (o?: (string | RecipeActionOption)[]): RecipeActionOption[] =>
     (o ?? []).map((x) => (typeof x === "string" ? { value: x } : x));
@@ -150,16 +155,21 @@ export default function ProjectShell({ s, id, reload, template }: {
     <>
       <div className="pagehead">
         <div>
-          <h1>{s.name}</h1>
+          <h1 style={{ display: "flex", alignItems: "center", gap: 10 }}>
+            {s.name}
+            <span className={`badge ${s.status === "active" ? "ok" : s.status === "paused" ? "paused" : "error"}`}>{s.status}</span>
+          </h1>
           <p className="subtitle">
-            {s.template_title} · <span className={`badge ${s.status === "active" ? "ok" : s.status === "paused" ? "paused" : "error"}`}>{s.status}</span>
-            {s.status === "paused" && <span className="help" style={{ marginLeft: 8 }}>sources keep ingesting; the triggers and agents are off</span>}
+            {s.template_title}
+            {s.status === "paused" && (pausedSources.length
+              ? ` · ${pausedSources.length === sourceCount ? "sources" : `${pausedSources.length} of ${sourceCount} sources`}, triggers and agents are off`
+              : " · triggers and agents are off; sources keep ingesting")}
           </p>
         </div>
         <div className="btnrow">
           {s.status === "paused"
             ? <button onClick={act(() => api.resumeProject(id))}>Resume</button>
-            : <button onClick={act(() => api.pauseProject(id))}>Pause</button>}
+            : <button onClick={() => { setPauseSources(false); setConfirmPause(true); }}>Pause</button>}
           <Link className="btn" to={`/projects/new/${custom ? "custom" : encodeURIComponent(s.template)}?edit=${encodeURIComponent(id)}`}>Edit</Link>
           <button className="danger" onClick={() => { setPurge(false); setConfirmDel(true); }}>Delete</button>
         </div>
@@ -561,6 +571,20 @@ export default function ProjectShell({ s, id, reload, template }: {
           onCancel={() => setUnsub(null)} />
       )}
 
+      {confirmPause && (
+        <ConfirmDialog title={`Pause ${s.name}?`}
+          message="Its triggers stop firing and its agents stop running. Sources keep ingesting unless you pause them too; resume brings back exactly what pause stopped."
+          confirmLabel="Pause project"
+          onConfirm={async () => { setConfirmPause(false); await act(() => api.pauseProject(id, pauseSources))(); }}
+          onCancel={() => setConfirmPause(false)}>
+          {sourceCount > 0 && (
+            <label style={{ display: "block", marginTop: 8 }}>
+              <input type="checkbox" checked={pauseSources} onChange={(e) => setPauseSources(e.target.checked)} />{" "}
+              also pause its {sourceCount === 1 ? "source" : `${sourceCount} sources`}, so no data accumulates while it is paused
+            </label>
+          )}
+        </ConfirmDialog>
+      )}
       {confirmDel && (
         <ConfirmDialog title={`Delete project ${s.name}?`}
           message={custom


### PR DESCRIPTION
Pausing a project stops its triggers and agents; sources kept ingesting, so a paused AI SRE demo kept filling the cell. Pause now has an option to pause the project's sources too.

- Engine: `pause(uid, sources=False)`. With the flag, the project's running sources are paused (the existing source pause: polling stops, pushes are refused) and remembered on the project. Resume brings back exactly those, so a source paused by hand before stays paused. The change log says how many sources were paused and resumed.
- API: `POST /api/projects/{uid}/pause` takes an optional body `{"sources": true}`. Default unchanged.
- Console: Pause opens a confirm with one checkbox, "also pause its N sources, so no data accumulates while it is paused". The status badge sits beside the project name; the subtitle says what is off: "sources, triggers and agents are off" or "triggers and agents are off; sources keep ingesting". Source and trigger tables refresh right after pause or resume instead of at the next poll.
- Test: pause with sources, a hand-paused source surviving resume, plain pause leaving sources running.

Verified locally on a second daemon.