### PR TITLE
Support LLM gateways for Tares agents 

### DIFF
--- a/tares/agent.py
+++ b/tares/agent.py
@@ -12,6 +12,8 @@ import time
 
 import httpx
 
+from .config import API_BASE
+
 DEFAULT_MODEL = os.getenv("TARES_AGENT_MODEL", "claude-sonnet-4-6")
 _SELF = f"http://127.0.0.1:{os.getenv('TARES_PORT', '8787')}"
 MAX_ROUNDS = 10
@@ -291,7 +293,7 @@ def _sse(obj: dict) -> str:
     return f"data: {json.dumps(obj)}\n\n"
 
 
-async def run_agent(api_key: str, messages: list,
+async def run_agent(anthropic_headers: dict, messages: list,
                     model: str | None = None, self_headers: dict | None = None,
                     on_usage=None):
     """Async generator of SSE lines: the agent loop, streaming assistant text and tool activity.
@@ -306,7 +308,7 @@ async def run_agent(api_key: str, messages: list,
                                                "(pip install tares[agent])"})
         return
 
-    client = anthropic.AsyncAnthropic(api_key=api_key)
+    client = anthropic.AsyncAnthropic(base_url=API_BASE, default_headers=anthropic_headers)
     convo = list(messages)
     headers = self_headers or {}
     used_model = model or DEFAULT_MODEL

--- a/tares/builtin_agents.py
+++ b/tares/builtin_agents.py
@@ -28,7 +28,7 @@ import uuid
 
 import httpx
 
-from .config import FINDINGS_SOURCE, agent_url
+from .config import FINDINGS_SOURCE, API_BASE, agent_url
 from .envelope import now_utc
 from .pricing import cost_usd
 from .slack import deep_link as _slack_deep_link
@@ -40,8 +40,6 @@ MODEL = os.getenv("TARES_AGENT_MODEL", "claude-sonnet-4-6")
 # instance default moves every agent that never chose one.
 AGENT_MODELS = list(dict.fromkeys(
     [MODEL, "claude-opus-5", "claude-sonnet-5", "claude-haiku-4-5-20251001"]))
-# Overridable so the end-to-end test can point at a stub instead of the real API.
-API_BASE = os.getenv("TARES_ANTHROPIC_BASE", "https://api.anthropic.com").rstrip("/")
 # Model-call rounds per run. The default is sized for read timeline + a query or two + a finding;
 # an agent that also reaches external MCP servers (a diff, a file, a write) needs more, so its
 # default is higher. Either can be overridden per agent (`max_rounds`, 1..24). One extra tools-off
@@ -144,17 +142,29 @@ def prompt_hash(prompt: str) -> str:
     return hashlib.sha256(prompt.encode("utf-8")).hexdigest()[:12]
 
 
-def resolve_key(store) -> tuple[str, str]:
-    """(key, where-it-came-from). The console-stored key wins over the env `ANTHROPIC_API_KEY`:
+def resolve_anthropic_headers(store) -> tuple[dict[str, str], str]:
+    """(header, where-it-came-from). The console-stored key wins over the env `ANTHROPIC_API_KEY`:
     the user's own key takes over from whatever the deployment shipped the moment they save one.
     That order is load-bearing for hosted trials — an operator-provided key in the env must yield
     to the customer's key instantly, so their spend lands on their key, not the trial's. Deleting
     the stored key falls back to the env key (if the deployment still carries one)."""
     stored = (store.get_setting("anthropic_key") or "").strip()
+    auth_token = os.getenv("ANTHROPIC_AUTH_TOKEN", "").strip()
+    api_key = os.getenv("ANTHROPIC_API_KEY", "").strip()
+    headers = {"anthropic-version": "2023-06-01",}
     if stored:
-        return stored, "console"
-    val = os.getenv("ANTHROPIC_API_KEY", "").strip()
-    return (val, "env:ANTHROPIC_API_KEY") if val else ("", "")
+        headers["x-api-key"] = stored
+        key_origin = "console"
+    elif auth_token:
+        headers["Authorization"] = f"Bearer {auth_token}"
+        key_origin = "env:ANTHROPIC_AUTH_TOKEN"
+    elif api_key:
+        headers["x-api-key"] = api_key
+        key_origin = "env:ANTHROPIC_API_KEY"
+    else:
+        return {}, ""
+
+    return headers, key_origin
 
 
 class AgentRunner:
@@ -324,8 +334,8 @@ class AgentRunner:
                    run_id: str, dispatch_id: str | None = None) -> tuple[str, str | None]:
         started_at = now_utc()
         t0 = time.monotonic()
-        api_key, key_origin = resolve_key(self.store)
-        if not api_key:
+        headers, key_origin = resolve_anthropic_headers(self.store)
+        if not headers:
             msg = "no Anthropic key: set ANTHROPIC_API_KEY before `tares up`, or add a key under Settings"
             self.store.finish_agent_run(run_id, "failed", error=msg)
             return "failed", msg
@@ -351,7 +361,7 @@ class AgentRunner:
                  "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0}
         try:
             finding, rounds, tool_calls, external_used, exhausted, partial = await self._loop(
-                agent, trigger_name, key, payload, api_key, usage)
+                agent, trigger_name, key, payload, headers, usage)
         finally:
             if usage["calls"]:
                 cost = cost_usd(model, usage["input_tokens"], usage["output_tokens"],
@@ -403,7 +413,7 @@ class AgentRunner:
 
     # ── the bounded model loop ────────────────────────────────────────────────
     async def _loop(self, agent: dict, trigger_name: str, key: str, payload: str,
-                    api_key: str, usage: dict) -> tuple[str, int, int, list[str], bool, str]:
+                    headers: dict, usage: dict) -> tuple[str, int, int, list[str], bool, str]:
         # External tools: the agent's selected MCP servers, connected for the duration of this
         # run. A server that fails to connect is skipped (recorded below) — losing a tool server
         # must not lose the run.
@@ -414,11 +424,11 @@ class AgentRunner:
         async with RemoteToolbox(servers) as toolbox:
             for failure in toolbox.failures:
                 print(f"[agent {agent['name']}] mcp connect failed; {failure}")
-            return await self._loop_with(agent, trigger_name, key, payload, api_key, toolbox,
+            return await self._loop_with(agent, trigger_name, key, payload, headers, toolbox,
                                          usage)
 
     async def _loop_with(self, agent: dict, trigger_name: str, key: str, payload: str,
-                         api_key: str, toolbox,
+                         headers: dict, toolbox,
                          usage: dict) -> tuple[str, int, int, list[str], bool, str]:
         """Returns (finding, rounds, tool_calls, external_tools_used, exhausted, partial_text)."""
         tools = TOOL_DEFS + toolbox.tool_defs
@@ -452,7 +462,7 @@ class AgentRunner:
                     body["tool_choice"] = {"type": "none"}
                 r = await cx.post(
                     f"{API_BASE}/v1/messages",
-                    headers={"x-api-key": api_key, "anthropic-version": "2023-06-01"},
+                    headers=headers,
                     json=body)
                 if r.status_code >= 400:
                     raise RuntimeError(f"anthropic {r.status_code}: {r.text[:300]}")

--- a/tares/config.py
+++ b/tares/config.py
@@ -5,6 +5,9 @@ Declares the sources (what to ingest and how), the views (named query shapes), a
 """
 from __future__ import annotations
 
+import os
+
+
 def reject_legacy_db(db_path: str) -> None:
     """Refuse to start if the database we are about to create sits next to a pre-1.0 one.
 
@@ -742,6 +745,11 @@ def validate_trigger_dict(t: dict, view_names: set) -> None:
 # The built-in source findings are written to. Named here (not in builtin_agents.py) because the
 # loop guard below is a catalog-validation concern and config must not import the runtime.
 FINDINGS_SOURCE = "findings"
+# Overridable so the end-to-end test can point at a stub instead of the real API.
+API_BASE = os.getenv(
+    "ANTHROPIC_BASE_URL",
+    os.getenv("TARES_ANTHROPIC_BASE", "https://api.anthropic.com"),
+).rstrip("/")
 
 _AGENT_NAME_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 MAX_PROMPT_CHARS = 8000

--- a/tares/daemon.py
+++ b/tares/daemon.py
@@ -27,7 +27,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse, PlainTextResponse, StreamingResponse
 from pydantic import BaseModel, model_validator
 
-from .config import (SLACK_URL_PREFIX, CatalogError, agent_url, export_db_to_yaml,
+from .config import (SLACK_URL_PREFIX, API_BASE, CatalogError, agent_url, export_db_to_yaml,
                      validate_mcp_server_dict,
                      import_yaml_to_db, slack_channel_from_url, slack_url,
                      validate_agent_dict, validate_slack_channel, validate_source_dict,
@@ -41,7 +41,7 @@ from .builtin_agents import (AGENT_MODELS, MODEL as AGENT_DEFAULT_MODEL,
                              MAX_ROUNDS_LIMIT as AGENT_MAX_ROUNDS_LIMIT,
                              MAX_ROUNDS_WITH_MCP as AGENT_MAX_ROUNDS_WITH_MCP,
                              PRESETS as AGENT_PRESETS, AgentRunner, effective_max_rounds,
-                             resolve_key as resolve_anthropic_key)
+                             resolve_anthropic_headers)
 from .runtime import Runtime
 from . import slack as slack_mod
 from . import slack_verify
@@ -74,7 +74,7 @@ LOGIN_URL = os.getenv("TARES_LOGIN_URL", "").strip()
 # self-host: no link. Public, non-secret, surfaced on /health next to login_url.
 WORKSPACE_URL = os.getenv("TARES_WORKSPACE_URL", "").strip()
 # The Anthropic key for the in-app Ask agent (and Tares agents) is resolved at request time via
-# resolve_anthropic_key(store): the console-stored key, else env ANTHROPIC_API_KEY.
+# resolve_anthropic_headers(store): the console-stored key, else env ANTHROPIC_API_KEY.
 # Never returned by any API — capabilities exposes only a boolean.
 # The Slack bot token behind the slack:// dispatch sink keeps the OPPOSITE order via
 # resolve_slack_token(store): env TARES_SLACK_BOT_TOKEN wins over the console-stored value
@@ -963,13 +963,15 @@ def make_app() -> FastAPI:
             ver = _pkg_version("tares")   # the installed release (release.sh bumps pyproject.toml)
         except Exception:
             ver = None
+        url_configured = API_BASE != "https://api.anthropic.com"
         return {
             "version": ver,
             "discover_docker": shutil.which("docker") is not None or os.path.exists("/var/run/docker.sock"),
             # the Ask assistant runs on the same resolved key as Tares agents (env ANTHROPIC_API_KEY
             # or the console-stored key) — so once a key is set anywhere, the Ask chat stops
             # prompting for a browser-pasted one.
-            "agent_key_configured": bool(resolve_anthropic_key(store)[0]),
+            "agent_key_configured": bool(resolve_anthropic_headers(store)[0]),
+            "url_configured": url_configured,
             # gates the "subscribe a Slack channel" affordance on a trigger — offering it with no
             # bot token configured only leads to a 400.
             "slack_configured": bool(resolve_slack_token(store)[0]),
@@ -1270,14 +1272,14 @@ def make_app() -> FastAPI:
         # `X-Anthropic-Key` header override, which the console filled from localStorage — so a key
         # added on the Ask page made Ask work while Slack and trigger-woken agents still reported
         # none configured, having no browser to read it from (NF-125).
-        key, key_origin = resolve_anthropic_key(store)
-        if not key:
+        headers, key_origin = resolve_anthropic_headers(store)
+        if not headers:
             _err(ValueError("add your Anthropic API key to use the assistant"), 400)
         body = await request.json()
         # the daemon's own token, so the agent's tool self-calls clear the auth middleware
         self_headers = {"Authorization": f"Bearer {AUTH_TOKEN}"} if AUTH_TOKEN else {}
         return StreamingResponse(
-            run_agent(key, body.get("messages") or [],
+            run_agent(headers, body.get("messages") or [],
                       model=body.get("model"), self_headers=self_headers,
                       on_usage=lambda m, u: _record_ask_usage(m, u, key_source=key_origin)),
             media_type="text/event-stream")
@@ -1647,7 +1649,7 @@ def make_app() -> FastAPI:
         """Tares agent definitions plus the state the UI needs to explain why one isn't running:
         no key configured is the common case on a fresh install and looks identical to "disabled"
         without this."""
-        key, origin = resolve_anthropic_key(store)
+        key, origin = resolve_anthropic_headers(store)
         stats = store.agent_stats()
         zero = {"runs": 0, "ok": 0, "finished": 0, "avg_duration_ms": None,
                 "cost_usd": None, "input_tokens": 0, "output_tokens": 0, "uncosted_runs": 0}
@@ -1736,7 +1738,7 @@ def make_app() -> FastAPI:
         agent = store.get_catalog_agent(name)
         if agent is None:
             _err(KeyError(f"unknown agent {name!r}"), 404)
-        key, _ = resolve_anthropic_key(store)
+        key, _ = resolve_anthropic_headers(store)
         if not key:
             _err(ValueError("no Anthropic key configured; set ANTHROPIC_API_KEY or add one "
                             "under Settings before enabling an agent"))
@@ -1789,7 +1791,7 @@ def make_app() -> FastAPI:
         """Never returns the key — only whether one is resolvable and where it came from. A key
         saved here takes over from the deployment's env key; `env_overrides` is kept for API
         compatibility and can now only be true when no key is stored."""
-        key, origin = resolve_anthropic_key(store)
+        key, origin = resolve_anthropic_headers(store)
         return {"configured": bool(key), "source": origin,
                 "stored": bool(store.get_setting("anthropic_key")),
                 "env_overrides": origin.startswith("env:")}
@@ -1800,7 +1802,7 @@ def make_app() -> FastAPI:
         if not key:
             _err(ValueError("key is required (use DELETE to remove the stored key)"))
         store.set_setting("anthropic_key", key)
-        _, origin = resolve_anthropic_key(store)
+        _, origin = resolve_anthropic_headers(store)
         return {"ok": True, "source": origin}
 
     @app.delete("/api/settings/anthropic-key")
@@ -1808,7 +1810,7 @@ def make_app() -> FastAPI:
         """Removing the stored key falls back to the deployment's env key when one exists — on a
         hosted trial cell that is the trial key, until its operator removes it too."""
         store.set_setting("anthropic_key", None)
-        key, origin = resolve_anthropic_key(store)
+        key, origin = resolve_anthropic_headers(store)
         return {"ok": True, "configured": bool(key), "source": origin}
 
     # ── the Slack bot token: same contract as the Anthropic key ──────────────
@@ -1925,11 +1927,11 @@ def make_app() -> FastAPI:
         from .agent import run_agent
         text, error = "", None
         try:
-            key, key_origin = resolve_anthropic_key(store)
+            headers, key_origin = resolve_anthropic_headers(store)
             self_headers = {"Authorization": f"Bearer {AUTH_TOKEN}"} if AUTH_TOKEN else {}
             async def _run():
                 nonlocal text, error
-                async for chunk in run_agent(key, [{"role": "user", "content": question}],
+                async for chunk in run_agent(headers, [{"role": "user", "content": question}],
                                              self_headers=self_headers,
                                              on_usage=lambda m, u: _record_ask_usage(
                                                  m, u, key_source=key_origin)):
@@ -2003,7 +2005,7 @@ def make_app() -> FastAPI:
             return slack_mod.build_error(
                 ":warning: that request carried no response_url; Tares has nowhere to reply",
                 thread_ts)
-        if not resolve_anthropic_key(store)[0]:
+        if not resolve_anthropic_headers(store)[0]:
             return slack_mod.build_error(
                 ":warning: no Anthropic API key is configured on this Tares instance; set "
                 "`ANTHROPIC_API_KEY` or add one under Settings in the console", thread_ts)

--- a/tares/daemon.py
+++ b/tares/daemon.py
@@ -75,7 +75,8 @@ LOGIN_URL = os.getenv("TARES_LOGIN_URL", "").strip()
 # self-host: no link. Public, non-secret, surfaced on /health next to login_url.
 WORKSPACE_URL = os.getenv("TARES_WORKSPACE_URL", "").strip()
 # The Anthropic key for the in-app Ask agent (and Tares agents) is resolved at request time via
-# resolve_anthropic_headers(store): the console-stored key, else env ANTHROPIC_API_KEY.
+# resolve_anthropic_headers(store): Resolve headers from the console-stored key,
+# then ANTHROPIC_AUTH_TOKEN, then ANTHROPIC_API_KEY.
 # Never returned by any API — capabilities exposes only a boolean.
 # The Slack bot token behind the slack:// dispatch sink keeps the OPPOSITE order via
 # resolve_slack_token(store): env TARES_SLACK_BOT_TOKEN wins over the console-stored value
@@ -1702,7 +1703,7 @@ def make_app() -> FastAPI:
         """Tares agent definitions plus the state the UI needs to explain why one isn't running:
         no key configured is the common case on a fresh install and looks identical to "disabled"
         without this."""
-        key, origin = resolve_anthropic_headers(store)
+        headers, origin = resolve_anthropic_headers(store)
         stats = store.agent_stats()
         zero = {"runs": 0, "ok": 0, "finished": 0, "avg_duration_ms": None,
                 "cost_usd": None, "input_tokens": 0, "output_tokens": 0, "uncosted_runs": 0}
@@ -1723,7 +1724,7 @@ def make_app() -> FastAPI:
                          "enabled": _agent_enabled(a["name"]), "updated_at": a.get("updated_at"),
                          "owned_by": a.get("owned_by"), "customized": bool(a.get("customized")),
                          "last_run": runs[0] if runs else None})
-        return {"agents": rows, "key_configured": bool(key), "key_source": origin,
+        return {"agents": rows, "key_configured": bool(headers), "key_source": origin,
                 "models": AGENT_MODELS, "default_model": AGENT_DEFAULT_MODEL,
                 "default_max_rounds": AGENT_MAX_ROUNDS,
                 "default_max_rounds_with_mcp": AGENT_MAX_ROUNDS_WITH_MCP,
@@ -1791,8 +1792,8 @@ def make_app() -> FastAPI:
         agent = store.get_catalog_agent(name)
         if agent is None:
             _err(KeyError(f"unknown agent {name!r}"), 404)
-        key, _ = resolve_anthropic_headers(store)
-        if not key:
+        headers, _ = resolve_anthropic_headers(store)
+        if not headers:
             _err(ValueError("no Anthropic key configured; set ANTHROPIC_API_KEY or add one "
                             "under Settings before enabling an agent"))
         # enable = subscribe to the trigger (the same wiring an external agent has). Idempotent.
@@ -1851,8 +1852,8 @@ def make_app() -> FastAPI:
         """Never returns the key — only whether one is resolvable and where it came from. A key
         saved here takes over from the deployment's env key; `env_overrides` is kept for API
         compatibility and can now only be true when no key is stored."""
-        key, origin = resolve_anthropic_headers(store)
-        return {"configured": bool(key), "source": origin,
+        headers, origin = resolve_anthropic_headers(store)
+        return {"configured": bool(headers), "source": origin,
                 "stored": bool(store.get_setting("anthropic_key")),
                 "env_overrides": origin.startswith("env:")}
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -14,7 +14,12 @@ import httpx
 P = F = 0
 def ck(l, c, d=""):
     global P, F; P += 1 if c else 0; F += 0 if c else 1
-    print(("  ok   " if c else "  FAIL ") + l + ("" if c else f"  {d}"))
+    print(("  ok   " if c else "  FAIL ") + l + (f"  {d}"))
+
+def start_daemon(env):
+    proc = subprocess.Popen([sys.executable, "-c", "from tares.cli import run_daemon; run_daemon()"],
+                            env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    return proc
 
 SEED = "/tmp/agents_catalog.yaml"
 with open(SEED, "w") as fh:
@@ -87,13 +92,23 @@ async def main():
     threading.Thread(target=stub.serve_forever, daemon=True).start()
 
     env = {**os.environ, "TARES_DB": DB, "TARES_CATALOG": SEED, "TARES_PORT": PORT,
-           "TARES_OTLP_GRPC_PORT": "off", "ANTHROPIC_API_KEY": "sk-test",
+           "TARES_OTLP_GRPC_PORT": "off", "ANTHROPIC_API_KEY": "sk-test","ANTHROPIC_AUTH_TOKEN": "test_token",
            "TARES_ANTHROPIC_BASE": f"http://127.0.0.1:{STUB_PORT}",
            "TARES_TRIGGER_DEBOUNCE_SECONDS": "0"}
-    proc = subprocess.Popen([sys.executable, "-c", "from tares.cli import run_daemon; run_daemon()"],
-                            env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    proc = start_daemon(env)
     B = f"http://127.0.0.1:{PORT}"
     try:
+        if not await _wait(f"{B}/health"):
+            ck("daemon up", False); return
+        async with httpx.AsyncClient(timeout=20) as cx:
+            # ── the token and key: env-provided, token WINS over the key ────────────────────────
+            k = (await cx.get(f"{B}/api/settings/anthropic-key")).json()
+            ck("key reported configured from env", k["configured"] and k["source"].startswith("env:"), str(k))
+        proc.terminate()
+        proc.wait(timeout=5)
+        env.pop("ANTHROPIC_AUTH_TOKEN", None)
+        proc = start_daemon(env)
+
         if not await _wait(f"{B}/health"):
             ck("daemon up", False); return
         async with httpx.AsyncClient(timeout=20) as cx:
@@ -101,6 +116,7 @@ async def main():
             k = (await cx.get(f"{B}/api/settings/anthropic-key")).json()
             ck("key reported configured from env", k["configured"] and k["source"].startswith("env:"), str(k))
             ck("key value is never returned", "sk-test" not in json.dumps(k), str(k))
+            input()
 
             # ── precedence: a stored key WINS over the env key (trial cells depend on it) ──
             r = await cx.put(f"{B}/api/settings/anthropic-key", json={"key": "sk-user-own"})
@@ -273,8 +289,7 @@ async def main():
         ck("orphan counts toward the cap while it is running", st.agent_runs_today("ghost") == 1)
         st.con.close()
 
-        proc = subprocess.Popen([sys.executable, "-c", "from tares.cli import run_daemon; run_daemon()"],
-                                env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        proc = start_daemon(env)
         try:
             if not await _wait(f"{B}/health"):
                 ck("daemon back up", False)

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -14,7 +14,7 @@ import httpx
 P = F = 0
 def ck(l, c, d=""):
     global P, F; P += 1 if c else 0; F += 0 if c else 1
-    print(("  ok   " if c else "  FAIL ") + l + (f"  {d}"))
+    print(("  ok   " if c else "  FAIL ") + l + ("" if c else f"  {d}"))
 
 def start_daemon(env):
     proc = subprocess.Popen([sys.executable, "-c", "from tares.cli import run_daemon; run_daemon()"],
@@ -103,7 +103,7 @@ async def main():
         async with httpx.AsyncClient(timeout=20) as cx:
             # ── the token and key: env-provided, token WINS over the key ────────────────────────
             k = (await cx.get(f"{B}/api/settings/anthropic-key")).json()
-            ck("key reported configured from env", k["configured"] and k["source"].startswith("env:"), str(k))
+            ck("key reported configured from env", k["configured"] and k["source"].startswith("env:ANTHROPIC_AUTH_TOKEN"), str(k))
         proc.terminate()
         proc.wait(timeout=5)
         env.pop("ANTHROPIC_AUTH_TOKEN", None)
@@ -114,9 +114,8 @@ async def main():
         async with httpx.AsyncClient(timeout=20) as cx:
             # ── the key: env-provided, never returned ────────────────────────
             k = (await cx.get(f"{B}/api/settings/anthropic-key")).json()
-            ck("key reported configured from env", k["configured"] and k["source"].startswith("env:"), str(k))
+            ck("key reported configured from env", k["configured"] and k["source"].startswith("env:ANTHROPIC_API_KEY"), str(k))
             ck("key value is never returned", "sk-test" not in json.dumps(k), str(k))
-            input()
 
             # ── precedence: a stored key WINS over the env key (trial cells depend on it) ──
             r = await cx.put(f"{B}/api/settings/anthropic-key", json={"key": "sk-user-own"})

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -100,7 +100,7 @@ export const api = {
   connectors: () => request<Record<string, ConnectorSpec>>("/api/connectors"),
   capabilities: () =>
     request<{ version?: string | null; discover_docker: boolean; agent_key_configured?: boolean;
-              slack_configured?: boolean }>("/api/capabilities"),
+              url_configured: boolean; slack_configured?: boolean }>("/api/capabilities"),
   keys: () => request<{ keys: ApiKey[]; enforced: boolean; scopes: string[] }>("/api/keys"),
   createKey: (name: string, scopes: string[]) =>
     request<{ id: string; name: string; scopes: string[]; secret: string }>(

--- a/ui/src/components/AskChat.tsx
+++ b/ui/src/components/AskChat.tsx
@@ -92,7 +92,8 @@ const scrollToEnd = () => {
 };
 
 export default function AskChat({ history = false }: { history?: boolean }) {
-  const [ready, setReady] = useState<boolean>();      // is a key configured on the server?
+  const [ready, setKeyReady] = useState<boolean>();      // is a key configured on the server?
+  const [urlReady, setUrlReady] = useState<boolean>();      // is an url configured on the server?
   const [msgs, setMsgs] = useState<Msg[]>([]);
   const [input, setInput] = useState("");
   const [busy, setBusy] = useState(false);
@@ -110,7 +111,15 @@ export default function AskChat({ history = false }: { history?: boolean }) {
   const taRef = useRef<HTMLTextAreaElement>(null);
 
   const refreshKey = () => api.capabilities()
-    .then((c) => setReady(!!c.agent_key_configured)).catch(() => setReady(false));
+  .then((c) => {
+    setKeyReady(!!c.agent_key_configured);
+    setUrlReady(c.url_configured);
+  })
+  .catch(() => {
+    setKeyReady(false);
+    setUrlReady(false);
+  });
+
   useEffect(() => { refreshKey(); }, []);
 
   // ── server-side chat history ──────────────────────────────────────────────
@@ -221,7 +230,7 @@ export default function AskChat({ history = false }: { history?: boolean }) {
   }, [msgs]);
 
   if (ready === undefined) return <div className="dim">loading…</div>;
-  if (!ready) return <KeySetup onSaved={refreshKey} />;
+  if (!ready) return <KeySetup onSaved={refreshKey} urlConfigured={urlReady} />;
 
   const mutLast = (fn: (parts: Part[]) => Part[]) =>
     setMsgs((cur) => cur.map((m, i) => (i === cur.length - 1 ? { ...m, parts: fn(m.parts) } : m)));
@@ -477,7 +486,7 @@ const fmtMs = (ms: number) => (ms < 1000 ? `${ms}ms` : `${(ms / 1000).toFixed(1)
 /** The key is stored on the SERVER, under Settings — the same one Slack and trigger-woken agents
  *  resolve. It used to live in this browser's localStorage and ride along as a header, so a key
  *  added here made Ask work while Slack still reported no key configured (NF-125). */
-function KeySetup({ onSaved }: { onSaved: () => void }) {
+function KeySetup({ onSaved, urlConfigured }: { onSaved: () => void, urlConfigured: boolean | undefined }) {
   const [value, setValue] = useState("");
   const [err, setErr] = useState<string>();
   const [saving, setSaving] = useState(false);
@@ -491,13 +500,14 @@ function KeySetup({ onSaved }: { onSaved: () => void }) {
 
   return (
     <div className="panel" style={{ maxWidth: 560 }}>
-      <h2 style={{ marginTop: 0 }}>Add your Anthropic API key</h2>
+      <h2 style={{ marginTop: 0 }}>Configure model access</h2>
       <p className="help" style={{ whiteSpace: "normal" }}>
         The assistant runs on your Tares daemon using this key. It is stored on this instance and
         used by everything that reasons over your data: this assistant, Tares agents woken by
         triggers, and <span className="mono">/tares ask</span> in Slack. You can change or remove it
-        later under <strong>Settings</strong>. Get one at{" "}
-        <a href="https://console.anthropic.com/settings/keys" target="_blank" rel="noreferrer">console.anthropic.com</a>.
+        later under <strong>Settings</strong>. {!urlConfigured && (<>Get one at{" "}
+        <a href="https://console.anthropic.com/settings/keys" target="_blank" rel="noreferrer">console.anthropic.com
+        </a>.</>)}
       </p>
       {err && <div className="alert error">{err}</div>}
       <form onSubmit={(e) => { e.preventDefault(); if (value.trim()) save(); }}>

--- a/ui/src/components/AskChat.tsx
+++ b/ui/src/components/AskChat.tsx
@@ -453,7 +453,7 @@ const fmtMs = (ms: number) => (ms < 1000 ? `${ms}ms` : `${(ms / 1000).toFixed(1)
 /** The key is stored on the SERVER, under Settings — the same one Slack and trigger-woken agents
  *  resolve. It used to live in this browser's localStorage and ride along as a header, so a key
  *  added here made Ask work while Slack still reported no key configured (NF-125). */
-export function KeySetup({ onSaved, urlConfigured }: { onSaved: () => void, urlConfigured: boolean | undefined }) {
+export function KeySetup({ onSaved, urlConfigured }: { onSaved: () => void, urlConfigured?: boolean | undefined }) {
   const [value, setValue] = useState("");
   const [err, setErr] = useState<string>();
   const [saving, setSaving] = useState(false);

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -141,7 +141,7 @@ export default function AgentDetail() {
                   <td>
                     {agent.enabled ? <span className="badge ok">enabled</span> : <span className="badge">disabled</span>}
                     {!data.key_configured
-                      ? <span className="help"> · no Anthropic key: set ANTHROPIC_API_KEY before <span className="mono">tares up</span>, or add a key under <Link to="/settings?tab=anthropic">Settings</Link></span>
+                      ? <span className="help"> · Model access is not configured: set ANTHROPIC_API_KEY before <span className="mono">tares up</span>, or add a key under <Link to="/settings?tab=anthropic">Settings</Link></span>
                       : <span className="help"> · key from <span className="mono">{data.key_source}</span></span>}
                   </td>
                 </tr>

--- a/ui/src/pages/AgentNew.tsx
+++ b/ui/src/pages/AgentNew.tsx
@@ -43,7 +43,7 @@ export default function AgentNew() {
       {err && <div className="alert error">{err}</div>}
       {!keyOk && (
         <div className="alert">
-          No Anthropic key configured; you can create the agent now, but it won't run until a key
+          Model access is not configured; you can create the agent now, but it won't run until a key
           is set under <Link to="/settings">Settings</Link>. It also starts disabled.
         </div>
       )}

--- a/ui/src/pages/Agents.tsx
+++ b/ui/src/pages/Agents.tsx
@@ -36,7 +36,7 @@ export default function Agents() {
 
       {data && !data.key_configured && (
         <div className="alert">
-          No Anthropic key: set ANTHROPIC_API_KEY before <span className="mono">tares up</span>, or add a
+          Model access is not configured: set ANTHROPIC_API_KEY before <span className="mono">tares up</span>, or add a
           key under <Link to="/settings?tab=anthropic">Settings</Link>. Agents can be created but not enabled until then.
         </div>
       )}

--- a/ui/src/pages/Security.tsx
+++ b/ui/src/pages/Security.tsx
@@ -309,12 +309,12 @@ function AnthropicKeyPanel() {
 
   return (
     <div className="panel">
-      <h2 style={{ marginTop: 0 }}>Anthropic key</h2>
+      <h2 style={{ marginTop: 0 }}>Model access</h2>
       <p className="help" style={{ marginTop: 0 }}>
         What <strong>Tares agents</strong> run on; their first look at an entity when a trigger
-        fires. Store one here (it takes precedence), or set <code>ANTHROPIC_API_KEY</code> in the
-        daemon's environment. It is never returned by the API and never included in a catalog
-        export.
+        fires. Store one here (it takes precedence),
+        or set <code>ANTHROPIC_API_KEY</code> or <code>ANTHROPIC_AUTH_TOKEN</code> in the daemon's environment.
+        It is never returned by the API and never included in a catalog export.
       </p>
 
       {err && <div className="alert error">{err}</div>}


### PR DESCRIPTION
Closes #47

Summary

Adds support for Anthropic-compatible LLM gateways in Tares agents.

Changes

- > Support ANTHROPIC_BASE_URL for routing Anthropic API requests through a custom gateway.
- > Keep TARES_ANTHROPIC_BASE as a backwards-compatible fallback.
- > Support ANTHROPIC_AUTH_TOKEN with Bearer authentication.
- > Keep ANTHROPIC_API_KEY and console-stored keys supported.
- > Preserve the existing credential precedence: console key → ANTHROPIC_AUTH_TOKEN → ANTHROPIC_API_KEY.
- > Pass the configured Anthropic base URL and authentication headers to the Anthropic client.
- > Expose the configured gateway URL through the daemon status/settings API without exposing credentials.
- > Update the UI terminology from "Anthropic key" to "Model access".
- > Show the Anthropic Console link only when no custom gateway is configured.
- > Display the configured gateway URL as read-only information when routing through a gateway.
- > Add tests for environment-based credentials