### PR TITLE
Tracing: instance and agent as span attributes on the root span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 Notable changes to Tares (formerly NavFlow). Format follows [Keep a Changelog](https://keepachangelog.com/);
 the project follows [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Changed
+- The root span of a traced run carries `tares.instance` and `tares.agent` as span attributes,
+  not only on the resource, so a backend's span view shows which instance sent it.
+
 ## [1.23.0] - 2026-09-03
 
 ### Added

--- a/tares/agent.py
+++ b/tares/agent.py
@@ -305,6 +305,7 @@ async def run_agent(api_key: str, messages: list,
     `tracer` (see tracing.py) makes the turn a trace: a root span, one LLM span per model call,
     one tool span per tool call. None means no tracing."""
     with _tracing.run_span(tracer, "ask", kind="CHAIN") as obs:
+        obs.set_attribute("tares.instance", _tracing.instance_name())
         async for line in _run_agent(api_key, messages, model, self_headers, on_usage, tracer,
                                      obs):
             yield line

--- a/tares/builtin_agents.py
+++ b/tares/builtin_agents.py
@@ -330,6 +330,10 @@ class AgentRunner:
         with _tracing.run_span(tracer, agent["name"], session=key, attributes={
                 "tares.run_id": run_id, "tares.dispatch_id": dispatch_id or "",
                 "tares.trigger": trigger_name, "tares.key": key}) as obs:
+            # The instance is on the resource (service.name) too, but a backend's span view
+            # may not show resource attributes; on the root span it is always in reach.
+            obs.set_attribute("tares.instance", _tracing.instance_name())
+            obs.set_attribute("tares.agent", agent["name"])
             status, error = await self._run_traced(agent, trigger_name, key, payload, run_id,
                                                    dispatch_id, tracer, obs)
             obs.set_attribute("tares.status", status)

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -348,6 +348,8 @@ async def part2():
                str([(kv.key, kv.value) for kv in root.attributes]) if root else "no root")
             ck("root output is the finding", root is not None and _attr(root, "output.value") == FINDING)
             ck("root session is the entity key", root is not None and _attr(root, "session.id") == "checkout")
+            ck("root carries the instance and agent as span attributes",
+               root is not None and _attr(root, "tares.instance") == "local" and _attr(root, "tares.agent") == "first-look")
             ck("root records cost + calls", root is not None and _attr(root, "tares.model_calls") == 2)
             llms = [sp for svc, sp in spans if _attr(sp, "openinference.span.kind") == "LLM"]
             ck("one LLM span per model call", len(llms) == 2, str(len(llms)))


### PR DESCRIPTION
The cell was only on the resource (service.name, tares.instance), which Rius's span view does not show, so a trace could not be traced back to its cell from the UI. The root span now carries tares.instance and tares.agent as span attributes too. Test extended, changelog under Unreleased.