### PR TITLE
Agent tracing over OTLP, Rius as a preset

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Backend — install + tests
         run: |
           pip install -e .
-          for t in test_labels test_normalize test_auth test_api_keys test_pricing test_agents test_catalog_sync test_cli test_status test_usage test_slack test_slack_verify test_slack_ask test_degraded test_loki test_projects test_rius_rca test_ai_sre_demo test_seed test_session_flow test_challenger_workflow test_plugin_challenger; do
+          for t in test_labels test_normalize test_auth test_api_keys test_pricing test_agents test_catalog_sync test_cli test_status test_usage test_slack test_slack_verify test_slack_ask test_degraded test_loki test_projects test_rius_rca test_ai_sre_demo test_seed test_session_flow test_challenger_workflow test_plugin_challenger test_tracing; do
             echo "== $t =="
             python "tests/$t.py"
           done

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,10 @@ Every knob is a `TARES_*` variable read at start. The ones you will meet most:
 | `TARES_MAX_DB_SIZE` | cap on the DuckDB file; `/api/usage` reports against it |
 | `TARES_SLACK_BOT_TOKEN`, `TARES_SLACK_SIGNING_SECRET` | the Slack surface |
 | `TARES_SEED_PROJECT` | template of the project to seed on first boot (`TARES_SEED_USECASE` still read) |
+| `TARES_TRACING_ENABLED` | agent tracing on/off (a console setting wins over it) |
+| `TARES_TRACING_PROVIDER`, `TARES_TRACING_ENDPOINT` | `rius` (endpoint preset) or `otlp` (any OTLP/HTTP endpoint) |
+| `TARES_TRACING_API_KEY`, `TARES_TRACING_HEADERS` | bearer key, or `k=v,k2=v2` headers for the exporter |
+| `TARES_INSTANCE_NAME` | prefix of the trace `service.name` (`<instance>/<agent>`); default the hostname |
 
 `grep -rhoE "TARES_[A-Z_]+" tares/*.py | sort -u` is the authoritative list.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 Notable changes to Tares (formerly NavFlow). Format follows [Keep a Changelog](https://keepachangelog.com/);
 the project follows [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+- **Agent tracing.** Every Tares agent run and every Ask turn can be exported as an
+  OpenTelemetry trace: a root span for the run, one span per model call (model, messages,
+  tokens, stop reason) and one per tool call, in the OpenInference and gen_ai conventions the
+  GenAI observability backends read. Rius is a preset (an API key is enough); any OTLP/HTTP
+  endpoint works with the `otlp` provider (Langfuse, Phoenix, a collector). Each agent is its
+  own service (`<instance>/<agent>`), so a backend groups per agent out of the box. Settings,
+  Observability holds the switch and the provider; `TARES_TRACING_*` sets the same from the
+  environment, and a console value wins. Off unless switched on.
+
 ## [1.22.0] - 2026-09-03
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,10 @@ dependencies = [
     "pytz>=2024.1",   # DuckDB needs it to bind tz-aware datetimes to TIMESTAMPTZ
     "asyncpg>=0.29",  # Postgres connector driver — base so the connector works on `tares up`
     "anthropic>=0.40",  # console Ask/Organize agent — base so it works on `tares up`
+    # Agent tracing (tracing.py): OTLP/HTTP export of agent runs to Rius, Langfuse, a collector.
+    # Base so the console switch works on `tares up`; the http exporter is pure Python.
+    "opentelemetry-sdk>=1.24",
+    "opentelemetry-exporter-otlp-proto-http>=1.24",
 ]
 
 [project.urls]

--- a/tares/agent.py
+++ b/tares/agent.py
@@ -384,9 +384,10 @@ async def _run_agent(api_key: str, messages: list, model, self_headers, on_usage
                 t0 = time.perf_counter()
                 with _tracing.tool_span(tracer, tu.name, tu.input) as tobs:
                     ok, out = await _execute_tool(tu.name, tu.input, headers)
-                    tobs.set_output(out)
-                    if not ok:
-                        tobs.error(out[:300])
+                    if ok:
+                        tobs.set_output(out)
+                    else:
+                        tobs.tool_error(out)
                 yield _sse({"type": "tool_done", "id": tu.id,
                             "ms": int((time.perf_counter() - t0) * 1000),
                             "ok": ok,

--- a/tares/agent.py
+++ b/tares/agent.py
@@ -12,6 +12,8 @@ import time
 
 import httpx
 
+from . import tracing as _tracing
+
 DEFAULT_MODEL = os.getenv("TARES_AGENT_MODEL", "claude-sonnet-4-6")
 _SELF = f"http://127.0.0.1:{os.getenv('TARES_PORT', '8787')}"
 MAX_ROUNDS = 10
@@ -293,12 +295,23 @@ def _sse(obj: dict) -> str:
 
 async def run_agent(api_key: str, messages: list,
                     model: str | None = None, self_headers: dict | None = None,
-                    on_usage=None):
+                    on_usage=None, tracer=None):
     """Async generator of SSE lines: the agent loop, streaming assistant text and tool activity.
 
     `on_usage(model, usage_dict)` is called once per turn (after the loop, including on an error
     mid-turn) with the summed token usage of every model call the turn made, so the caller can
-    meter Ask's Anthropic spend. Never called when no model call completed."""
+    meter Ask's Anthropic spend. Never called when no model call completed.
+
+    `tracer` (see tracing.py) makes the turn a trace: a root span, one LLM span per model call,
+    one tool span per tool call. None means no tracing."""
+    with _tracing.run_span(tracer, "ask", kind="CHAIN") as obs:
+        async for line in _run_agent(api_key, messages, model, self_headers, on_usage, tracer,
+                                     obs):
+            yield line
+
+
+async def _run_agent(api_key: str, messages: list, model, self_headers, on_usage, tracer,
+                     obs: _tracing.Observation):
     try:
         import anthropic
     except ImportError:
@@ -308,29 +321,40 @@ async def run_agent(api_key: str, messages: list,
 
     client = anthropic.AsyncAnthropic(api_key=api_key)
     convo = list(messages)
+    last = convo[-1] if convo else None
+    obs.set_input(last.get("content") if isinstance(last, dict) else last)
     headers = self_headers or {}
     used_model = model or DEFAULT_MODEL
     usage = {"calls": 0, "input_tokens": 0, "output_tokens": 0,
              "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0}
     try:
         for _ in range(MAX_ROUNDS):
-            async with client.messages.stream(
-                model=model or DEFAULT_MODEL, max_tokens=2048,
-                system=system_prompt(), tools=tools_for(), messages=convo,
-            ) as stream:
-                async for event in stream:
-                    if event.type == "content_block_delta" and event.delta.type == "text_delta":
-                        yield _sse({"type": "text", "text": event.delta.text})
-                final = await stream.get_final_message()
+            with _tracing.generation(tracer, model or DEFAULT_MODEL, convo,
+                                     {"max_tokens": 2048}) as gen:
+                async with client.messages.stream(
+                    model=model or DEFAULT_MODEL, max_tokens=2048,
+                    system=system_prompt(), tools=tools_for(), messages=convo,
+                ) as stream:
+                    async for event in stream:
+                        if event.type == "content_block_delta" and event.delta.type == "text_delta":
+                            gen.record_first_token()
+                            yield _sse({"type": "text", "text": event.delta.text})
+                    final = await stream.get_final_message()
 
-            usage["calls"] += 1
-            for field in ("input_tokens", "output_tokens",
-                          "cache_creation_input_tokens", "cache_read_input_tokens"):
-                usage[field] += int(getattr(final.usage, field, 0) or 0)
-            used_model = final.model or used_model
+                usage["calls"] += 1
+                for field in ("input_tokens", "output_tokens",
+                              "cache_creation_input_tokens", "cache_read_input_tokens"):
+                    usage[field] += int(getattr(final.usage, field, 0) or 0)
+                used_model = final.model or used_model
+                gen.set_output(list(final.content))
+                gen.set_usage(final.usage)
+                gen.set_response_model(final.model)
+                gen.set_finish_reason(getattr(final, "stop_reason", None))
             convo.append({"role": "assistant", "content": final.content})
             tool_uses = [b for b in final.content if b.type == "tool_use"]
             if not tool_uses:
+                text = "\n".join(b.text for b in final.content if b.type == "text")
+                obs.set_output(text)
                 break
             results = []
             for tu in tool_uses:
@@ -358,7 +382,11 @@ async def run_agent(api_key: str, messages: list,
                 # "thinking…", and a read that takes four seconds looked identical to a hung one.
                 yield _sse({"type": "tool", "id": tu.id, "name": tu.name, "input": tu.input})
                 t0 = time.perf_counter()
-                ok, out = await _execute_tool(tu.name, tu.input, headers)
+                with _tracing.tool_span(tracer, tu.name, tu.input) as tobs:
+                    ok, out = await _execute_tool(tu.name, tu.input, headers)
+                    tobs.set_output(out)
+                    if not ok:
+                        tobs.error(out[:300])
                 yield _sse({"type": "tool_done", "id": tu.id,
                             "ms": int((time.perf_counter() - t0) * 1000),
                             "ok": ok,
@@ -368,6 +396,7 @@ async def run_agent(api_key: str, messages: list,
             convo.append({"role": "user", "content": results})
         yield _sse({"type": "done"})
     except Exception as e:  # noqa: BLE001 — surface auth/rate/other errors to the chat
+        obs.error(e)
         yield _sse({"type": "error", "detail": f"{type(e).__name__}: {e}"})
     finally:
         if usage["calls"] and on_usage is not None:

--- a/tares/builtin_agents.py
+++ b/tares/builtin_agents.py
@@ -528,8 +528,9 @@ class AgentRunner:
                                 out = self._tool(agent["name"], name, u.get("input") or {})
                         except Exception as e:   # a tool error is evidence, not a crash
                             out = f"tool error: {type(e).__name__}: {e}"
-                            tobs.error(e)
-                        tobs.set_output(out)
+                            tobs.tool_error(out)
+                        else:
+                            tobs.set_output(out)
                     results.append({"type": "tool_result", "tool_use_id": u["id"], "content": out})
                 messages.append({"role": "user", "content": results})
 

--- a/tares/builtin_agents.py
+++ b/tares/builtin_agents.py
@@ -28,6 +28,7 @@ import uuid
 
 import httpx
 
+from . import tracing as _tracing
 from .config import FINDINGS_SOURCE, agent_url
 from .envelope import now_utc
 from .pricing import cost_usd
@@ -171,9 +172,12 @@ class AgentRunner:
     delays an external webhook on the same trigger.
     """
 
-    def __init__(self, store, runtime):
+    def __init__(self, store, runtime, tracing=None):
         self.store = store
         self.runtime = runtime
+        # One trace per run, exported to whatever backend the instance is configured for (see
+        # tracing.py); off unless switched on, and never in the way of a run.
+        self.tracing = tracing or _tracing.Tracing(store)
         self._tasks: set[asyncio.Task] = set()
         # The daemon's loop, so run_now() also works from a worker thread (a project action runs
         # in one); None when constructed outside a loop (tests building a runner by hand).
@@ -322,6 +326,22 @@ class AgentRunner:
 
     async def _run(self, agent: dict, trigger_name: str, key: str, payload: str,
                    run_id: str, dispatch_id: str | None = None) -> tuple[str, str | None]:
+        tracer = self.tracing.tracer_for(agent["name"])
+        with _tracing.run_span(tracer, agent["name"], session=key, attributes={
+                "tares.run_id": run_id, "tares.dispatch_id": dispatch_id or "",
+                "tares.trigger": trigger_name, "tares.key": key}) as obs:
+            status, error = await self._run_traced(agent, trigger_name, key, payload, run_id,
+                                                   dispatch_id, tracer, obs)
+            obs.set_attribute("tares.status", status)
+            if status == "failed" and error:
+                obs.error(error)
+            elif error:
+                obs.set_attribute("tares.note", error)
+            return status, error
+
+    async def _run_traced(self, agent: dict, trigger_name: str, key: str, payload: str,
+                          run_id: str, dispatch_id: str | None, tracer,
+                          obs: _tracing.Observation) -> tuple[str, str | None]:
         started_at = now_utc()
         t0 = time.monotonic()
         api_key, key_origin = resolve_key(self.store)
@@ -351,7 +371,7 @@ class AgentRunner:
                  "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0}
         try:
             finding, rounds, tool_calls, external_used, exhausted, partial = await self._loop(
-                agent, trigger_name, key, payload, api_key, usage)
+                agent, trigger_name, key, payload, api_key, usage, tracer, obs)
         finally:
             if usage["calls"]:
                 cost = cost_usd(model, usage["input_tokens"], usage["output_tokens"],
@@ -365,11 +385,15 @@ class AgentRunner:
                     usage["input_tokens"], usage["output_tokens"],
                     usage["cache_creation_input_tokens"], usage["cache_read_input_tokens"], cost,
                     key_source=key_origin)
+                obs.set_attribute("tares.cost_usd", cost)
+                obs.set_attribute("tares.model_calls", usage["calls"])
         if exhausted:
             # The round budget ran out before the model concluded. Keep whatever it said last as
             # a partial note (in `finding`, so it is visible) and say plainly what to do.
             cap = effective_max_rounds(agent)
             msg = f"round budget of {cap} exhausted before a conclusion; raise max rounds"
+            if partial:
+                obs.set_output(partial)
             self.store.finish_agent_run(run_id, "exhausted", rounds=rounds,
                                         tool_calls=tool_calls, finding=partial or None,
                                         error=msg, external_tools=external_used)
@@ -380,6 +404,9 @@ class AgentRunner:
                                         error=msg, external_tools=external_used)
             return "empty", msg
 
+        obs.set_output(finding)
+        obs.set_attribute("tares.rounds", rounds)
+        obs.set_attribute("tares.tool_calls", tool_calls)
         await self._record(agent, trigger_name, key, finding)
         self.store.finish_agent_run(run_id, "ok", rounds=rounds, tool_calls=tool_calls,
                                     finding=finding, external_tools=external_used)
@@ -403,7 +430,9 @@ class AgentRunner:
 
     # ── the bounded model loop ────────────────────────────────────────────────
     async def _loop(self, agent: dict, trigger_name: str, key: str, payload: str,
-                    api_key: str, usage: dict) -> tuple[str, int, int, list[str], bool, str]:
+                    api_key: str, usage: dict, tracer=None,
+                    obs: _tracing.Observation | None = None,
+                    ) -> tuple[str, int, int, list[str], bool, str]:
         # External tools: the agent's selected MCP servers, connected for the duration of this
         # run. A server that fails to connect is skipped (recorded below) — losing a tool server
         # must not lose the run.
@@ -415,11 +444,12 @@ class AgentRunner:
             for failure in toolbox.failures:
                 print(f"[agent {agent['name']}] mcp connect failed; {failure}")
             return await self._loop_with(agent, trigger_name, key, payload, api_key, toolbox,
-                                         usage)
+                                         usage, tracer, obs)
 
     async def _loop_with(self, agent: dict, trigger_name: str, key: str, payload: str,
-                         api_key: str, toolbox,
-                         usage: dict) -> tuple[str, int, int, list[str], bool, str]:
+                         api_key: str, toolbox, usage: dict, tracer=None,
+                         obs: _tracing.Observation | None = None,
+                         ) -> tuple[str, int, int, list[str], bool, str]:
         """Returns (finding, rounds, tool_calls, external_tools_used, exhausted, partial_text)."""
         tools = TOOL_DEFS + toolbox.tool_defs
         max_rounds = effective_max_rounds(agent)
@@ -441,6 +471,8 @@ class AgentRunner:
         }]
         rounds = tool_calls = 0
         last_text = ""
+        if obs is not None:
+            obs.set_input(messages[0]["content"])
         async with httpx.AsyncClient(timeout=TOOL_TIMEOUT) as cx:
             async def call(with_tools: bool) -> dict:
                 # The tools stay declared on the final call (a conversation holding tool_use
@@ -450,19 +482,25 @@ class AgentRunner:
                         "tools": tools, "messages": messages}
                 if not with_tools:
                     body["tool_choice"] = {"type": "none"}
-                r = await cx.post(
-                    f"{API_BASE}/v1/messages",
-                    headers={"x-api-key": api_key, "anthropic-version": "2023-06-01"},
-                    json=body)
-                if r.status_code >= 400:
-                    raise RuntimeError(f"anthropic {r.status_code}: {r.text[:300]}")
-                msg = r.json()
-                # Defensive get: stubs (tests) may answer without a usage block.
-                u = msg.get("usage") or {}
-                usage["calls"] += 1
-                for field in ("input_tokens", "output_tokens",
-                              "cache_creation_input_tokens", "cache_read_input_tokens"):
-                    usage[field] += int(u.get(field) or 0)
+                with _tracing.generation(tracer, body["model"], messages,
+                                         {"max_tokens": MAX_TOKENS}) as gen:
+                    r = await cx.post(
+                        f"{API_BASE}/v1/messages",
+                        headers={"x-api-key": api_key, "anthropic-version": "2023-06-01"},
+                        json=body)
+                    if r.status_code >= 400:
+                        raise RuntimeError(f"anthropic {r.status_code}: {r.text[:300]}")
+                    msg = r.json()
+                    # Defensive get: stubs (tests) may answer without a usage block.
+                    u = msg.get("usage") or {}
+                    usage["calls"] += 1
+                    for field in ("input_tokens", "output_tokens",
+                                  "cache_creation_input_tokens", "cache_read_input_tokens"):
+                        usage[field] += int(u.get(field) or 0)
+                    gen.set_output(msg.get("content") or [])
+                    gen.set_usage(u)
+                    gen.set_response_model(msg.get("model"))
+                    gen.set_finish_reason(msg.get("stop_reason"))
                 return msg
 
             for rounds in range(1, max_rounds + 1):
@@ -481,14 +519,17 @@ class AgentRunner:
                 for u in uses:
                     tool_calls += 1
                     name = str(u["name"])
-                    try:
-                        if toolbox.owns(name):
-                            external_used.append(name)
-                            out = await toolbox.call(name, u.get("input") or {})
-                        else:
-                            out = self._tool(agent["name"], name, u.get("input") or {})
-                    except Exception as e:   # a tool error is evidence, not a crash
-                        out = f"tool error: {type(e).__name__}: {e}"
+                    with _tracing.tool_span(tracer, name, u.get("input") or {}) as tobs:
+                        try:
+                            if toolbox.owns(name):
+                                external_used.append(name)
+                                out = await toolbox.call(name, u.get("input") or {})
+                            else:
+                                out = self._tool(agent["name"], name, u.get("input") or {})
+                        except Exception as e:   # a tool error is evidence, not a crash
+                            out = f"tool error: {type(e).__name__}: {e}"
+                            tobs.error(e)
+                        tobs.set_output(out)
                     results.append({"type": "tool_result", "tool_use_id": u["id"], "content": out})
                 messages.append({"role": "user", "content": results})
 

--- a/tares/daemon.py
+++ b/tares/daemon.py
@@ -46,6 +46,7 @@ from .runtime import Runtime
 from . import slack as slack_mod
 from . import slack_verify
 from .slack import SETTING_KEY as SLACK_TOKEN_SETTING, resolve_token as resolve_slack_token
+from .tracing import PROVIDERS as tracing_providers, status as tracing_status
 from .store import Store, StoreUnavailable
 from .projects import Engine as ProjectEngine, ProjectError
 from .views import resolve_query_full, resolve_read
@@ -357,6 +358,14 @@ class AskSessionIn(BaseModel):
     state: str             # opaque JSON blob owned by the console (messages + decisions)
 
 
+class TracingIn(BaseModel):
+    enabled: bool | None = None
+    provider: str | None = None
+    endpoint: str | None = None
+    api_key: str | None = None
+    headers: str | None = None
+
+
 class AnthropicKeyIn(BaseModel):
     key: str    # blank-to-keep is not offered here: the only edits are "set a new one" or DELETE
 
@@ -422,6 +431,9 @@ def make_app() -> FastAPI:
     # webhook). In-process, so `tares up` closes the loop with nothing to deploy.
     dispatcher.agents = AgentRunner(store, runtime)
     dispatcher.runtime = runtime
+    # Agent tracing (tracing.py): the runner's provider cache, shared with Ask so both surfaces
+    # follow the same switch and land in the same backend.
+    tracing = dispatcher.agents.tracing
 
     _seed_project(store, projects)
 
@@ -468,6 +480,7 @@ def make_app() -> FastAPI:
         if grpc_server is not None:
             await grpc_server.stop(grace=2)
         runtime.shutdown()
+        tracing.shutdown()   # flush the last spans; a lost trace is not a lost run
 
     app = FastAPI(title="taresd", lifespan=lifespan)
     app.state.store = store   # for in-process tests; DuckDB is single-writer, so no second Store
@@ -1279,7 +1292,8 @@ def make_app() -> FastAPI:
         return StreamingResponse(
             run_agent(key, body.get("messages") or [],
                       model=body.get("model"), self_headers=self_headers,
-                      on_usage=lambda m, u: _record_ask_usage(m, u, key_source=key_origin)),
+                      on_usage=lambda m, u: _record_ask_usage(m, u, key_source=key_origin),
+                      tracer=tracing.tracer_for("ask")),
             media_type="text/event-stream")
 
     # ── MCP connections — external tool servers a Tares agent can opt into ─────
@@ -1811,6 +1825,38 @@ def make_app() -> FastAPI:
         key, origin = resolve_anthropic_key(store)
         return {"ok": True, "configured": bool(key), "source": origin}
 
+    # ── agent tracing: where runs are exported, and whether ──────────────────
+    # A console-stored value wins over the environment, like the Anthropic key. Secrets (the
+    # key, the headers) are write-only: the API says whether one resolves and where from.
+    @app.get("/api/settings/tracing")
+    async def get_tracing():
+        return tracing_status(store)
+
+    @app.put("/api/settings/tracing")
+    async def set_tracing(body: TracingIn):
+        """Every field is optional; a field left out is untouched, an empty string clears the
+        stored value (the environment value, if any, takes over again)."""
+        if body.provider is not None:
+            p = body.provider.strip().lower()
+            if p and p not in tracing_providers:
+                _err(ValueError(f"provider must be one of {', '.join(tracing_providers)}"))
+            store.set_setting("tracing_provider", p or None)
+        if body.endpoint is not None:
+            ep = body.endpoint.strip()
+            if ep and not (ep.startswith("http://") or ep.startswith("https://")):
+                _err(ValueError("endpoint must be an http(s) URL, e.g. https://collector:4318"))
+            store.set_setting("tracing_endpoint", ep or None)
+        if body.api_key is not None:
+            store.set_setting("tracing_api_key", body.api_key.strip() or None)
+        if body.headers is not None:
+            store.set_setting("tracing_headers", body.headers.strip() or None)
+        if body.enabled is not None:
+            store.set_setting("tracing_enabled", "1" if body.enabled else "0")
+        out = tracing_status(store)
+        if out["enabled"] and not out["active"]:
+            out["note"] = "switched on, but no endpoint resolves; pick a provider or set one"
+        return {"ok": True, **out}
+
     # ── the Slack bot token: same contract as the Anthropic key ──────────────
     # One token per instance, behind every slack:// subscription. It is a credential, so it is
     # write-only over the API exactly like the model key: the console can learn THAT one resolves
@@ -1932,7 +1978,8 @@ def make_app() -> FastAPI:
                 async for chunk in run_agent(key, [{"role": "user", "content": question}],
                                              self_headers=self_headers,
                                              on_usage=lambda m, u: _record_ask_usage(
-                                                 m, u, key_source=key_origin)):
+                                                 m, u, key_source=key_origin),
+                                             tracer=tracing.tracer_for("ask")):
                     for line in chunk.splitlines():
                         if not line.startswith("data: "):
                             continue

--- a/tares/tracing.py
+++ b/tares/tracing.py
@@ -1,0 +1,508 @@
+"""Agent tracing: one OpenTelemetry trace per agent run, exported over OTLP/HTTP.
+
+Every Tares agent run and every Ask turn becomes a trace: a root span for the run, one LLM span
+per model call (model, messages, tokens, stop reason) and one tool span per tool call. The spans
+carry the OpenInference and gen_ai attribute names, which is what the GenAI observability
+backends read: Rius, Langfuse, Phoenix, an OpenTelemetry collector, anything that accepts
+OTLP/HTTP. The cell has no vendor dependency; a provider is a preset that fills defaults.
+
+    provider `rius`  endpoint defaults to Rius's ingest, the API key becomes a bearer header
+    provider `otlp`  any endpoint, headers given explicitly (Langfuse, Phoenix, a collector)
+
+Configuration is a console setting first and an environment variable second, like the
+Anthropic key: a value saved in the console takes over from whatever the deployment shipped.
+Tares Cloud ships the Rius preset and the shared key through the environment, so the only
+control a cloud user meets is the switch.
+
+Separation per agent: backends group every view by the `service.name` resource attribute, and
+that attribute is fixed per tracer provider. So each agent gets its own provider with
+`service.name = <instance>/<agent>` (`TARES_INSTANCE_NAME`, else the hostname), built on first
+use and kept for the life of the process. A changed setting (endpoint, key, switch) rebuilds
+them on the next run; nothing needs a restart.
+
+Tracing must never break a run: every helper here swallows its own failures, the exporter
+batches in a background thread, and a backend that is down only costs dropped spans.
+"""
+from __future__ import annotations
+
+import json
+import os
+import socket
+import threading
+import uuid
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import Any, Iterator
+
+# ── conventions (OpenInference + OpenTelemetry gen_ai) ─────────────────────────
+SPAN_KIND = "openinference.span.kind"          # AGENT | CHAIN | LLM | TOOL
+INPUT_VALUE = "input.value"
+OUTPUT_VALUE = "output.value"
+SESSION_ID = "session.id"
+GEN_AI_OPERATION = "gen_ai.operation.name"
+GEN_AI_PROVIDER = "gen_ai.provider.name"
+GEN_AI_REQUEST_MODEL = "gen_ai.request.model"
+GEN_AI_RESPONSE_MODEL = "gen_ai.response.model"
+GEN_AI_INPUT_MESSAGES = "gen_ai.input.messages"
+GEN_AI_OUTPUT_MESSAGES = "gen_ai.output.messages"
+GEN_AI_USAGE_INPUT = "gen_ai.usage.input_tokens"
+GEN_AI_USAGE_OUTPUT = "gen_ai.usage.output_tokens"
+GEN_AI_USAGE_CACHE_CREATION = "gen_ai.usage.cache_creation_input_tokens"
+GEN_AI_USAGE_CACHE_READ = "gen_ai.usage.cache_read_input_tokens"
+GEN_AI_FINISH_REASONS = "gen_ai.response.finish_reasons"
+GEN_AI_TOOL_NAME = "gen_ai.tool.name"
+GEN_AI_FIRST_TOKEN = "gen_ai.first_token"
+_OPERATION_BY_KIND = {"AGENT": "invoke_agent", "CHAIN": "chain", "LLM": "chat",
+                      "TOOL": "execute_tool"}
+
+# ── providers ──────────────────────────────────────────────────────────────────
+PROVIDERS = ("rius", "otlp")
+RIUS_ENDPOINT = "https://ingest.eu.console.rius-glassflow.com"
+RIUS_CONSOLE_URL = "https://eu.console.rius-glassflow.com"
+
+# settings-table keys and their environment fallbacks
+SETTING_ENABLED = ("tracing_enabled", "TARES_TRACING_ENABLED")
+SETTING_PROVIDER = ("tracing_provider", "TARES_TRACING_PROVIDER")
+SETTING_ENDPOINT = ("tracing_endpoint", "TARES_TRACING_ENDPOINT")
+SETTING_API_KEY = ("tracing_api_key", "TARES_TRACING_API_KEY")
+SETTING_HEADERS = ("tracing_headers", "TARES_TRACING_HEADERS")
+ENV_INSTANCE = "TARES_INSTANCE_NAME"
+
+MAX_ATTR_CHARS = 32_768   # per string attribute; a timeline payload can be large
+_TRUE = ("1", "true", "yes", "on")
+
+
+def _read(store, key: str, env: str) -> tuple[str, str]:
+    """(value, where-it-came-from): the console-stored value, else the environment, else ''."""
+    stored = (store.get_setting(key) or "").strip() if store is not None else ""
+    if stored:
+        return stored, "console"
+    val = os.getenv(env, "").strip()
+    return (val, f"env:{env}") if val else ("", "")
+
+
+def parse_headers(raw: str) -> dict[str, str]:
+    """`k=v,k2=v2` (the OTEL_EXPORTER_OTLP_HEADERS shape) -> dict. Bad pairs are skipped."""
+    out: dict[str, str] = {}
+    for pair in (raw or "").split(","):
+        if "=" not in pair:
+            continue
+        k, v = pair.split("=", 1)
+        if k.strip():
+            out[k.strip()] = v.strip()
+    return out
+
+
+def instance_name() -> str:
+    return os.getenv(ENV_INSTANCE, "").strip() or socket.gethostname() or "tares"
+
+
+@dataclass(frozen=True)
+class TracingConfig:
+    enabled: bool
+    provider: str
+    endpoint: str
+    headers: dict[str, str]
+    instance: str
+    # where each value came from ("console", "env:...", "preset", "default", "")
+    sources: dict[str, str] = field(default_factory=dict)
+    key_stored: bool = False
+    key_configured: bool = False
+    headers_configured: bool = False
+
+    @property
+    def active(self) -> bool:
+        return self.enabled and bool(self.endpoint)
+
+    @property
+    def fingerprint(self) -> tuple:
+        return (self.endpoint, tuple(sorted(self.headers.items())), self.instance)
+
+
+def resolve(store) -> TracingConfig:
+    enabled_raw, enabled_src = _read(store, *SETTING_ENABLED)
+    provider, provider_src = _read(store, *SETTING_PROVIDER)
+    endpoint, endpoint_src = _read(store, *SETTING_ENDPOINT)
+    api_key, key_src = _read(store, *SETTING_API_KEY)
+    headers_raw, headers_src = _read(store, *SETTING_HEADERS)
+
+    provider = provider.lower()
+    if provider not in PROVIDERS:
+        # No provider named: an explicit endpoint means "some OTLP backend"; a key alone means
+        # Rius, whose endpoint the preset knows.
+        provider, provider_src = ("otlp", "default") if endpoint else ("rius", "default")
+    if provider == "rius" and not endpoint:
+        endpoint, endpoint_src = RIUS_ENDPOINT, "preset"
+
+    headers = parse_headers(headers_raw)
+    if api_key and not any(k.lower() == "authorization" for k in headers):
+        headers["authorization"] = f"Bearer {api_key}"
+
+    return TracingConfig(
+        enabled=enabled_raw.lower() in _TRUE,
+        provider=provider, endpoint=endpoint.rstrip("/"), headers=headers,
+        instance=instance_name(),
+        sources={"enabled": enabled_src, "provider": provider_src, "endpoint": endpoint_src,
+                 "api_key": key_src, "headers": headers_src},
+        key_stored=bool((store.get_setting(SETTING_API_KEY[0]) or "").strip()) if store else False,
+        key_configured=bool(api_key), headers_configured=bool(headers_raw),
+    )
+
+
+def status(store) -> dict:
+    """What the settings API returns: everything but the secrets."""
+    cfg = resolve(store)
+    return {
+        "enabled": cfg.enabled, "enabled_source": cfg.sources["enabled"],
+        "active": cfg.active,
+        "provider": cfg.provider, "provider_source": cfg.sources["provider"],
+        "endpoint": cfg.endpoint, "endpoint_source": cfg.sources["endpoint"],
+        "key_configured": cfg.key_configured, "key_source": cfg.sources["api_key"],
+        "key_stored": cfg.key_stored,
+        "headers_configured": cfg.headers_configured, "headers_source": cfg.sources["headers"],
+        "instance": cfg.instance,
+        "providers": list(PROVIDERS),
+        "rius_console_url": RIUS_CONSOLE_URL,
+    }
+
+
+# ── the provider cache ─────────────────────────────────────────────────────────
+class Tracing:
+    """One tracer provider per traced name (`<instance>/<name>`), built lazily, rebuilt when
+    the configuration changes, flushed at shutdown. `tracer_for` returns None whenever tracing
+    is off, so a call site holds either a tracer or nothing and the helpers below accept both."""
+
+    def __init__(self, store, exporter_factory=None):
+        self.store = store
+        # exporter_factory(config) -> SpanExporter; tests hand in an in-memory one
+        self._exporter_factory = exporter_factory
+        self._providers: dict[str, Any] = {}
+        self._fingerprint: tuple | None = None
+        self._lock = threading.Lock()
+        # one identity per process, shared by every provider it builds
+        self._instance_id = str(uuid.uuid4())
+
+    def tracer_for(self, name: str):
+        try:
+            cfg = resolve(self.store)
+        except Exception as e:   # a broken settings read must not stop the run
+            print(f"tracing: config read failed: {type(e).__name__}: {e}")
+            return None
+        if not cfg.active:
+            if self._providers:
+                self.shutdown()
+            return None
+        with self._lock:
+            if cfg.fingerprint != self._fingerprint:
+                self._shutdown_locked()
+                self._fingerprint = cfg.fingerprint
+            provider = self._providers.get(name)
+            if provider is None:
+                try:
+                    provider = self._build(cfg, name)
+                except Exception as e:   # missing SDK, bad endpoint: trace nothing, say so once
+                    print(f"tracing: could not start a tracer for {name!r}: "
+                          f"{type(e).__name__}: {e}")
+                    return None
+                self._providers[name] = provider
+        return provider.get_tracer("tares")
+
+    def _build(self, cfg: TracingConfig, name: str):
+        from opentelemetry.sdk.resources import Resource
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+        try:
+            from importlib.metadata import version as _v
+            tares_version = _v("tares")
+        except Exception:
+            tares_version = "dev"
+        resource = Resource.create({
+            "service.name": f"{cfg.instance}/{name}",
+            "service.instance.id": self._instance_id,
+            "tares.instance": cfg.instance,
+            "tares.agent": name,
+            "tares.version": tares_version,
+        })
+        provider = TracerProvider(resource=resource)
+        provider.add_span_processor(_SessionProcessor())
+        if self._exporter_factory is not None:
+            exporter = self._exporter_factory(cfg)
+        else:
+            from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+            exporter = OTLPSpanExporter(endpoint=f"{cfg.endpoint}/v1/traces",
+                                        headers=cfg.headers or None)
+        provider.add_span_processor(BatchSpanProcessor(exporter))
+        return provider
+
+    def flush(self, timeout_ms: int = 5000) -> None:
+        with self._lock:
+            for provider in list(self._providers.values()):
+                try:
+                    provider.force_flush(timeout_ms)
+                except Exception:
+                    pass
+
+    def shutdown(self) -> None:
+        with self._lock:
+            self._shutdown_locked()
+
+    def _shutdown_locked(self) -> None:
+        for provider in list(self._providers.values()):
+            try:
+                provider.force_flush(5000)
+                provider.shutdown()
+            except Exception:
+                pass
+        self._providers.clear()
+        self._fingerprint = None
+
+
+# ── session propagation (session.id on every span of a run) ───────────────────
+# Backends derive a per-span session id with the trace id as the fallback, so stamping the root
+# alone would scatter the children. The id rides the OTel context and a processor copies it onto
+# each span at start, the same way the Rius SDK does it.
+try:
+    from opentelemetry import context as _otel_context
+    from opentelemetry.sdk.trace import SpanProcessor as _SpanProcessor
+    _SESSION_KEY = _otel_context.create_key("tares-session-id")
+
+    class _SessionProcessor(_SpanProcessor):
+        def on_start(self, span, parent_context=None):
+            value = _otel_context.get_value(_SESSION_KEY, context=parent_context)
+            if isinstance(value, str) and value:
+                span.set_attribute(SESSION_ID, value)
+
+        def on_end(self, span):
+            pass
+
+        def shutdown(self):
+            pass
+
+        def force_flush(self, timeout_millis: int = 30000) -> bool:
+            return True
+except ImportError:   # SDK absent: Tracing._build raises and tracer_for returns None
+    _otel_context = None
+    _SESSION_KEY = None
+    _SessionProcessor = None   # type: ignore[assignment,misc]
+
+
+# ── serialisation ──────────────────────────────────────────────────────────────
+def _clip(s: str) -> str:
+    return s if len(s) <= MAX_ATTR_CHARS else s[:MAX_ATTR_CHARS] + "…"
+
+
+def serialize(value: Any) -> str:
+    if isinstance(value, str):
+        return _clip(value)
+    try:
+        return _clip(json.dumps(value, ensure_ascii=False, default=str))
+    except Exception:
+        return _clip(repr(value))
+
+
+def _part(item: Any) -> dict:
+    """One Anthropic content block -> the gen_ai message part shape."""
+    if isinstance(item, dict):
+        t = item.get("type")
+        if t == "text":
+            return {"type": "text", "content": item.get("text", "")}
+        if t == "tool_use":
+            return {"type": "tool_call", "id": item.get("id"), "name": item.get("name"),
+                    "arguments": item.get("input")}
+        if t == "tool_result":
+            return {"type": "tool_call_response", "id": item.get("tool_use_id"),
+                    "response": item.get("content")}
+        if t:
+            return item
+        return {"type": "text", "content": serialize(item)}
+    # SDK objects (anthropic.types.*) expose the same fields as attributes
+    t = getattr(item, "type", None)
+    if t == "text":
+        return {"type": "text", "content": getattr(item, "text", "")}
+    if t == "tool_use":
+        return {"type": "tool_call", "id": getattr(item, "id", None),
+                "name": getattr(item, "name", None), "arguments": getattr(item, "input", None)}
+    return {"type": "text", "content": item if isinstance(item, str) else serialize(item)}
+
+
+def _message(message: Any, default_role: str) -> dict:
+    if isinstance(message, str):
+        return {"role": default_role, "parts": [{"type": "text", "content": message}]}
+    if not isinstance(message, dict):
+        return {"role": default_role, "parts": [{"type": "text", "content": serialize(message)}]}
+    role = message.get("role", default_role)
+    content = message.get("content")
+    if isinstance(content, str):
+        parts = [{"type": "text", "content": content}]
+    elif isinstance(content, list):
+        parts = [_part(c) for c in content]
+    elif content is None:
+        parts = []
+    else:
+        parts = [{"type": "text", "content": serialize(content)}]
+    return {"role": role, "parts": parts}
+
+
+def messages_json(messages: Any, default_role: str) -> str:
+    if isinstance(messages, str):
+        return serialize([_message(messages, default_role)])
+    if isinstance(messages, list) and messages and not isinstance(messages[0], dict) \
+            and not isinstance(messages[0], str) and hasattr(messages[0], "type"):
+        # a bare list of content blocks (a model response): one message
+        return serialize([{"role": default_role, "parts": [_part(c) for c in messages]}])
+    if isinstance(messages, list) and messages and isinstance(messages[0], dict) \
+            and "role" not in messages[0] and "type" in messages[0]:
+        return serialize([{"role": default_role, "parts": [_part(c) for c in messages]}])
+    return serialize([_message(m, default_role) for m in (messages or [])])
+
+
+# ── span helpers ───────────────────────────────────────────────────────────────
+class Observation:
+    """A span with the OpenInference annotation surface. `None`-safe: every method is a no-op
+    on an observation without a span, so call sites need no `if tracer` guards."""
+
+    def __init__(self, span=None):
+        self._span = span
+
+    def set_input(self, value: Any) -> None:
+        self.set_attribute(INPUT_VALUE, serialize(value))
+
+    def set_output(self, value: Any) -> None:
+        self.set_attribute(OUTPUT_VALUE, serialize(value))
+
+    def set_attribute(self, key: str, value: Any) -> None:
+        if self._span is None or value is None:
+            return
+        try:
+            self._span.set_attribute(key, value)
+        except Exception:
+            pass
+
+    def error(self, detail: str | BaseException) -> None:
+        if self._span is None:
+            return
+        try:
+            from opentelemetry.trace import Status, StatusCode
+            if isinstance(detail, BaseException):
+                self._span.record_exception(detail)
+                detail = f"{type(detail).__name__}: {detail}"
+            self._span.set_status(Status(StatusCode.ERROR, str(detail)[:500]))
+        except Exception:
+            pass
+
+
+class Generation(Observation):
+    """An LLM span: messages in the gen_ai shape, usage, response model, stop reason."""
+
+    def __init__(self, span=None):
+        super().__init__(span)
+        self._first_token = False
+
+    def set_input(self, messages: Any) -> None:
+        self.set_attribute(GEN_AI_INPUT_MESSAGES, messages_json(messages, "user"))
+
+    def set_output(self, messages: Any) -> None:
+        self.set_attribute(GEN_AI_OUTPUT_MESSAGES, messages_json(messages, "assistant"))
+
+    def set_usage(self, usage: Any) -> None:
+        """`usage` is Anthropic's usage block, as a dict or an SDK object."""
+        get = (usage.get if isinstance(usage, dict) else
+               lambda k, d=None: getattr(usage, k, d))
+        for key, attr in (("input_tokens", GEN_AI_USAGE_INPUT),
+                          ("output_tokens", GEN_AI_USAGE_OUTPUT),
+                          ("cache_creation_input_tokens", GEN_AI_USAGE_CACHE_CREATION),
+                          ("cache_read_input_tokens", GEN_AI_USAGE_CACHE_READ)):
+            val = get(key)
+            if val is not None:
+                self.set_attribute(attr, int(val))
+
+    def set_response_model(self, model: str | None) -> None:
+        if model:
+            self.set_attribute(GEN_AI_RESPONSE_MODEL, model)
+
+    def set_finish_reason(self, reason: str | None) -> None:
+        if reason:
+            self.set_attribute(GEN_AI_FINISH_REASONS, [reason])
+
+    def record_first_token(self) -> None:
+        if self._first_token or self._span is None:
+            return
+        self._first_token = True
+        try:
+            self._span.add_event(GEN_AI_FIRST_TOKEN)
+        except Exception:
+            pass
+
+
+@contextmanager
+def _span(tracer, name: str, attributes: dict, cls=Observation) -> Iterator[Observation]:
+    if tracer is None:
+        yield cls(None)
+        return
+    try:
+        cm = tracer.start_as_current_span(name, attributes=attributes)
+        span = cm.__enter__()
+    except Exception:
+        yield cls(None)
+        return
+    obs = cls(span)
+    try:
+        yield obs
+    except BaseException as e:
+        obs.error(e)
+        cm.__exit__(type(e), e, e.__traceback__)
+        raise
+    else:
+        cm.__exit__(None, None, None)
+
+
+@contextmanager
+def run_span(tracer, name: str, *, kind: str = "AGENT", session: str | None = None,
+             attributes: dict | None = None) -> Iterator[Observation]:
+    """The root span of a run. `session` (the entity key) groups the runs that looked at the
+    same entity; it is stamped on every span of the run via the OTel context."""
+    attrs = {SPAN_KIND: kind, GEN_AI_OPERATION: _OPERATION_BY_KIND[kind]}
+    for k, v in (attributes or {}).items():
+        if v is not None and v != "":
+            attrs[k] = v
+    token = None
+    if tracer is not None and session and _otel_context is not None:
+        try:
+            token = _otel_context.attach(_otel_context.set_value(_SESSION_KEY, session))
+        except Exception:
+            token = None
+    try:
+        with _span(tracer, name, attrs) as obs:
+            yield obs
+    finally:
+        if token is not None:
+            try:
+                _otel_context.detach(token)
+            except Exception:
+                pass
+
+
+@contextmanager
+def generation(tracer, model: str, messages: Any = None,
+               parameters: dict | None = None) -> Iterator[Generation]:
+    """One model call. Sets the request side up front; the caller records the response with
+    `set_output` / `set_usage` / `set_response_model` / `set_finish_reason`."""
+    attrs = {SPAN_KIND: "LLM", GEN_AI_OPERATION: "chat", GEN_AI_PROVIDER: "anthropic",
+             GEN_AI_REQUEST_MODEL: model}
+    for k, v in (parameters or {}).items():
+        if v is not None:
+            attrs[f"gen_ai.request.{k}"] = v
+    with _span(tracer, f"chat {model}", attrs, cls=Generation) as gen:
+        if messages is not None:
+            gen.set_input(messages)
+        yield gen
+
+
+@contextmanager
+def tool_span(tracer, name: str, arguments: Any = None) -> Iterator[Observation]:
+    attrs = {SPAN_KIND: "TOOL", GEN_AI_OPERATION: "execute_tool", GEN_AI_TOOL_NAME: name}
+    with _span(tracer, name, attrs) as obs:
+        if arguments is not None:
+            obs.set_input(arguments)
+        yield obs

--- a/tares/tracing.py
+++ b/tares/tracing.py
@@ -379,7 +379,16 @@ class Observation:
         except Exception:
             pass
 
+    def tool_error(self, detail: str) -> None:
+        """A tool call that returned an error. The model gets the error text back and goes on,
+        so the run is not failed: the span carries the text and a flag, but NOT the ERROR status
+        (a backend rolls span status up to the trace, and a trace with one fumbled tool call
+        would read as a failed run)."""
+        self.set_attribute("tares.tool_error", True)
+        self.set_output(detail)
+
     def error(self, detail: str | BaseException) -> None:
+        """The run itself failed: ERROR status, which the backend rolls up to the trace."""
         if self._span is None:
             return
         try:

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -1,0 +1,400 @@
+"""Agent tracing (tares/tracing.py): configuration resolution, the span helpers, and an
+end-to-end run exported over OTLP/HTTP to a stub receiver.
+
+Part 1 is in-process: presets and precedence, the OpenInference/gen_ai attributes the helpers
+write, the provider cache rebuilding when the configuration changes.
+Part 2 boots the daemon against the stub Anthropic endpoint from test_agents.py and a stub OTLP
+receiver, runs an agent, and asserts the trace that arrives: service.name per agent, a root
+AGENT span, an LLM span with token usage, a TOOL span. Then switches tracing off through the
+settings API and checks the next run exports nothing.
+"""
+import asyncio, json, os, signal, subprocess, sys, threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import httpx
+
+P = F = 0
+def ck(l, c, d=""):
+    global P, F; P += 1 if c else 0; F += 0 if c else 1
+    print(("  ok   " if c else "  FAIL ") + l + ("" if c else f"  {d}"))
+
+
+class FakeStore:
+    def __init__(self):
+        self.d = {}
+    def get_setting(self, k):
+        return self.d.get(k)
+    def set_setting(self, k, v):
+        if v is None:
+            self.d.pop(k, None)
+        else:
+            self.d[k] = v
+
+
+def _clear_env():
+    for k in list(os.environ):
+        if k.startswith("TARES_TRACING") or k == "TARES_INSTANCE_NAME":
+            del os.environ[k]
+
+
+# ── part 1: in-process ────────────────────────────────────────────────────────
+def part1():
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+    from tares import tracing as T
+
+    _clear_env()
+    st = FakeStore()
+
+    cfg = T.resolve(st)
+    ck("off by default", not cfg.enabled and not cfg.active, str(cfg))
+    ck("no provider named and no endpoint -> the rius preset",
+       cfg.provider == "rius" and cfg.endpoint == T.RIUS_ENDPOINT
+       and cfg.sources["endpoint"] == "preset", str(cfg))
+
+    os.environ["TARES_TRACING_API_KEY"] = "gf_env"
+    os.environ["TARES_TRACING_ENABLED"] = "true"
+    os.environ["TARES_INSTANCE_NAME"] = "cell-a"
+    cfg = T.resolve(st)
+    ck("env key becomes a bearer header", cfg.headers.get("authorization") == "Bearer gf_env", str(cfg.headers))
+    ck("env switch turns it on", cfg.enabled and cfg.active, str(cfg))
+    ck("instance from env", cfg.instance == "cell-a", cfg.instance)
+    ck("key source reported as env", cfg.sources["api_key"] == "env:TARES_TRACING_API_KEY", str(cfg.sources))
+
+    st.set_setting("tracing_api_key", "gf_console")
+    st.set_setting("tracing_enabled", "0")
+    cfg = T.resolve(st)
+    ck("console key wins over env", cfg.headers.get("authorization") == "Bearer gf_console", str(cfg.headers))
+    ck("console switch wins over env", not cfg.enabled, str(cfg))
+
+    st.set_setting("tracing_enabled", "1")
+    st.set_setting("tracing_endpoint", "http://collector:4318")
+    st.set_setting("tracing_headers", "x-langfuse-public=pk, x-langfuse-secret=sk")
+    cfg = T.resolve(st)
+    ck("an endpoint without a provider means otlp", cfg.provider == "otlp", cfg.provider)
+    ck("headers parsed", cfg.headers.get("x-langfuse-public") == "pk"
+       and cfg.headers.get("x-langfuse-secret") == "sk", str(cfg.headers))
+    st.set_setting("tracing_headers", "authorization=Basic abc")
+    ck("explicit authorization header wins over the key",
+       T.resolve(st).headers.get("authorization") == "Basic abc", str(T.resolve(st).headers))
+    st.set_setting("tracing_headers", "x-langfuse-public=pk, x-langfuse-secret=sk")
+    s = T.status(st)
+    ck("status never carries secrets", "gf_console" not in json.dumps(s) and "sk" not in json.dumps(s.get("headers_source")), json.dumps(s))
+    ck("status reports key configured + stored", s["key_configured"] and s["key_stored"], str(s))
+
+    # ── the helpers ──────────────────────────────────────────────────────────
+    exporters = []
+    def factory(cfg):
+        ex = InMemorySpanExporter(); exporters.append(ex); return ex
+    tr = T.Tracing(st, exporter_factory=factory)
+    tracer = tr.tracer_for("first-look")
+    ck("tracer built when active", tracer is not None)
+    with T.run_span(tracer, "first-look", session="checkout",
+                    attributes={"tares.run_id": "run_1", "tares.dispatch_id": ""}) as obs:
+        obs.set_input("timeline")
+        with T.generation(tracer, "claude-sonnet-4-6",
+                          [{"role": "user", "content": "hi"}], {"max_tokens": 10}) as gen:
+            gen.set_output([{"type": "text", "text": "ok"},
+                            {"type": "tool_use", "id": "t1", "name": "read", "input": {"a": 1}}])
+            gen.set_usage({"input_tokens": 100, "output_tokens": 50, "cache_read_input_tokens": 7})
+            gen.set_response_model("claude-sonnet-4-6-x")
+            gen.set_finish_reason("tool_use")
+        with T.tool_span(tracer, "read", {"selector": {"service": "checkout"}}) as tobs:
+            tobs.set_output("payload")
+        obs.set_output("the finding")
+        obs.set_attribute("tares.status", "ok")
+    tr.flush()
+    spans = exporters[0].get_finished_spans()
+    by = {s.name: s for s in spans}
+    ck("three spans: run, chat, tool", len(spans) == 3 and {"first-look", "chat claude-sonnet-4-6", "read"} <= set(by), str(list(by)))
+    root = by["first-look"]
+    ck("service.name is <instance>/<agent>", root.resource.attributes.get("service.name") == "cell-a/first-look",
+       str(root.resource.attributes))
+    ck("root span is AGENT kind", root.attributes.get("openinference.span.kind") == "AGENT", str(root.attributes))
+    ck("root carries input and output", root.attributes.get("input.value") == "timeline"
+       and root.attributes.get("output.value") == "the finding", str(root.attributes))
+    ck("empty attributes are dropped", "tares.dispatch_id" not in root.attributes, str(root.attributes))
+    ck("session.id on every span", all(s.attributes.get("session.id") == "checkout" for s in spans),
+       str([s.attributes.get("session.id") for s in spans]))
+    ck("children nest under the root", all(s.parent and s.parent.span_id == root.context.span_id
+                                           for s in spans if s is not root))
+    llm = by["chat claude-sonnet-4-6"]
+    a = llm.attributes
+    ck("llm span kind + provider + model", a.get("openinference.span.kind") == "LLM"
+       and a.get("gen_ai.provider.name") == "anthropic" and a.get("gen_ai.request.model") == "claude-sonnet-4-6", str(a))
+    ck("llm usage", a.get("gen_ai.usage.input_tokens") == 100 and a.get("gen_ai.usage.output_tokens") == 50
+       and a.get("gen_ai.usage.cache_read_input_tokens") == 7, str(a))
+    ck("llm response model + finish reason", a.get("gen_ai.response.model") == "claude-sonnet-4-6-x"
+       and tuple(a.get("gen_ai.response.finish_reasons")) == ("tool_use",), str(a))
+    inp = json.loads(a["gen_ai.input.messages"]); out = json.loads(a["gen_ai.output.messages"])
+    ck("input messages in the gen_ai shape", inp == [{"role": "user", "parts": [{"type": "text", "content": "hi"}]}], str(inp))
+    ck("tool_use block becomes a tool_call part", out[0]["role"] == "assistant"
+       and out[0]["parts"][1] == {"type": "tool_call", "id": "t1", "name": "read", "arguments": {"a": 1}}, str(out))
+    ck("request parameter recorded", a.get("gen_ai.request.max_tokens") == 10, str(a))
+    tool = by["read"]
+    ck("tool span kind + name", tool.attributes.get("openinference.span.kind") == "TOOL"
+       and tool.attributes.get("gen_ai.tool.name") == "read", str(tool.attributes))
+    ck("tool input serialised", json.loads(tool.attributes["input.value"]) == {"selector": {"service": "checkout"}}, str(tool.attributes))
+
+    # errors mark the span
+    with T.run_span(tracer, "first-look", session="k") as obs:
+        obs.error("boom")
+    tr.flush()
+    last = exporters[0].get_finished_spans()[-1]
+    ck("error sets ERROR status", last.status.status_code.name == "ERROR" and "boom" in (last.status.description or ""), str(last.status))
+
+    # an exception inside the block is recorded and re-raised
+    try:
+        with T.run_span(tracer, "x", session="k"):
+            raise RuntimeError("bad")
+    except RuntimeError:
+        raised = True
+    else:
+        raised = False
+    tr.flush()
+    last = exporters[0].get_finished_spans()[-1]
+    ck("exception re-raised and recorded", raised and last.status.status_code.name == "ERROR", str(last.status))
+
+    # None tracer: everything is a no-op
+    with T.run_span(None, "x", session="k") as obs:
+        obs.set_input("a"); obs.error("b")
+        with T.generation(None, "m", "hi") as gen:
+            gen.set_usage({"input_tokens": 1}); gen.record_first_token()
+        with T.tool_span(None, "t", {}) as tobs:
+            tobs.set_output("o")
+    ck("no tracer: helpers are no-ops", True)
+
+    # one provider per agent, cached
+    t2 = tr.tracer_for("second"); t1b = tr.tracer_for("first-look")
+    ck("providers cached per agent", len(exporters) == 2 and t1b is not None and t2 is not None, str(len(exporters)))
+
+    # config change rebuilds; switching off tears down
+    st.set_setting("tracing_endpoint", "http://other:4318")
+    tr.tracer_for("first-look")
+    ck("changed endpoint rebuilds the providers", len(exporters) == 3, str(len(exporters)))
+    st.set_setting("tracing_enabled", "0")
+    ck("switched off -> no tracer", tr.tracer_for("first-look") is None)
+    ck("switched off -> cache emptied", not tr._providers)
+    st.set_setting("tracing_enabled", "1")
+    ck("switched on again -> tracer without a restart", tr.tracer_for("first-look") is not None)
+    tr.shutdown()
+    _clear_env()
+
+
+# ── part 2: end to end through the daemon ────────────────────────────────────
+SEED = "/tmp/tracing_catalog.yaml"
+DB, PORT, STUB_PORT, OTLP_PORT = "/tmp/tracing.duckdb", "8816", "8817", "8818"
+FINDING = "checkout is returning 500s; roll back."
+_calls = []
+_received = []   # decoded ExportTraceServiceRequest messages
+
+
+class AnthropicStub(BaseHTTPRequestHandler):
+    def do_POST(self):
+        body = json.loads(self.rfile.read(int(self.headers["content-length"])))
+        _calls.append(body)
+        # the stub is shared across runs: one tool round per run, then the conclusion
+        n = sum(1 for c in _calls if c["messages"][0] == body["messages"][0])
+        if n == 1:
+            content = [{"type": "tool_use", "id": "tu_1", "name": "read",
+                        "input": {"selector": {"service": "checkout"}, "window": "1h"}}]
+        else:
+            content = [{"type": "text", "text": FINDING}]
+        out = json.dumps({"content": content, "model": body.get("model"), "stop_reason": "end_turn",
+                          "usage": {"input_tokens": 100, "output_tokens": 50}}).encode()
+        self.send_response(200)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(out)))
+        self.end_headers()
+        self.wfile.write(out)
+
+    def log_message(self, *a):
+        pass
+
+
+class OtlpStub(BaseHTTPRequestHandler):
+    def do_POST(self):
+        from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceRequest
+        raw = self.rfile.read(int(self.headers["content-length"]))
+        req = ExportTraceServiceRequest(); req.ParseFromString(raw)
+        _received.append((self.path, dict(self.headers), req))
+        self.send_response(200)
+        self.send_header("content-type", "application/x-protobuf")
+        self.send_header("content-length", "0")
+        self.end_headers()
+
+    def log_message(self, *a):
+        pass
+
+
+def _spans():
+    """Flatten what the receiver got: [(service.name, span)]."""
+    out = []
+    for _path, _h, req in _received:
+        for rs in req.resource_spans:
+            svc = next((kv.value.string_value for kv in rs.resource.attributes if kv.key == "service.name"), "")
+            for ss in rs.scope_spans:
+                for sp in ss.spans:
+                    out.append((svc, sp))
+    return out
+
+
+def _attr(span, key):
+    for kv in span.attributes:
+        if kv.key == key:
+            v = kv.value
+            if v.HasField("string_value"): return v.string_value
+            if v.HasField("int_value"): return v.int_value
+            if v.HasField("array_value"): return [x.string_value for x in v.array_value.values]
+    return None
+
+
+async def _wait(url, tries=80):
+    for _ in range(tries):
+        try:
+            async with httpx.AsyncClient() as cx:
+                if (await cx.get(url, timeout=2)).status_code == 200:
+                    return True
+        except Exception:
+            pass
+        await asyncio.sleep(0.25)
+    return False
+
+
+async def _until(fn, tries=60):
+    for _ in range(tries):
+        if await fn():
+            return True
+        await asyncio.sleep(0.5)
+    return False
+
+
+async def part2():
+    with open(SEED, "w") as fh:
+        fh.write(
+            "sources:\n  - name: evt\n    connector: webhook\n    poll: 5s\n"
+            "    config:\n      labels:\n        - name: service\n          field: service\n"
+            "          primary: true\n"
+            "views:\n  - name: svc\n    key_field: service\n    sources: [evt]\n"
+            "triggers:\n  - name: incident\n    view: svc\n    cooldown: 1s\n"
+            "    condition:\n      aggregate: count\n      predicate: '>= 2'\n      window: 1m\n")
+    for p in (DB, DB + ".wal"):
+        if os.path.exists(p):
+            os.remove(p)
+    for srv in (HTTPServer(("127.0.0.1", int(STUB_PORT)), AnthropicStub),
+                HTTPServer(("127.0.0.1", int(OTLP_PORT)), OtlpStub)):
+        threading.Thread(target=srv.serve_forever, daemon=True).start()
+
+    env = {**os.environ, "TARES_DB": DB, "TARES_CATALOG": SEED, "TARES_PORT": PORT,
+           "TARES_OTLP_GRPC_PORT": "off", "ANTHROPIC_API_KEY": "sk-test",
+           "TARES_ANTHROPIC_BASE": f"http://127.0.0.1:{STUB_PORT}",
+           "TARES_TRIGGER_DEBOUNCE_SECONDS": "0",
+           # the generic provider: any OTLP/HTTP endpoint, a key as bearer, on from the env
+           "TARES_TRACING_ENABLED": "1", "TARES_TRACING_PROVIDER": "otlp",
+           "TARES_TRACING_ENDPOINT": f"http://127.0.0.1:{OTLP_PORT}",
+           "TARES_TRACING_API_KEY": "gf_test", "TARES_INSTANCE_NAME": "local",
+           "OTEL_BSP_SCHEDULE_DELAY": "200"}
+    proc = subprocess.Popen([sys.executable, "-c", "from tares.cli import run_daemon; run_daemon()"],
+                            env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    B = f"http://127.0.0.1:{PORT}"
+    try:
+        if not await _wait(f"{B}/health"):
+            ck("daemon up", False); return
+        async with httpx.AsyncClient(timeout=20) as cx:
+            s = (await cx.get(f"{B}/api/settings/tracing")).json()
+            ck("settings: on from env, provider otlp, endpoint from env",
+               s["enabled"] and s["active"] and s["provider"] == "otlp"
+               and s["endpoint_source"] == "env:TARES_TRACING_ENDPOINT", str(s))
+            ck("settings never return the key", "gf_test" not in json.dumps(s), json.dumps(s))
+
+            r = await cx.post(f"{B}/api/agents/builtin", json={
+                "name": "first-look", "trigger": "incident", "prompt": "Take a first look."})
+            ck("create agent -> 201", r.status_code == 201, r.text)
+            await cx.post(f"{B}/api/agents/builtin/first-look/enable")
+            for i in range(3):
+                await cx.post(f"{B}/ingest/evt", json={"service": "checkout", "msg": f"500 #{i}"})
+
+            async def _ran():
+                rs = (await cx.get(f"{B}/api/agents/builtin/first-look/runs")).json()
+                return bool(rs) and rs[0]["status"] != "running"
+            ck("a run completed", await _until(_ran), "no completed run")
+            run = (await cx.get(f"{B}/api/agents/builtin/first-look/runs")).json()[0]
+            ck("run status ok (tracing did not get in the way)", run.get("status") == "ok", str(run))
+
+            async def _got():
+                return any(sp.name == "first-look" for _s, sp in _spans())
+            ck("trace exported to the OTLP endpoint", await _until(_got), str(len(_received)))
+            path, headers, _ = _received[0]
+            ck("posted to /v1/traces", path == "/v1/traces", path)
+            ck("bearer header carries the key", headers.get("authorization") == "Bearer gf_test", str(headers))
+            spans = _spans()
+            root = next((sp for svc, sp in spans if sp.name == "first-look"), None)
+            svc = next((svc for svc, sp in spans if sp.name == "first-look"), None)
+            ck("service.name is <instance>/<agent>", svc == "local/first-look", str(svc))
+            ck("root span: AGENT kind, run id, status ok",
+               root is not None and _attr(root, "openinference.span.kind") == "AGENT"
+               and _attr(root, "tares.run_id") == run["id"] and _attr(root, "tares.status") == "ok",
+               str([(kv.key, kv.value) for kv in root.attributes]) if root else "no root")
+            ck("root output is the finding", root is not None and _attr(root, "output.value") == FINDING)
+            ck("root session is the entity key", root is not None and _attr(root, "session.id") == "checkout")
+            ck("root records cost + calls", root is not None and _attr(root, "tares.model_calls") == 2)
+            llms = [sp for svc, sp in spans if _attr(sp, "openinference.span.kind") == "LLM"]
+            ck("one LLM span per model call", len(llms) == 2, str(len(llms)))
+            ck("LLM spans carry usage", all(_attr(sp, "gen_ai.usage.input_tokens") == 100
+                                           and _attr(sp, "gen_ai.usage.output_tokens") == 50 for sp in llms))
+            ck("LLM spans carry the finish reason", all(_attr(sp, "gen_ai.response.finish_reasons") == ["end_turn"] for sp in llms))
+            tools = [sp for svc, sp in spans if _attr(sp, "openinference.span.kind") == "TOOL"]
+            ck("one TOOL span, named read", len(tools) == 1 and tools[0].name == "read"
+               and _attr(tools[0], "gen_ai.tool.name") == "read", str([t.name for t in tools]))
+            ck("tool span has the payload as output", bool(tools) and "checkout" in (_attr(tools[0], "output.value") or ""))
+            ck("children share the root trace", all(sp.trace_id == root.trace_id for _s, sp in spans))
+
+            # ── switch off through the API; the next run exports nothing ────
+            r = await cx.put(f"{B}/api/settings/tracing", json={"enabled": False})
+            ck("PUT enabled=false -> off", r.status_code == 200 and not r.json()["enabled"]
+               and r.json()["enabled_source"] == "console", r.text[:200])
+            before = len(_spans())
+            await asyncio.sleep(1.2)
+            for i in range(3):
+                await cx.post(f"{B}/ingest/evt", json={"service": "checkout", "msg": f"500 again #{i}"})
+            async def _ran2():
+                rs = (await cx.get(f"{B}/api/agents/builtin/first-look/runs")).json()
+                return len(rs) >= 2 and rs[0]["status"] != "running"
+            ck("a second run completed", await _until(_ran2), "no second run")
+            await asyncio.sleep(1.0)
+            ck("no spans exported while off", len(_spans()) == before, f"{before} -> {len(_spans())}")
+
+            # ── back on, and a stored key/provider round trip ────────────────
+            r = await cx.put(f"{B}/api/settings/tracing", json={"enabled": True, "api_key": "gf_console"})
+            ck("PUT enabled=true + key -> on, key stored", r.status_code == 200 and r.json()["active"]
+               and r.json()["key_stored"] and r.json()["key_source"] == "console", r.text[:200])
+            r = await cx.put(f"{B}/api/settings/tracing", json={"provider": "bogus"})
+            ck("unknown provider rejected", r.status_code == 400, r.text[:200])
+            r = await cx.put(f"{B}/api/settings/tracing", json={"endpoint": "collector:4318"})
+            ck("bad endpoint rejected", r.status_code == 400, r.text[:200])
+            r = await cx.put(f"{B}/api/settings/tracing", json={"api_key": ""})
+            ck("empty key clears the stored one (env takes over)",
+               r.status_code == 200 and not r.json()["key_stored"]
+               and r.json()["key_source"] == "env:TARES_TRACING_API_KEY", r.text[:200])
+            await asyncio.sleep(1.2)
+            for i in range(3):
+                await cx.post(f"{B}/ingest/evt", json={"service": "checkout", "msg": f"500 third #{i}"})
+            async def _ran3():
+                rs = (await cx.get(f"{B}/api/agents/builtin/first-look/runs")).json()
+                return len(rs) >= 3 and rs[0]["status"] != "running"
+            ck("a third run completed", await _until(_ran3), "no third run")
+            async def _more():
+                return len(_spans()) > before
+            ck("spans flow again after switching back on", await _until(_more), f"{before} -> {len(_spans())}")
+    finally:
+        proc.send_signal(signal.SIGTERM)
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+if __name__ == "__main__":
+    part1()
+    asyncio.run(part2())
+    print(f"\n{P} passed, {F} failed")
+    sys.exit(1 if F else 0)

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -135,7 +135,19 @@ def part1():
        and tool.attributes.get("gen_ai.tool.name") == "read", str(tool.attributes))
     ck("tool input serialised", json.loads(tool.attributes["input.value"]) == {"selector": {"service": "checkout"}}, str(tool.attributes))
 
-    # errors mark the span
+    # a failed tool call is flagged on its span, but does not fail the trace
+    with T.run_span(tracer, "first-look", session="k") as obs:
+        with T.tool_span(tracer, "query", {}) as tobs:
+            tobs.tool_error("tool error: query needs a key")
+    tr.flush()
+    got = exporters[0].get_finished_spans()[-2:]
+    tspan = next(s for s in got if s.name == "query"); rspan = next(s for s in got if s.name == "first-look")
+    ck("tool error: flag + text on the tool span", tspan.attributes.get("tares.tool_error") is True
+       and "needs a key" in tspan.attributes.get("output.value", ""), str(tspan.attributes))
+    ck("tool error: no ERROR status on the tool span", tspan.status.status_code.name != "ERROR", str(tspan.status))
+    ck("tool error: run span stays unset", rspan.status.status_code.name == "UNSET", str(rspan.status))
+
+    # a failed run marks the span
     with T.run_span(tracer, "first-look", session="k") as obs:
         obs.error("boom")
     tr.flush()

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -185,6 +185,13 @@ export const api = {
     request<{ ok: boolean; configured: boolean }>("/api/settings/anthropic-key",
       { method: "DELETE" }),
 
+  // Agent tracing: where runs are exported and whether. Secrets are write-only; the status says
+  // what resolves and where from (console vs environment).
+  tracingStatus: () => request<TracingStatus>("/api/settings/tracing"),
+  setTracing: (body: { enabled?: boolean; provider?: string; endpoint?: string; api_key?: string; headers?: string }) =>
+    request<TracingStatus & { ok: boolean; note?: string }>("/api/settings/tracing",
+      { method: "PUT", body: JSON.stringify(body) }),
+
   // The Slack bot token behind slack:// subscriptions. Same contract as the Anthropic key: the
   // value never leaves the server, only whether one resolves and where from.
   slackTokenStatus: () =>
@@ -365,4 +372,13 @@ export const api = {
       method: "POST",
       body: JSON.stringify({ yaml, mode }),
     }),
+};
+
+export type TracingStatus = {
+  enabled: boolean; enabled_source: string; active: boolean;
+  provider: string; provider_source: string;
+  endpoint: string; endpoint_source: string;
+  key_configured: boolean; key_source: string; key_stored: boolean;
+  headers_configured: boolean; headers_source: string;
+  instance: string; providers: string[]; rius_console_url: string;
 };

--- a/ui/src/pages/Security.tsx
+++ b/ui/src/pages/Security.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 
-import { api } from "../api";
+import { api, type TracingStatus } from "../api";
 import ConfirmDialog from "../components/ConfirmDialog";
 import { Close } from "../components/icons";
 import { TimeAgo } from "../components/bits";
@@ -13,12 +13,13 @@ import type { ApiKey, GithubCredential } from "../types";
 //   · Slack      — the bot token behind slack:// trigger subscriptions (outbound), and the
 //                  signing secret that authenticates the /tares slash command (inbound)
 // The per-source ingest URL is an address, not a secret — it lives on the source page, not here.
-type SettingsTab = "access" | "anthropic" | "github" | "slack";
+type SettingsTab = "access" | "anthropic" | "github" | "slack" | "observability";
 const TABS: { key: SettingsTab; label: string }[] = [
   { key: "access", label: "Access and API keys" },
   { key: "anthropic", label: "Anthropic" },
   { key: "github", label: "GitHub" },
   { key: "slack", label: "Slack" },
+  { key: "observability", label: "Observability" },
 ];
 
 export default function Security() {
@@ -40,7 +41,7 @@ export default function Security() {
   return (
     <>
       <h1>Settings</h1>
-      <p className="subtitle">access mode, API keys, and the instance credentials: Anthropic, GitHub and Slack</p>
+      <p className="subtitle">access mode, API keys, the instance credentials (Anthropic, GitHub, Slack) and agent tracing</p>
       {workspaceUrl && (
         <div className="alert" style={{ marginBottom: 14 }}>
           <strong>Users, the Slack app, plan and storage</strong> are managed in your workspace, not
@@ -58,6 +59,7 @@ export default function Security() {
       {tab === "anthropic" && <AnthropicKeyPanel />}
       {tab === "github" && <GithubPanel />}
       {tab === "slack" && <><SlackTokenPanel /><SlackSigningSecretPanel /></>}
+      {tab === "observability" && <TracingPanel />}
     </>
   );
 }
@@ -350,6 +352,139 @@ function AnthropicKeyPanel() {
           </div>
         </>
       )}
+    </div>
+  );
+}
+
+// Agent tracing: every agent run and Ask turn exported as an OpenTelemetry trace. Rius is a
+// preset (a key is enough); any OTLP/HTTP endpoint works. Same precedence as the Anthropic key:
+// a value saved here wins over the environment, so a cloud cell shows "from env" everywhere and
+// the switch is the one live control. The key and headers are write-only.
+function TracingPanel() {
+  const [st, setSt] = useState<TracingStatus>();
+  const [provider, setProvider] = useState<string>();
+  const [endpoint, setEndpoint] = useState<string>();
+  const [apiKey, setApiKey] = useState("");
+  const [headers, setHeaders] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string>();
+  const [msg, setMsg] = useState<string>();
+
+  const load = () =>
+    api.tracingStatus().then((s) => { setSt(s); setProvider(undefined); setEndpoint(undefined); })
+      .catch((e) => setErr(String((e as Error).message ?? e)));
+  useEffect(() => { load(); }, []);
+
+  const apply = async (body: Parameters<typeof api.setTracing>[0], done?: string) => {
+    setBusy(true); setErr(undefined); setMsg(undefined);
+    try {
+      const r = await api.setTracing(body);
+      setMsg(r.note ?? done ?? "✓ saved");
+      setApiKey(""); setHeaders("");
+      await load();
+    } catch (e) { setErr(String((e as Error).message ?? e)); }
+    setBusy(false);
+  };
+
+  const from = (source: string) =>
+    source === "console" ? "saved here" : source.startsWith("env:") ? `from ${source}` :
+    source === "preset" ? "the provider's default" : source === "default" ? "default" : "";
+
+  if (!st) return <div className="panel"><h2 style={{ marginTop: 0 }}>Agent tracing</h2>
+    {err ? <div className="alert error">{err}</div> : <div className="muted">loading…</div>}</div>;
+
+  const prov = provider ?? st.provider;
+  const ep = endpoint ?? (st.endpoint_source === "preset" ? "" : st.endpoint);
+  const envOnly = st.provider_source.startsWith("env:") || st.key_source.startsWith("env:");
+
+  return (
+    <div className="panel">
+      <h2 style={{ marginTop: 0 }}>Agent tracing</h2>
+      <p className="help" style={{ marginTop: 0 }}>
+        Every agent run and every Ask turn becomes an OpenTelemetry trace: the run, each model
+        call with its prompt, answer, tokens and cost, and each tool call. Traces go to the
+        backend below; each agent is its own service, named <code>{st.instance}/&lt;agent&gt;</code>.
+        The key and headers are never returned by the API.
+      </p>
+
+      {err && <div className="alert error">{err}</div>}
+      {msg && <p className="help">{msg}</p>}
+
+      <p style={{ margin: "0 0 12px" }}>
+        <label style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
+          <input type="checkbox" checked={st.enabled} disabled={busy}
+                 onChange={(e) => apply({ enabled: e.target.checked },
+                                        e.target.checked ? "✓ tracing on" : "✓ tracing off")} />
+          <strong>Send agent traces</strong>
+        </label>{" "}
+        {st.enabled
+          ? (st.active
+              ? <span className="badge ok">on</span>
+              : <span className="badge error">on, but no endpoint resolves</span>)
+          : <span className="badge">off</span>}
+        {st.enabled_source && <span className="help"> {from(st.enabled_source)}</span>}
+      </p>
+
+      {envOnly && (
+        <p className="help" style={{ margin: "0 0 10px" }}>
+          The provider and key come from the deployment's environment. Saving a value here
+          replaces it for this instance; clearing it falls back to the environment.
+        </p>
+      )}
+
+      <div style={{ display: "grid", gap: 10, maxWidth: 720 }}>
+        <label className="help">Provider{" "}
+          <select value={prov} disabled={busy} onChange={(e) => setProvider(e.target.value)}>
+            <option value="rius">Rius (GlassFlow)</option>
+            <option value="otlp">Any OpenTelemetry endpoint (OTLP/HTTP)</option>
+          </select>{" "}
+          <span className="muted">{from(st.provider_source)}</span>
+        </label>
+
+        {prov === "rius" ? (
+          <>
+            <p className="help" style={{ margin: 0 }}>
+              Create an API key in the Rius console under Settings, API keys and paste it here.{" "}
+              <a href={st.rius_console_url} target="_blank" rel="noreferrer">Open Rius ↗</a>
+              {" "}{st.key_configured
+                ? <><span className="badge ok">key configured</span> <span className="muted">{from(st.key_source)}</span></>
+                : <span className="badge error">no key</span>}
+            </p>
+            <div className="btnrow" style={{ alignItems: "center" }}>
+              <input type="password" className="mono" style={{ flex: 1 }} placeholder="gf_…"
+                     value={apiKey} onChange={(e) => setApiKey(e.target.value)} />
+              <button className="primary" disabled={busy || !apiKey.trim()}
+                      onClick={() => apply({ provider: "rius", api_key: apiKey.trim() })}>Save</button>
+              {st.key_stored && (
+                <button className="danger" disabled={busy}
+                        onClick={() => apply({ api_key: "" }, "✓ stored key cleared")}>Clear stored key</button>
+              )}
+            </div>
+          </>
+        ) : (
+          <>
+            <label className="help">Endpoint <span className="muted">{from(st.endpoint_source)}</span>
+              <input className="mono" style={{ width: "100%" }} placeholder="https://collector:4318"
+                     value={ep} onChange={(e) => setEndpoint(e.target.value)} />
+            </label>
+            <label className="help">Headers, <code>name=value</code> separated by commas{" "}
+              {st.headers_configured && <><span className="badge ok">configured</span> <span className="muted">{from(st.headers_source)}</span></>}
+              <input type="password" className="mono" style={{ width: "100%" }}
+                     placeholder="authorization=Bearer …, x-other=…"
+                     value={headers} onChange={(e) => setHeaders(e.target.value)} />
+            </label>
+            <div className="btnrow" style={{ alignItems: "center" }}>
+              <button className="primary" disabled={busy || !ep.trim()}
+                      onClick={() => apply({ provider: "otlp", endpoint: ep.trim(),
+                                             ...(headers.trim() ? { headers: headers.trim() } : {}) })}>Save</button>
+              {st.headers_configured && st.headers_source === "console" && (
+                <button className="danger" disabled={busy}
+                        onClick={() => apply({ headers: "" }, "✓ stored headers cleared")}>Clear stored headers</button>
+              )}
+            </div>
+          </>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
OSS half of the Linear project "Setup Rius workspace for tares".

Every Tares agent run and every Ask turn can be exported as an OpenTelemetry trace: a root span for the run, one span per model call (model, messages, tokens, stop reason) and one per tool call, in the OpenInference and gen_ai conventions the GenAI backends read. No vendor package: plain `opentelemetry-sdk` + the OTLP/HTTP exporter (base deps, so the switch works on `tares up`).

- Provider `rius` is a preset: an API key is enough, the endpoint is filled in. Provider `otlp` takes any OTLP/HTTP endpoint plus headers (Langfuse, Phoenix, a collector).
- One tracer provider per agent, so `service.name` is `<instance>/<agent>` (`TARES_INSTANCE_NAME`, else the hostname) and any backend groups per agent out of the box. `session.id` is the entity key.
- Settings, Observability: the switch, the provider, the key or endpoint + headers. A console value wins over the env (`TARES_TRACING_*`), so a cloud cell shows "from env" and the switch is the live control. Secrets are write-only.
- `GET/PUT /api/settings/tracing` (admin scope). A settings change rebuilds the providers on the next run; no restart.
- Off unless switched on. Tracing never breaks a run: helpers swallow their own failures, export is batched off the hot path.

Tests: `tests/test_tracing.py` (65 checks: config precedence and presets, the span attributes, an end-to-end run exported to a stub OTLP receiver, switching off and on through the API), added to CI. `test_agents`, `test_slack_ask`, `test_usage`, `test_agent_rounds` unchanged and green.

Not in this cut: Rius heartbeats (its Live Agents page), which would need the `glassflow-rius` package as an optional extra; the docs page in glassflow-docs.