### PR TITLE
AI-guided project builder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Backend — install + tests
         run: |
           pip install -e .
-          for t in test_labels test_normalize test_auth test_api_keys test_pricing test_agents test_catalog_sync test_cli test_status test_usage test_slack test_slack_verify test_slack_ask test_degraded test_loki test_projects test_rius_rca test_ai_sre_demo test_seed test_session_flow test_challenger_workflow test_plugin_challenger test_tracing; do
+          for t in test_labels test_normalize test_auth test_api_keys test_pricing test_agents test_catalog_sync test_cli test_status test_usage test_slack test_slack_verify test_slack_ask test_degraded test_loki test_projects test_rius_rca test_ai_sre_demo test_seed test_session_flow test_challenger_workflow test_plugin_challenger test_tracing test_agent_build test_builder_flow; do
             echo "== $t =="
             python "tests/$t.py"
           done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 Notable changes to Tares (formerly NavFlow). Format follows [Keep a Changelog](https://keepachangelog.com/);
 the project follows [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+- AI-guided project builder: "Build with Tares" on the new-project gallery. Describe what you
+  need; the assistant proposes sources from the installed connectors, then views, triggers and
+  an agent, one step at a time. Each proposal is the object's own form, prefilled, with the
+  fields only you can fill (tokens, URLs, the Slack channel) marked. Every Apply creates a real
+  object through its normal API and adds it to an ordinary project, so leaving part way keeps
+  what was created. `POST /api/agent/chat` takes `mode: "build"` and `step` for this; each step
+  gets only its own proposal tool.
+
 ## [1.23.0] - 2026-09-03
 
 ### Added

--- a/tares/agent.py
+++ b/tares/agent.py
@@ -191,7 +191,11 @@ BUILD_PROPOSAL_TOOLS = [
          "delivery": {"type": "object", "properties": {
              "kind": {"type": "string", "enum": ["slack", "webhook", "none"],
                       "description": "where the finding also goes; it always lands on the "
-                                     "entity's timeline"}},
+                                     "entity's timeline"},
+             "url": {"type": "string",
+                     "description": "webhook only: a URL the user typed in this conversation, "
+                                    "copied exactly. Never invent or guess one; omit it and the "
+                                    "user fills it in the form."}},
              "required": ["kind"]},
          "reasoning": {"type": "string"}},
          "required": ["name", "trigger", "prompt", "delivery", "reasoning"]}},
@@ -364,9 +368,13 @@ every key, filter and field in `source_fields` from real data, exactly as in the
 If no events have arrived yet, say so and ask the user to send some first, or propose from the \
 source's configured fields and say the thresholds are theirs to confirm. Ask about thresholds, \
 windows and which conditions matter before proposing them unless the user already said.
-· AGENT: one propose_agent card. The prompt is the substance; the user will pick the channel or \
-URL for the delivery kind you choose. Pick "slack" when the user mentioned Slack, "webhook" \
-when they named a system to post into, "none" otherwise.
+· AGENT: one propose_agent card. The prompt is the substance, and it is the user's: before you \
+write it, ask what the agent should do when the trigger fires (what to look at, what a useful \
+finding says, what it should recommend or decide, any thresholds or vocabulary they use), unless \
+the goal already says. Write the prompt from their answer, in their terms. For delivery, pick \
+"slack" when the user mentioned Slack, "webhook" when they named a system or URL to post into, \
+"none" otherwise; a webhook URL the user typed goes in `delivery.url` exactly as given, the Slack \
+channel is always picked by the user in the form.
 
 One card per object. The cards are the answer: never restate a card's contents as text or a \
 table. The page moves to the next step when the user is ready, so do not list next steps, do \

--- a/tares/agent.py
+++ b/tares/agent.py
@@ -204,8 +204,9 @@ _PROPOSAL_KIND = {"propose_labels": "labels", "propose_view": "view", "propose_t
 # proposal impossible: a views turn cannot emit a trigger card because the tool is not there.
 BUILD_STEPS = {
     "sources": ["propose_source"],
-    "views": ["propose_view", "propose_labels"],
-    "triggers": ["propose_trigger"],
+    # views and triggers are one step: a view exists to be watched, and the user thinks about
+    # "what should fire" as one question, not two pages
+    "watch": ["propose_view", "propose_labels", "propose_trigger"],
     "agent": ["propose_agent"],
 }
 
@@ -341,27 +342,37 @@ _SYSTEM_BUILD = """
 
 BUILD MODE. The user is assembling a new project from nothing, one step at a time, on a page that \
 turns each of your proposals into a prefilled form. The console tells you which step you are on; \
-you only have that step's proposal tool, so propose only what the step asks for.
+you only have that step's proposal tools, so propose only what the step asks for.
+
+ASK BEFORE YOU GUESS. A proposal is only as good as what the user told you. When the goal leaves \
+a real choice open (which service or API, which places or entities, which conditions matter and at \
+what threshold, which channel), ask up to three short, numbered questions in plain text and \
+propose NOTHING in that turn; the user answers in the box under your message and you propose on \
+the next turn. When the goal already says enough, propose directly. Never fill a gap with a \
+default the user did not choose and present it as theirs.
 
 · SOURCES: map the user's goal onto the INSTALLED connectors only. Call list_connectors first and \
 pick from what it returns; never name a connector it does not list. If nothing installed fits \
-part of the goal, say so in text rather than forcing a poor match. One propose_source card per \
-source. Put in `config` only the non-secret values the user actually told you (a URL they \
-pasted, a container or repo name); every secret and every value you would have to guess goes in \
-`needs`. Check list_sources first: if a source already covers what the goal needs, say so and \
+part of the goal, say so in one sentence rather than forcing a poor match. One propose_source \
+card per source. Put in `config` only the non-secret values the user actually told you (a URL \
+they pasted, a container or repo name); every secret and every value you would have to guess goes \
+in `needs`. Check list_sources first: if a source already covers what the goal needs, say so and \
 propose only what is missing.
-· VIEWS: the sources are connected now. Ground every key and filter in `source_fields` from real \
-data, exactly as in the rules above; propose labels first where a source needs them, then the view.
-· TRIGGERS: propose conditions on the views that exist, with a threshold, window and cooldown \
-the user can tune on the card.
+· WATCH: the sources are connected now. Propose the views and the triggers on them together: \
+labels first where a source needs them, then the view, then each trigger on that view. Ground \
+every key, filter and field in `source_fields` from real data, exactly as in the rules above. \
+If no events have arrived yet, say so and ask the user to send some first, or propose from the \
+source's configured fields and say the thresholds are theirs to confirm. Ask about thresholds, \
+windows and which conditions matter before proposing them unless the user already said.
 · AGENT: one propose_agent card. The prompt is the substance; the user will pick the channel or \
 URL for the delivery kind you choose. Pick "slack" when the user mentioned Slack, "webhook" \
 when they named a system to post into, "none" otherwise.
 
-One card per object. Keep the text short: the cards are the answer. The page moves to the next \
-step when the user is ready, so do not list next steps, do not ask the user to apply and come \
-back, and do not describe objects you cannot propose on this step; a push source's ingest URL and \
-payload example are shown by the console once the source exists, so do not write them."""
+One card per object. The cards are the answer: never restate a card's contents as text or a \
+table. The page moves to the next step when the user is ready, so do not list next steps, do \
+not ask the user to apply and come back, and do not describe objects you cannot propose on this \
+step. A push source's ingest URL and payload example are shown by the console once the source \
+exists, so do not write them."""
 
 
 def system_prompt(mode: str = "ask") -> str:

--- a/tares/agent.py
+++ b/tares/agent.py
@@ -358,7 +358,10 @@ the user can tune on the card.
 URL for the delivery kind you choose. Pick "slack" when the user mentioned Slack, "webhook" \
 when they named a system to post into, "none" otherwise.
 
-One card per object. Keep the text short: the cards are the answer."""
+One card per object. Keep the text short: the cards are the answer. The page moves to the next \
+step when the user is ready, so do not list next steps, do not ask the user to apply and come \
+back, and do not describe objects you cannot propose on this step; a push source's ingest URL and \
+payload example are shown by the console once the source exists, so do not write them."""
 
 
 def system_prompt(mode: str = "ask") -> str:

--- a/tares/agent.py
+++ b/tares/agent.py
@@ -147,7 +147,67 @@ PROPOSAL_TOOLS = [
          "reasoning": {"type": "string"}},
          "required": ["name", "view", "condition", "reasoning"]}},
 ]
-_PROPOSAL_NAMES = {t["name"] for t in PROPOSAL_TOOLS}
+_PROPOSAL_NAMES = {t["name"] for t in PROPOSAL_TOOLS}   # the Ask set; build mode adds more below
+
+
+# Build mode (the AI-guided project builder, TR-242): two more proposal cards that only make sense
+# while assembling a project from nothing. A source proposal is a prefilled connector form; the
+# model never sees or invents a secret, it names the fields the user has to type in `needs`. An
+# agent proposal is a prefilled agent form; the model picks a delivery KIND, the user picks the
+# channel or URL. Same contract as the others: nothing happens server-side until the user clicks.
+BUILD_PROPOSAL_TOOLS = [
+    {"name": "propose_source",
+     "description": "Propose ONE source to connect, as a prefilled connector form the user will "
+                    "complete and test. `connector` must be a name list_connectors returned and "
+                    "`config` may hold only its non-secret fields (URLs, names, containers) that "
+                    "you can infer from what the user said. Never invent a token, password, DSN "
+                    "or URL you were not told: list every such field in `needs` and leave it out "
+                    "of `config`. Say in `reasoning` why this connector fits the goal.",
+     "input_schema": {"type": "object", "properties": {
+         "name": {"type": "string", "description": "a short, lowercase source name"},
+         "connector": {"type": "string", "description": "a connector name from list_connectors"},
+         "poll": {"type": "string", "description": "poll interval, e.g. 30s; omit for the default"},
+         "config": {"type": "object",
+                    "description": "non-secret field values only, keyed by the connector's field "
+                                   "names; a field in `needs` must not appear here"},
+         "needs": {"type": "array", "items": {"type": "string"},
+                   "description": "connector field names the user must supply themselves: every "
+                                  "secret, plus anything you would otherwise have to guess"},
+         "reasoning": {"type": "string"}},
+         "required": ["name", "connector", "needs", "reasoning"]}},
+    {"name": "propose_agent",
+     "description": "Propose the Tares agent that runs when the trigger fires, as a prefilled "
+                    "agent form the user will review. `trigger` must be a trigger that exists or "
+                    "was applied in this build. The prompt is the substance: say what to look at "
+                    "in the correlated timeline and what a useful finding looks like. Pick only the "
+                    "delivery KIND; the user chooses the channel or URL.",
+     "input_schema": {"type": "object", "properties": {
+         "name": {"type": "string"},
+         "trigger": {"type": "string"},
+         "prompt": {"type": "string"},
+         "model": {"type": "string", "description": "omit to follow the instance default"},
+         "max_rounds": {"type": "integer"},
+         "budget_usd": {"type": "number"},
+         "delivery": {"type": "object", "properties": {
+             "kind": {"type": "string", "enum": ["slack", "webhook", "none"],
+                      "description": "where the finding also goes; it always lands on the "
+                                     "entity's timeline"}},
+             "required": ["kind"]},
+         "reasoning": {"type": "string"}},
+         "required": ["name", "trigger", "prompt", "delivery", "reasoning"]}},
+]
+_ALL_PROPOSALS = {t["name"]: t for t in PROPOSAL_TOOLS + BUILD_PROPOSAL_TOOLS}
+_PROPOSAL_KIND = {"propose_labels": "labels", "propose_view": "view", "propose_trigger": "trigger",
+                  "propose_source": "source", "propose_agent": "agent"}
+
+# Which proposal tools each build step gets. The step-scoped toolset is what makes an out-of-order
+# proposal impossible: a views turn cannot emit a trigger card because the tool is not there.
+BUILD_STEPS = {
+    "sources": ["propose_source"],
+    "views": ["propose_view", "propose_labels"],
+    "triggers": ["propose_trigger"],
+    "agent": ["propose_agent"],
+}
 
 
 def _canon_labels(specs) -> list:
@@ -277,15 +337,45 @@ permission to inspect."""
 # It is not duplicated here: a second copy is a copy that drifts.
 
 
-def system_prompt() -> str:
-    """One prompt. There used to be a second, "organize" one — but `tools_for` ignored the mode, so
-    the ONLY difference between the two surfaces was guidance the assistant needed in both. A user
-    asking Ask to add a label got an agent with no idea what makes a key good."""
-    return _SYSTEM_BASE
+_SYSTEM_BUILD = """
+
+BUILD MODE. The user is assembling a new project from nothing, one step at a time, on a page that \
+turns each of your proposals into a prefilled form. The console tells you which step you are on; \
+you only have that step's proposal tool, so propose only what the step asks for.
+
+· SOURCES: map the user's goal onto the INSTALLED connectors only. Call list_connectors first and \
+pick from what it returns; never name a connector it does not list. If nothing installed fits \
+part of the goal, say so in text rather than forcing a poor match. One propose_source card per \
+source. Put in `config` only the non-secret values the user actually told you (a URL they \
+pasted, a container or repo name); every secret and every value you would have to guess goes in \
+`needs`. Check list_sources first: if a source already covers what the goal needs, say so and \
+propose only what is missing.
+· VIEWS: the sources are connected now. Ground every key and filter in `source_fields` from real \
+data, exactly as in the rules above; propose labels first where a source needs them, then the view.
+· TRIGGERS: propose conditions on the views that exist, with a threshold, window and cooldown \
+the user can tune on the card.
+· AGENT: one propose_agent card. The prompt is the substance; the user will pick the channel or \
+URL for the delivery kind you choose. Pick "slack" when the user mentioned Slack, "webhook" \
+when they named a system to post into, "none" otherwise.
+
+One card per object. Keep the text short: the cards are the answer."""
 
 
-def tools_for() -> list:
-    # read tools + proposal cards — the agent never mutates the catalog directly
+def system_prompt(mode: str = "ask") -> str:
+    """One base prompt for every surface, with a build-mode section on top when the console is
+    assembling a project. There used to be a second, "organize" prompt too; `tools_for` ignored
+    the mode back then, so the two surfaces differed only in guidance the assistant needed in
+    both. Build mode is different: it changes the toolset for real (see tools_for)."""
+    return _SYSTEM_BASE + (_SYSTEM_BUILD if mode == "build" else "")
+
+
+def tools_for(mode: str = "ask", step: str | None = None) -> list:
+    """The read tools plus the proposal cards this turn may emit. Ask gets every catalog card;
+    build mode gets only the cards of the current step, so the schema itself makes an
+    out-of-order proposal impossible. The agent never mutates the catalog directly either way."""
+    if mode == "build":
+        names = BUILD_STEPS.get(step or "", [])
+        return TOOLS + [_ALL_PROPOSALS[n] for n in names]
     return TOOLS + PROPOSAL_TOOLS
 
 
@@ -295,7 +385,7 @@ def _sse(obj: dict) -> str:
 
 async def run_agent(api_key: str, messages: list,
                     model: str | None = None, self_headers: dict | None = None,
-                    on_usage=None, tracer=None):
+                    on_usage=None, tracer=None, mode: str = "ask", step: str | None = None):
     """Async generator of SSE lines: the agent loop, streaming assistant text and tool activity.
 
     `on_usage(model, usage_dict)` is called once per turn (after the loop, including on an error
@@ -303,15 +393,18 @@ async def run_agent(api_key: str, messages: list,
     meter Ask's Anthropic spend. Never called when no model call completed.
 
     `tracer` (see tracing.py) makes the turn a trace: a root span, one LLM span per model call,
-    one tool span per tool call. None means no tracing."""
+    one tool span per tool call. None means no tracing.
+
+    `mode` is "ask" or "build"; `step` names the build step (see BUILD_STEPS) and picks which
+    proposal cards the turn may emit."""
     with _tracing.run_span(tracer, "ask", kind="CHAIN") as obs:
         async for line in _run_agent(api_key, messages, model, self_headers, on_usage, tracer,
-                                     obs):
+                                     obs, mode, step):
             yield line
 
 
 async def _run_agent(api_key: str, messages: list, model, self_headers, on_usage, tracer,
-                     obs: _tracing.Observation):
+                     obs: _tracing.Observation, mode: str = "ask", step: str | None = None):
     try:
         import anthropic
     except ImportError:
@@ -333,7 +426,7 @@ async def _run_agent(api_key: str, messages: list, model, self_headers, on_usage
                                      {"max_tokens": 2048}) as gen:
                 async with client.messages.stream(
                     model=model or DEFAULT_MODEL, max_tokens=2048,
-                    system=system_prompt(), tools=tools_for(), messages=convo,
+                    system=system_prompt(mode), tools=tools_for(mode, step), messages=convo,
                 ) as stream:
                     async for event in stream:
                         if event.type == "content_block_delta" and event.delta.type == "text_delta":
@@ -358,7 +451,7 @@ async def _run_agent(api_key: str, messages: list, model, self_headers, on_usage
                 break
             results = []
             for tu in tool_uses:
-                if tu.name in _PROPOSAL_NAMES:
+                if tu.name in _PROPOSAL_KIND:
                     # no-op proposals are suppressed deterministically: re-proposing a source's
                     # exact current label set produces no card (re-runs must converge, not nag)
                     if tu.name == "propose_labels":
@@ -371,7 +464,7 @@ async def _run_agent(api_key: str, messages: list, model, self_headers, on_usage
                                                        "changes."})
                             continue
                     # a proposal is a card for the user, not a server-side action
-                    kind = {"propose_labels": "labels", "propose_view": "view", "propose_trigger": "trigger"}[tu.name]
+                    kind = _PROPOSAL_KIND[tu.name]
                     yield _sse({"type": "proposal", "kind": kind, "id": tu.id, "payload": tu.input})
                     results.append({"type": "tool_result", "tool_use_id": tu.id,
                                     "content": "proposal recorded; the user will review it as a "

--- a/tares/daemon.py
+++ b/tares/daemon.py
@@ -1278,7 +1278,7 @@ def make_app() -> FastAPI:
 
     @app.post("/api/agent/chat")
     async def agent_chat(request: Request):
-        from .agent import run_agent
+        from .agent import BUILD_STEPS, run_agent
         # ONE key for the whole instance: env, else the console-stored one. There used to be an
         # `X-Anthropic-Key` header override, which the console filled from localStorage — so a key
         # added on the Ask page made Ask work while Slack and trigger-woken agents still reported
@@ -1289,11 +1289,17 @@ def make_app() -> FastAPI:
         body = await request.json()
         # the daemon's own token, so the agent's tool self-calls clear the auth middleware
         self_headers = {"Authorization": f"Bearer {AUTH_TOKEN}"} if AUTH_TOKEN else {}
+        # mode "build" + step (sources|views|triggers|agent) is the AI-guided project builder:
+        # same loop, same endpoint, a step-scoped toolset (tares/agent.py, TR-242)
+        mode = "build" if body.get("mode") == "build" else "ask"
+        step = str(body.get("step") or "") or None
+        if mode == "build" and step not in BUILD_STEPS:
+            _err(ValueError(f"build step must be one of {', '.join(BUILD_STEPS)}"), 400)
         return StreamingResponse(
             run_agent(key, body.get("messages") or [],
                       model=body.get("model"), self_headers=self_headers,
                       on_usage=lambda m, u: _record_ask_usage(m, u, key_source=key_origin),
-                      tracer=tracing.tracer_for("ask")),
+                      tracer=tracing.tracer_for("ask"), mode=mode, step=step),
             media_type="text/event-stream")
 
     # ── MCP connections — external tool servers a Tares agent can opt into ─────

--- a/tests/test_agent_build.py
+++ b/tests/test_agent_build.py
@@ -69,9 +69,10 @@ ck("propose_source config is an object, poll optional",
 ag = by_name["propose_agent"]["input_schema"]
 ck("propose_agent requires name, trigger, prompt, delivery, reasoning",
    set(ag["required"]) == {"name", "trigger", "prompt", "delivery", "reasoning"}, str(ag["required"]))
-ck("propose_agent delivery is a kind from slack|webhook|none, nothing else",
+ck("propose_agent delivery is a kind from slack|webhook|none plus an optional typed URL",
    ag["properties"]["delivery"]["properties"]["kind"]["enum"] == ["slack", "webhook", "none"]
-   and set(ag["properties"]["delivery"]["properties"]) == {"kind"})
+   and set(ag["properties"]["delivery"]["properties"]) == {"kind", "url"}
+   and ag["properties"]["delivery"]["required"] == ["kind"])
 ck("every proposal tool requires reasoning",
    all("reasoning" in t["input_schema"]["required"]
        for t in agent.PROPOSAL_TOOLS + agent.BUILD_PROPOSAL_TOOLS))
@@ -86,7 +87,8 @@ ck("ask prompt has no build section", "BUILD MODE" not in base)
 ck("build prompt is the ask prompt plus the build section",
    build.startswith(base) and "BUILD MODE" in build)
 for marker in ("ASK BEFORE YOU GUESS", "INSTALLED connectors", "`needs`", "source_fields",
-               "One card per object", "channel or URL", "propose NOTHING in that turn"):
+               "One card per object", "propose NOTHING in that turn",
+               "ask what the agent should do", "delivery.url"):
     ck(f"build prompt says: {marker}", marker in build)
 
 

--- a/tests/test_agent_build.py
+++ b/tests/test_agent_build.py
@@ -45,8 +45,7 @@ ck("ask mode never offers the build-only cards",
    not names(agent.tools_for()) & {"propose_source", "propose_agent"})
 expected = {
     "sources": {"propose_source"},
-    "views": {"propose_view", "propose_labels"},
-    "triggers": {"propose_trigger"},
+    "watch": {"propose_view", "propose_labels", "propose_trigger"},
     "agent": {"propose_agent"},
 }
 for step, cards in expected.items():
@@ -55,7 +54,7 @@ for step, cards in expected.items():
 ck("an unknown build step gets no proposal tools at all",
    names(agent.tools_for("build", "nope")) == READ)
 ck("BUILD_STEPS lists the steps in flow order",
-   list(agent.BUILD_STEPS) == ["sources", "views", "triggers", "agent"])
+   list(agent.BUILD_STEPS) == ["sources", "watch", "agent"])
 
 print("== schemas ==")
 by_name = {t["name"]: t for t in agent.BUILD_PROPOSAL_TOOLS}
@@ -86,8 +85,8 @@ base, build = agent.system_prompt(), agent.system_prompt("build")
 ck("ask prompt has no build section", "BUILD MODE" not in base)
 ck("build prompt is the ask prompt plus the build section",
    build.startswith(base) and "BUILD MODE" in build)
-for marker in ("INSTALLED connectors", "`needs`", "source_fields", "One card per object",
-               "channel or URL"):
+for marker in ("ASK BEFORE YOU GUESS", "INSTALLED connectors", "`needs`", "source_fields",
+               "One card per object", "channel or URL", "propose NOTHING in that turn"):
     ck(f"build prompt says: {marker}", marker in build)
 
 

--- a/tests/test_agent_build.py
+++ b/tests/test_agent_build.py
@@ -1,0 +1,111 @@
+"""The AI-guided project builder's backend (TR-242, TR-246): build mode on the assist endpoint.
+
+No live LLM. Checks the step-scoped toolsets, the proposal schemas, the build system prompt and
+that POST /api/agent/chat accepts mode + step (and still refuses without a key).
+
+Run: .venv/bin/python tests/test_agent_build.py
+"""
+import asyncio
+import os
+
+os.environ["TARES_DB"] = "/tmp/agent_build_t.duckdb"
+os.environ["TARES_CATALOG"] = "/tmp/none_agent_build.yaml"
+os.environ.pop("TARES_ANTHROPIC_KEY", None)
+os.environ.pop("ANTHROPIC_API_KEY", None)
+for _p in ("/tmp/agent_build_t.duckdb", "/tmp/agent_build_t.duckdb.wal"):
+    if os.path.exists(_p):
+        os.remove(_p)
+
+import httpx
+from tares import agent
+
+P = F = 0
+
+
+def ck(label, cond, detail=""):
+    global P, F
+    P += 1 if cond else 0
+    F += 0 if cond else 1
+    print(("  ok   " if cond else "  FAIL ") + label + ("" if cond else f"  {detail}"))
+
+
+READ = {t["name"] for t in agent.TOOLS}
+ALL_PROPOSALS = {t["name"] for t in agent.PROPOSAL_TOOLS + agent.BUILD_PROPOSAL_TOOLS}
+
+
+def names(tools):
+    return {t["name"] for t in tools}
+
+
+print("== toolsets ==")
+ck("ask mode is the read tools plus the catalog cards",
+   names(agent.tools_for()) == READ | {"propose_labels", "propose_view", "propose_trigger"},
+   str(names(agent.tools_for())))
+ck("ask mode never offers the build-only cards",
+   not names(agent.tools_for()) & {"propose_source", "propose_agent"})
+expected = {
+    "sources": {"propose_source"},
+    "views": {"propose_view", "propose_labels"},
+    "triggers": {"propose_trigger"},
+    "agent": {"propose_agent"},
+}
+for step, cards in expected.items():
+    got = names(agent.tools_for("build", step))
+    ck(f"build/{step} = read tools + exactly {sorted(cards)}", got == READ | cards, str(got - READ))
+ck("an unknown build step gets no proposal tools at all",
+   names(agent.tools_for("build", "nope")) == READ)
+ck("BUILD_STEPS lists the steps in flow order",
+   list(agent.BUILD_STEPS) == ["sources", "views", "triggers", "agent"])
+
+print("== schemas ==")
+by_name = {t["name"]: t for t in agent.BUILD_PROPOSAL_TOOLS}
+src = by_name["propose_source"]["input_schema"]
+ck("propose_source requires name, connector, needs, reasoning",
+   set(src["required"]) == {"name", "connector", "needs", "reasoning"}, str(src["required"]))
+ck("propose_source needs is a list of field names",
+   src["properties"]["needs"]["type"] == "array"
+   and src["properties"]["needs"]["items"]["type"] == "string")
+ck("propose_source config is an object, poll optional",
+   src["properties"]["config"]["type"] == "object" and "poll" not in src["required"])
+ag = by_name["propose_agent"]["input_schema"]
+ck("propose_agent requires name, trigger, prompt, delivery, reasoning",
+   set(ag["required"]) == {"name", "trigger", "prompt", "delivery", "reasoning"}, str(ag["required"]))
+ck("propose_agent delivery is a kind from slack|webhook|none, nothing else",
+   ag["properties"]["delivery"]["properties"]["kind"]["enum"] == ["slack", "webhook", "none"]
+   and set(ag["properties"]["delivery"]["properties"]) == {"kind"})
+ck("every proposal tool requires reasoning",
+   all("reasoning" in t["input_schema"]["required"]
+       for t in agent.PROPOSAL_TOOLS + agent.BUILD_PROPOSAL_TOOLS))
+ck("every proposal tool maps to a card kind",
+   set(agent._PROPOSAL_KIND) == ALL_PROPOSALS, str(set(agent._PROPOSAL_KIND) ^ ALL_PROPOSALS))
+ck("card kinds are the object kinds the console knows",
+   set(agent._PROPOSAL_KIND.values()) == {"labels", "view", "trigger", "source", "agent"})
+
+print("== prompts ==")
+base, build = agent.system_prompt(), agent.system_prompt("build")
+ck("ask prompt has no build section", "BUILD MODE" not in base)
+ck("build prompt is the ask prompt plus the build section",
+   build.startswith(base) and "BUILD MODE" in build)
+for marker in ("INSTALLED connectors", "`needs`", "source_fields", "One card per object",
+               "channel or URL"):
+    ck(f"build prompt says: {marker}", marker in build)
+
+
+async def main():
+    from tares.daemon import make_app
+    app = make_app()
+    async with app.router.lifespan_context(app):
+        cx = httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://t")
+        print("== endpoint ==")
+        r = await cx.post("/api/agent/chat", json={
+            "messages": [{"role": "user", "content": "watch my logs"}],
+            "mode": "build", "step": "sources"})
+        ck("build turn without a key -> 400 (same gate as Ask)", r.status_code == 400, r.text)
+        r = await cx.post("/api/agent/chat", json={"messages": [{"role": "user", "content": "hi"}]})
+        ck("ask turn without a key -> 400", r.status_code == 400, r.text)
+        await cx.aclose()
+    print(f"\n{P} passed, {F} failed")
+    raise SystemExit(1 if F else 0)
+
+
+asyncio.run(main())

--- a/tests/test_builder_flow.py
+++ b/tests/test_builder_flow.py
@@ -1,0 +1,138 @@
+"""The AI-guided project builder's ownership flow (TR-244, TR-246), through the real endpoints.
+
+The builder creates nothing new on the engine: each Apply creates an ordinary object via its own
+API, then appends it to a `custom` project. This mirrors that sequence exactly: source, then the
+project owning it, then view / trigger / agent each created and appended; the agent is enabled
+through the same endpoint the console uses. Asserts ownership, that a name collision fails
+cleanly without touching the project, and that deleting the project releases the objects.
+
+Run: .venv/bin/python tests/test_builder_flow.py
+"""
+import asyncio
+import os
+
+DB = "/tmp/tares-builder-flow.duckdb"
+os.environ["TARES_DB"] = DB
+os.environ["TARES_CATALOG"] = "/tmp/tares-builder-flow.catalog.yaml"
+# enable checks that a key resolves; it never calls Anthropic
+os.environ["ANTHROPIC_API_KEY"] = "sk-ant-test-not-a-real-key"
+for _p in (DB, DB + ".wal", os.environ["TARES_CATALOG"]):
+    if os.path.exists(_p):
+        os.remove(_p)
+
+import httpx
+
+P = F = 0
+
+
+def ck(label, cond, detail=""):
+    global P, F
+    P += 1 if cond else 0
+    F += 0 if cond else 1
+    print(("  ok   " if cond else "  FAIL ") + label + ("" if cond else f"  {detail}"))
+
+
+SOURCE = {"name": "checkout_logs", "connector": "webhook", "poll": "5s",
+          "config": {"event_type": "log", "text_template": "{msg}",
+                     "labels": [{"name": "service", "field": "service", "primary": True}]}}
+VIEW = {"name": "checkout_timeline", "key_field": "service", "sources": ["checkout_logs"]}
+TRIGGER = {"name": "checkout_errors", "view": "checkout_timeline",
+           "condition": {"aggregate": "count", "predicate": "> 5", "window": "1m"},
+           "emit": {"kind": "error_spike", "context_window": "15m"}, "cooldown": "5m"}
+AGENT = {"name": "checkout_sre", "trigger": "checkout_errors",
+         "prompt": "Read the timeline and say what broke first.",
+         "webhook_url": "https://example.invalid/findings", "webhook_token": "t0k"}
+
+
+async def main():
+    from tares.daemon import make_app
+    app = make_app()
+    async with app.router.lifespan_context(app):
+        cx = httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://t")
+
+        print("== sources step: create the source, then the project that owns it ==")
+        r = await cx.post("/api/sources", json=SOURCE)
+        ck("source created", r.status_code == 201, r.text)
+        r = await cx.post("/api/projects", json={
+            "template": "custom", "name": "Checkout watch",
+            "objects": [{"kind": "source", "name": "checkout_logs"}]})
+        ck("custom project created around the source", r.status_code == 201, r.text)
+        proj = r.json()
+        uid = proj["id"]
+        objects = [{"kind": "source", "name": "checkout_logs"}]
+        src = next(s for s in (await cx.get("/api/sources")).json() if s["name"] == "checkout_logs")
+        ck("source owned by the project", src.get("owned_by") == uid, str(src.get("owned_by")))
+
+        print("== a name collision fails cleanly and leaves the project alone ==")
+        r = await cx.post("/api/sources", json=SOURCE)
+        ck("duplicate source name -> 409", r.status_code == 409, r.text)
+        after = (await cx.get(f"/api/projects/{uid}")).json()
+        ck("project unchanged: still one object, no error",
+           len(after["objects"]) == 1 and after["status"] == "active" and not after["last_error"],
+           str(after))
+
+        async def append(kind, name):
+            objects.append({"kind": kind, "name": name})
+            r = await cx.put(f"/api/projects/{uid}", json={"objects": objects})
+            ck(f"{kind} {name} appended to the project", r.status_code == 200
+               and f"{kind}:{name}" in r.json().get("report", {}).get("added", []), r.text)
+
+        print("== views step ==")
+        r = await cx.post("/api/views", json=VIEW)
+        ck("view created", r.status_code == 201, r.text)
+        await append("view", "checkout_timeline")
+
+        print("== triggers step ==")
+        r = await cx.post("/api/triggers", json=TRIGGER)
+        ck("trigger created", r.status_code == 201, r.text)
+        await append("trigger", "checkout_errors")
+
+        print("== agent step: create, enable, append ==")
+        r = await cx.post("/api/agents/builtin", json=AGENT)
+        ck("agent created (disabled)", r.status_code == 201 and r.json()["enabled"] is False, r.text)
+        r = await cx.post("/api/agents/builtin/checkout_sre/enable")
+        ck("agent enabled through the real endpoint", r.status_code == 200 and r.json()["enabled"], r.text)
+        await append("agent", "checkout_sre")
+
+        print("== everything is owned, the project page sees it all ==")
+        proj = (await cx.get(f"/api/projects/{uid}")).json()
+        kinds = sorted(o["kind"] for o in proj["objects"])
+        ck("project lists source, view, trigger, agent",
+           kinds == ["agent", "source", "trigger", "view"], str(kinds))
+        views = {v["name"]: v for v in (await cx.get("/api/views")).json()}
+        trig = {t["name"]: t for t in (await cx.get("/api/triggers")).json()}
+        ag = {a["name"]: a for a in (await cx.get("/api/agents/builtin")).json()["agents"]}
+        ck("view owned", views["checkout_timeline"].get("owned_by") == uid)
+        ck("trigger owned", trig["checkout_errors"].get("owned_by") == uid)
+        ck("agent owned and enabled", ag["checkout_sre"].get("owned_by") == uid
+           and ag["checkout_sre"]["enabled"] is True, str(ag["checkout_sre"]))
+        ck("the agent is subscribed to its trigger, not to a URL the builder made up",
+           any(s.get("trigger") == "checkout_errors" and "tares://agent/checkout_sre" in s.get("url", "")
+               for s in (await cx.get("/api/subscriptions")).json()))
+        r = await cx.get(f"/api/projects/{uid}/summary")
+        ck("summary renders (runs, triggers)", r.status_code == 200 and "triggers" in r.json(), r.text[:200])
+
+        print("== appending an object that does not exist fails cleanly ==")
+        r = await cx.put(f"/api/projects/{uid}", json={
+            "objects": objects + [{"kind": "view", "name": "ghost"}]})
+        ck("unknown object -> 400", r.status_code == 400, r.text)
+        proj = (await cx.get(f"/api/projects/{uid}")).json()
+        ck("project keeps its four objects", len(proj["objects"]) == 4, str(proj["objects"]))
+
+        print("== delete releases, never deletes ==")
+        r = await cx.delete(f"/api/projects/{uid}")
+        ck("project deleted with objects released", r.status_code == 200
+           and len(r.json().get("released", [])) == 4 and not r.json().get("deleted"), r.text)
+        names = {s["name"] for s in (await cx.get("/api/sources")).json()}
+        ck("source still exists", "checkout_logs" in names)
+        src = next(s for s in (await cx.get("/api/sources")).json() if s["name"] == "checkout_logs")
+        ck("source no longer owned", not src.get("owned_by"), str(src.get("owned_by")))
+        ag = {a["name"]: a for a in (await cx.get("/api/agents/builtin")).json()["agents"]}
+        ck("agent still exists and still enabled", "checkout_sre" in ag and ag["checkout_sre"]["enabled"])
+
+        await cx.aclose()
+    print(f"\n{P} passed, {F} failed")
+    raise SystemExit(1 if F else 0)
+
+
+asyncio.run(main())

--- a/ui/src/components/AgentForm.tsx
+++ b/ui/src/components/AgentForm.tsx
@@ -52,11 +52,13 @@ function OptionRow({ title, desc, on, disabled, disabledHint, onToggle, children
 // lands on the entity's timeline; these rows only deliver it elsewhere too. The write-back URL and
 // its bearer token render as one connected control (.hook-group): they are one credential pair,
 // not two settings.
-export default function AgentForm({ initial, presetTrigger, triggers, presets, models,
-                                    defaultModel, slackWorkspace, onSaved, onCancel,
-                                    defaultMaxRounds = 6, defaultMaxRoundsWithMcp = 12,
+export default function AgentForm({ initial, prefill, deliveryKind, presetTrigger, triggers,
+                                    presets, models, defaultModel, slackWorkspace, onSaved,
+                                    onCancel, defaultMaxRounds = 6, defaultMaxRoundsWithMcp = 12,
                                     maxRoundsLimit = 24 }: {
   initial?: BuiltinAgent;              // absent = create
+  prefill?: boolean;                   // initial is a proposal for a NEW agent: create, editable name
+  deliveryKind?: "slack" | "webhook" | "none";   // prefill: which delivery row starts open (and on)
   presetTrigger?: string;              // create: trigger preselected (came from a trigger page)
   triggers: string[];
   presets: AgentPreset[];
@@ -69,7 +71,7 @@ export default function AgentForm({ initial, presetTrigger, triggers, presets, m
   onSaved: (name: string) => void;
   onCancel: () => void;
 }) {
-  const isNew = !initial;
+  const isNew = !initial || !!prefill;
   const [name, setName] = useState(initial?.name ?? "");
   const [trigger, setTrigger] = useState(initial?.trigger ?? presetTrigger ?? "");
   const [prompt, setPrompt] = useState(initial?.prompt ?? "");
@@ -77,11 +79,11 @@ export default function AgentForm({ initial, presetTrigger, triggers, presets, m
 
   // Delivery options: each is a toggle plus its fields. Off at save time means off, even if the
   // fields still hold text.
-  const [channelOn, setChannelOn] = useState(!!initial?.slack_channel);
+  const [channelOn, setChannelOn] = useState(!!initial?.slack_channel || (deliveryKind === "slack" && slackWorkspace));
   const [channel, setChannel] = useState(initial?.slack_channel ?? "");
   const [hookOn, setHookOn] = useState(!!initial?.slack_configured);
   const [slack, setSlack] = useState("");
-  const [writebackOn, setWritebackOn] = useState(!!initial?.webhook_url);
+  const [writebackOn, setWritebackOn] = useState(!!initial?.webhook_url || deliveryKind === "webhook");
   const [webhookUrl, setWebhookUrl] = useState(initial?.webhook_url ?? "");
   const [webhookToken, setWebhookToken] = useState("");
   const [mcpSel, setMcpSel] = useState<string[]>(initial?.mcp_servers ?? []);

--- a/ui/src/components/AskChat.tsx
+++ b/ui/src/components/AskChat.tsx
@@ -2,10 +2,12 @@ import { memo, useEffect, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
-import { api, authHeader } from "../api";
+import { api } from "../api";
 import { TimeAgo } from "./bits";
 import { applyProposal, ProposalCard } from "./proposals";
 import type { DecisionMap, Proposal } from "./proposals";
+import { useAgentStream } from "./useAgentStream";
+import type { StreamEvent } from "./useAgentStream";
 
 type SessionMeta = { id: string; title: string; created_at: string; updated_at: string };
 
@@ -16,8 +18,11 @@ type SessionMeta = { id: string; title: string; created_at: string; updated_at: 
 // differed only by a system prompt, so the judgement it carried (what makes a good key, labels come
 // from real fields, watch for value variants) now applies to every proposal — see tares/agent.py.
 // The full-source sweep it ran is a starter prompt below.
+//
+// The wire itself (fetch, SSE parse, Stop) lives in useAgentStream, shared with the AI-guided
+// project builder; this component owns the transcript and how it renders.
 
-type ToolPart = {
+export type ToolPart = {
   type: "tool"; id: string; name: string; input: unknown;
   // filled in by the matching `tool_done` event
   ms?: number; ok?: boolean; preview?: string;
@@ -60,7 +65,7 @@ const textOf = (m: Msg, decisions?: DecisionMap) =>
       const st = decisions?.[p.proposal.id]?.status ?? "pending";
       const what = p.proposal.kind === "labels"
         ? `labels for source ${p.proposal.source}`
-        : p.proposal.kind === "view" ? `view ${p.proposal.name}` : `trigger ${p.proposal.name}`;
+        : `${p.proposal.kind} ${p.proposal.name}`;
       return `\n[proposal: ${what}; ${st}]\n`;
     }
     return "";
@@ -95,7 +100,7 @@ export default function AskChat({ history = false }: { history?: boolean }) {
   const [ready, setReady] = useState<boolean>();      // is a key configured on the server?
   const [msgs, setMsgs] = useState<Msg[]>([]);
   const [input, setInput] = useState("");
-  const [busy, setBusy] = useState(false);
+  const { send: stream, stop, streaming: busy } = useAgentStream();
   const [decisions, setDecisions] = useState<DecisionMap>({});
   // Follow the tail only while the reader is at the tail. The old code called scrollTo() on every
   // streamed chunk unconditionally, so scrolling up to re-read something was undone by the next
@@ -106,7 +111,6 @@ export default function AskChat({ history = false }: { history?: boolean }) {
   // jump button needs to re-render, so only it gets state, and only when the value truly changes.
   const stick = useRef(true);
   const [showJump, setShowJump] = useState(false);
-  const abortRef = useRef<AbortController | null>(null);
   const taRef = useRef<HTMLTextAreaElement>(null);
 
   const refreshKey = () => api.capabilities()
@@ -252,51 +256,14 @@ export default function AskChat({ history = false }: { history?: boolean }) {
     stick.current = true;
     const history: Msg[] = [...msgs, { role: "user", parts: [{ type: "text", text }] }];
     setMsgs([...history, { role: "assistant", parts: [] }]);
-    setBusy(true);
-    const ctl = new AbortController();
-    abortRef.current = ctl;
-    try {
-      const res = await fetch("/api/agent/chat", {
-        method: "POST",
-        signal: ctl.signal,
-        headers: { "content-type": "application/json", ...authHeader() },
-        body: JSON.stringify({ messages: history.map(wire) }),
-      });
-      if (!res.ok || !res.body) {
-        appendText(`⚠️ ${await res.text().catch(() => res.statusText)}`);
-        return;
-      }
-      const reader = res.body.getReader();
-      const dec = new TextDecoder();
-      let buf = "";
-      for (;;) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        buf += dec.decode(value, { stream: true });
-        let idx;
-        while ((idx = buf.indexOf("\n\n")) >= 0) {
-          const chunk = buf.slice(0, idx); buf = buf.slice(idx + 2);
-          if (!chunk.startsWith("data: ")) continue;
-          const e = JSON.parse(chunk.slice(6));
-          if (e.type === "text") appendText(e.text);
-          else if (e.type === "tool") addTool(e.id, e.name, e.input);
-          else if (e.type === "tool_done") finishTool(e.id, { ms: e.ms, ok: e.ok, preview: e.preview });
-          else if (e.type === "proposal") {
-            const proposal = { id: e.id, kind: e.kind, ...e.payload } as Proposal;
-            mutLast((parts) => [...parts, { type: "proposal", proposal }]);
-          }
-          else if (e.type === "error") appendText(`\n\n⚠️ ${e.detail}`);
-        }
-      }
-    } catch (err) {
-      // An aborted run is the user pressing Stop, not a failure to report.
-      if ((err as Error).name !== "AbortError") {
-        appendText(`\n\n⚠️ ${String((err as Error).message ?? err)}`);
-      }
-    } finally {
-      abortRef.current = null;
-      setBusy(false);
-    }
+    const onEvent = (e: StreamEvent) => {
+      if (e.type === "text") appendText(e.text);
+      else if (e.type === "tool") addTool(e.id, e.name, e.input);
+      else if (e.type === "tool_done") finishTool(e.id, { ms: e.ms, ok: e.ok, preview: e.preview });
+      else if (e.type === "proposal") mutLast((parts) => [...parts, { type: "proposal", proposal: e.proposal }]);
+      else if (e.type === "error") appendText(`\n\n⚠️ ${e.detail}`);
+    };
+    await stream(history.map(wire), onEvent);
   }
 
   const decide = (id: string, status: "applied" | "skipped" | "error", detail?: string) => {
@@ -371,7 +338,7 @@ export default function AskChat({ history = false }: { history?: boolean }) {
         {/* One button, two jobs — the prototype's call, and right: Send and Stop are never both
             available, so two buttons is one more thing to read mid-answer. */}
         {busy
-          ? <button type="button" className="danger" onClick={() => abortRef.current?.abort()}>Stop</button>
+          ? <button type="button" className="danger" onClick={stop}>Stop</button>
           : <button className="primary" disabled={!input.trim()}>Send</button>}
         {!history && msgs.length > 0 && !busy && (
           <button type="button" className="dim" title="start a new conversation"
@@ -438,7 +405,7 @@ const Turn = memo(function Turn({ msg, decisions, apply, decide, thinking }: {
  *  took, and its input/output behind a click. Borrowed from the chat prototype, and worth it —
  *  a fold reading "2 steps" told you nothing while it was happening, so a read that takes four
  *  seconds looked exactly like a hung one. */
-function ToolRun({ tools }: { tools: ToolPart[] }) {
+export function ToolRun({ tools }: { tools: ToolPart[] }) {
   return (
     <div className="rail">
       {tools.map((t) => <ToolNode key={t.id} tool={t} />)}
@@ -477,7 +444,7 @@ const fmtMs = (ms: number) => (ms < 1000 ? `${ms}ms` : `${(ms / 1000).toFixed(1)
 /** The key is stored on the SERVER, under Settings — the same one Slack and trigger-woken agents
  *  resolve. It used to live in this browser's localStorage and ride along as a header, so a key
  *  added here made Ask work while Slack still reported no key configured (NF-125). */
-function KeySetup({ onSaved }: { onSaved: () => void }) {
+export function KeySetup({ onSaved }: { onSaved: () => void }) {
   const [value, setValue] = useState("");
   const [err, setErr] = useState<string>();
   const [saving, setSaving] = useState(false);

--- a/ui/src/components/IngestEndpoint.tsx
+++ b/ui/src/components/IngestEndpoint.tsx
@@ -1,0 +1,46 @@
+import { useState } from "react";
+
+import IngestSetup from "./IngestSetup";
+import type { Source } from "../types";
+
+export function CopyableUrl({ url }: { url: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <div className="ingest-url">
+      <code className="mono">{url}</code>
+      <button onClick={() => {
+        navigator.clipboard?.writeText(url);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1500);
+      }}>{copied ? "copied" : "copy"}</button>
+    </div>
+  );
+}
+
+// The full, copyable ingest URL of a push source, built from the browser's own origin so it is
+// correct wherever the console is served. Shown on the source page and, folded into the row, on
+// the project page: a push source is nothing until a producer posts to it, and the project page
+// is where a builder-made source is first looked at. On a secured instance IngestSetup adds the
+// auth-key guidance. OTLP uses the /v1/* endpoints (source chosen by header), no path key.
+export default function IngestEndpoint({ source }: { source: Source }) {
+  const origin = window.location.origin;
+  if (source.connector === "otlp") {
+    return (
+      <div className="card ingest-card">
+        <div className="k">OTLP endpoint</div>
+        <CopyableUrl url={`${origin}/v1/logs`} />
+        <p className="muted">Point an OTLP/HTTP exporter here (also <span className="mono">/v1/traces</span>, <span className="mono">/v1/metrics</span>).</p>
+        <IngestSetup connector="otlp" url={`${origin}/v1/logs`} />
+      </div>
+    );
+  }
+  const url = `${origin}/ingest/${source.ingest_key || source.name}`;
+  return (
+    <div className="card ingest-card">
+      <div className="k">ingest endpoint · POST</div>
+      <CopyableUrl url={url} />
+      <p className="muted">Point your producer (e.g. a Vercel log drain) at this URL.</p>
+      <IngestSetup connector={source.connector} url={url} />
+    </div>
+  );
+}

--- a/ui/src/components/SourceForm.tsx
+++ b/ui/src/components/SourceForm.tsx
@@ -48,6 +48,7 @@ interface Props {
   spec: ConnectorSpec;
   initial?: { name: string; type: string; poll: string; config: Record<string, unknown> };
   lockName?: boolean;
+  highlight?: string[];   // field names to mark as "yours to fill" (a builder proposal's `needs`)
   submitLabel: string;
   onSubmit: (body: {
     name: string; type: string; connector: string; poll: string; config: Record<string, unknown>;
@@ -56,7 +57,7 @@ interface Props {
 
 /** Form generated from the connector's spec (GET /api/connectors). string/number fields render
  *  as inputs, json fields as a code textarea. Test runs one poll server-side before saving. */
-export default function SourceForm({ connector, spec, initial, lockName, submitLabel, onSubmit }: Props) {
+export default function SourceForm({ connector, spec, initial, lockName, highlight, submitLabel, onSubmit }: Props) {
   const [name, setName] = useState(initial?.name ?? "");
   const type = initial?.type ?? "event_stream";  // ignored by the daemon; derived from connector
   const [poll, setPoll] = useState(initial?.poll ?? spec.poll ?? "5s");
@@ -593,10 +594,11 @@ export default function SourceForm({ connector, spec, initial, lockName, submitL
       return <ListFieldEditor key={f.name} field={f} rows={rows[f.name] ?? []}
                               onChange={(r) => setRows({ ...rows, [f.name]: r })} />;
     return (
-      <div className={"fld-row" + (jsonErrors[f.name] ? " invalid" : "")} key={f.name}>
+      <div className={"fld-row" + (jsonErrors[f.name] ? " invalid" : "") + (highlight?.includes(f.name) ? " needs" : "")} key={f.name}>
         <div className="fld-meta">
           <span className="lbl">{fieldLabel(f)}{f.required && <span className="req"> *</span>}
-            {fieldDetected(f) && <span className="badge ok" style={{ marginLeft: 8 }}>detected</span>}</span>
+            {fieldDetected(f) && <span className="badge ok" style={{ marginLeft: 8 }}>detected</span>}
+            {highlight?.includes(f.name) && <span className="badge" style={{ marginLeft: 8 }}>yours to fill</span>}</span>
           {fieldHelp(f)}
         </div>
         <div className="fld-ctrl">{fieldControl(f)}</div>

--- a/ui/src/components/TriggerEditor.tsx
+++ b/ui/src/components/TriggerEditor.tsx
@@ -10,13 +10,14 @@ import type { Trigger } from "../types";
 
 const AGGREGATES = ["max", "min", "sum", "avg", "count", "any"];
 
-export default function TriggerEditor({ initial, presetView, onSaved, onCancel }: {
+export default function TriggerEditor({ initial, prefill, presetView, onSaved, onCancel }: {
   initial?: Trigger;            // absent = create
+  prefill?: boolean;            // initial is a proposal for a NEW trigger: create, editable name
   presetView?: string;          // create mode: view preselected (e.g. from a view page)
   onSaved: (name: string) => void;
   onCancel: () => void;
 }) {
-  const isNew = !initial;
+  const isNew = !initial || !!prefill;
   const [t, setT] = useState<Trigger>(initial ?? {
     name: "", view: presetView ?? "",
     condition: { aggregate: "max", predicate: "> 1.0", window: "1m", field: "" },

--- a/ui/src/components/ViewEditor.tsx
+++ b/ui/src/components/ViewEditor.tsx
@@ -10,13 +10,14 @@ import type { ConnectorSpec, View, ViewFilter } from "../types";
 
 const NUMERIC_OPS = new Set(["gt", "lt", "gte", "lte"]);
 
-export default function ViewEditor({ initial, sourceNames, onSaved, onCancel }: {
+export default function ViewEditor({ initial, prefill, sourceNames, onSaved, onCancel }: {
   initial?: View;                     // absent = create
+  prefill?: boolean;                  // initial is a proposal for a NEW view: create, editable name
   sourceNames: string[];
   onSaved: (name: string) => void;
   onCancel: () => void;
 }) {
-  const isNew = !initial;
+  const isNew = !initial || !!prefill;
   const [name, setName] = useState(initial?.name ?? "");
   const [keyField, setKeyField] = useState(initial?.key_field ?? "");
   const [sources, setSources] = useState<string[]>(initial?.sources ?? []);

--- a/ui/src/components/proposals.tsx
+++ b/ui/src/components/proposals.tsx
@@ -24,7 +24,8 @@ export type Proposal =
   | { id: string; kind: "source"; name: string; connector: string; poll?: string;
       config?: Record<string, unknown>; needs: string[]; reasoning: string }
   | { id: string; kind: "agent"; name: string; trigger: string; prompt: string; model?: string;
-      max_rounds?: number; budget_usd?: number; delivery: { kind: "slack" | "webhook" | "none" };
+      max_rounds?: number; budget_usd?: number;
+      delivery: { kind: "slack" | "webhook" | "none"; url?: string };   // url only when the user typed it
       reasoning: string };
 
 // The operators a view filter may use — the set `tares/config.py` validates against on Apply.
@@ -266,7 +267,7 @@ export function ProposalBody({ proposal }: { proposal: Proposal }) {
           {proposal.model && <> · model <span className="chip mono">{proposal.model}</span></>}
           {" · "}
           {proposal.delivery.kind === "slack" ? "posts the finding to a Slack channel you pick"
-            : proposal.delivery.kind === "webhook" ? "posts the finding to a URL you give"
+            : proposal.delivery.kind === "webhook" ? (proposal.delivery.url ? <>posts the finding to <span className="mono">{proposal.delivery.url}</span></> : "posts the finding to a URL you give")
             : "writes the finding onto the timeline only"}
         </p>
       )}

--- a/ui/src/components/proposals.tsx
+++ b/ui/src/components/proposals.tsx
@@ -3,9 +3,13 @@ import { useEffect, useState } from "react";
 import { api } from "../api";
 import type { Trigger } from "../types";
 
-// Shared proposal-card machinery for the in-app agent (Ask chat + Organize). The agent's
-// propose_* tools stream these as structured cards; every mutation happens only when the user
-// clicks Apply, through the normal validated management APIs.
+// Shared proposal-card machinery for the in-app agent (Ask chat and the AI-guided project
+// builder). The agent's propose_* tools stream these as structured cards; every mutation happens
+// only when the user clicks Apply, through the normal validated management APIs.
+//
+// `source` and `agent` are build-mode cards (TR-243, TR-246): they arrive only on the builder
+// page, which renders them as prefilled forms rather than through applyProposal, because both
+// need values only the user has (a token, a Slack channel).
 
 export type LabelSpec = { name: string; field?: string; const?: string; primary?: boolean;
                           type?: "string" | "number";
@@ -16,7 +20,12 @@ export type Proposal =
   | { id: string; kind: "view"; name: string; key_field: string; sources: string[];
       filters?: Array<Record<string, unknown>>; reasoning: string }
   | { id: string; kind: "trigger"; name: string; view: string; condition: TriggerCondition;
-      emit?: { kind?: string; context_window?: string }; cooldown?: string; reasoning: string };
+      emit?: { kind?: string; context_window?: string }; cooldown?: string; reasoning: string }
+  | { id: string; kind: "source"; name: string; connector: string; poll?: string;
+      config?: Record<string, unknown>; needs: string[]; reasoning: string }
+  | { id: string; kind: "agent"; name: string; trigger: string; prompt: string; model?: string;
+      max_rounds?: number; budget_usd?: number; delivery: { kind: "slack" | "webhook" | "none" };
+      reasoning: string };
 
 // The operators a view filter may use — the set `tares/config.py` validates against on Apply.
 const FILTER_OPS = ["eq", "neq", "contains", "gt", "gte", "lt", "lte"];
@@ -39,8 +48,12 @@ export function filterText(f: Record<string, unknown>): { text: string; ok: bool
 export type Decision = "applied" | "skipped" | "error";
 export type DecisionMap = Record<string, { status: Decision; detail?: string }>;
 
-/** Apply one proposal via the normal management APIs. Throws with a readable message. */
+/** Apply one proposal via the normal management APIs. Throws with a readable message. Source
+ *  and agent cards are not applied here: they become forms on the builder page. */
 export async function applyProposal(p: Proposal): Promise<void> {
+  if (p.kind === "source" || p.kind === "agent") {
+    throw new Error(`a ${p.kind} proposal is completed as a form, not applied as is`);
+  }
   if (p.kind === "labels") {
     const src = await api.source(p.source);
     await api.updateSource(p.source, {
@@ -109,23 +122,65 @@ function NormPreview({ source, label }: { source: string; label: LabelSpec }) {
   );
 }
 
-export function ProposalCard({ proposal, decision, onApply, onSkip }: {
-  proposal: Proposal; decision?: { status: Decision; detail?: string };
-  onApply: () => void; onSkip: () => void;
+/** What a proposal is called on its card: "View timeline", "Labels for logs", ... */
+export function proposalTitle(p: Proposal) {
+  if (p.kind === "labels") return <>Labels for <span className="mono">{p.source}</span></>;
+  const noun = { view: "View", trigger: "Trigger", source: "Source", agent: "Agent" }[p.kind];
+  return <>{noun} <span className="mono">{p.name}</span></>;
+}
+
+/** The card around any proposal: title and state badge, the body, the reasoning paragraph, the
+ *  error if the last Apply failed, and the Apply/Skip row. Ask's ProposalCard and the builder's
+ *  form cards share this so a proposal looks the same wherever it appears. `actions` replaces
+ *  the default Apply/Skip row (the builder's forms carry their own submit button); `null` hides
+ *  the row without replacing it. */
+export function ProposalShell({ title, decision, reasoning, children, onApply, onSkip, actions, applyLabel }: {
+  title: React.ReactNode; decision?: { status: Decision; detail?: string };
+  reasoning: string; children?: React.ReactNode;
+  onApply?: () => void; onSkip?: () => void;
+  actions?: React.ReactNode | null; applyLabel?: string;
 }) {
   const st = decision?.status;
+  const open = !st || st === "error";
   return (
     <div className="card" style={{ margin: "10px 0", padding: 14, opacity: st === "skipped" ? 0.55 : 1 }}>
       <div className="pagehead" style={{ marginBottom: 8 }}>
-        <h3 style={{ margin: 0 }}>
-          {proposal.kind === "labels" && <>Labels for <span className="mono">{proposal.source}</span></>}
-          {proposal.kind === "view" && <>View <span className="mono">{proposal.name}</span></>}
-          {proposal.kind === "trigger" && <>Trigger <span className="mono">{proposal.name}</span></>}
-        </h3>
+        <h3 style={{ margin: 0 }}>{title}</h3>
         {st === "applied" && <span className="badge ok">applied</span>}
         {st === "skipped" && <span className="badge starting">skipped</span>}
         {st === "error" && <span className="badge error">failed</span>}
       </div>
+      {children}
+      <p className="help" style={{ whiteSpace: "normal", margin: "0 0 10px" }}>{reasoning}</p>
+      {decision?.detail && <div className="alert error">{decision.detail}</div>}
+      {open && (actions !== undefined ? actions : (
+        <div className="btnrow">
+          {onApply && <button className="primary" onClick={onApply}>{st === "error" ? "Retry" : (applyLabel ?? "Apply")}</button>}
+          {onSkip && <button onClick={onSkip}>Skip</button>}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function ProposalCard({ proposal, decision, onApply, onSkip }: {
+  proposal: Proposal; decision?: { status: Decision; detail?: string };
+  onApply: () => void; onSkip: () => void;
+}) {
+  return (
+    <ProposalShell title={proposalTitle(proposal)} decision={decision} reasoning={proposal.reasoning}
+                   onApply={onApply} onSkip={onSkip}>
+      <ProposalBody proposal={proposal} />
+    </ProposalShell>
+  );
+}
+
+/** The kind-specific summary of a proposal: the label table, the view's key and filters, the
+ *  trigger's condition, a source's connector and prefilled fields, an agent's trigger and
+ *  delivery. */
+export function ProposalBody({ proposal }: { proposal: Proposal }) {
+  return (
+    <>
 
       {proposal.kind === "labels" && (
         <table style={{ marginBottom: 8 }}>
@@ -186,19 +241,39 @@ export function ProposalCard({ proposal, decision, onApply, onSkip }: {
         </p>
       )}
 
+      {proposal.kind === "source" && (
+        <p style={{ margin: "0 0 8px" }}>
+          connector <span className="chip mono">{proposal.connector}</span>
+          {proposal.poll && <> · polls every <span className="chip mono">{proposal.poll}</span></>}
+          {Object.keys(proposal.config ?? {}).length > 0 && (
+            <> · prefilled{" "}
+              {Object.entries(proposal.config ?? {}).map(([k, v]) => (
+                <span key={k} className="chip mono" title={String(v)}>{k}</span>
+              ))}
+            </>
+          )}
+          {proposal.needs.length > 0 && (
+            <span className="help" style={{ display: "block" }}>
+              you fill in: {proposal.needs.map((n) => <span key={n} className="chip mono">{n}</span>)}
+            </span>
+          )}
+        </p>
+      )}
+
+      {proposal.kind === "agent" && (
+        <p style={{ margin: "0 0 8px" }}>
+          runs on <span className="chip mono">{proposal.trigger}</span>
+          {proposal.model && <> · model <span className="chip mono">{proposal.model}</span></>}
+          {" · "}
+          {proposal.delivery.kind === "slack" ? "posts the finding to a Slack channel you pick"
+            : proposal.delivery.kind === "webhook" ? "posts the finding to a URL you give"
+            : "writes the finding onto the timeline only"}
+        </p>
+      )}
+
       {proposal.kind === "labels" && proposal.labels
         .filter((l) => l.field && (l.pattern || l.map))
         .map((l) => <NormPreview key={l.name} source={proposal.source} label={l} />)}
-
-      <p className="help" style={{ whiteSpace: "normal", margin: "0 0 10px" }}>{proposal.reasoning}</p>
-      {decision?.detail && <div className="alert error">{decision.detail}</div>}
-
-      {(!st || st === "error") && (
-        <div className="btnrow">
-          <button className="primary" onClick={onApply}>{st === "error" ? "Retry" : "Apply"}</button>
-          <button onClick={onSkip}>Skip</button>
-        </div>
-      )}
-    </div>
+    </>
   );
 }

--- a/ui/src/components/useAgentStream.ts
+++ b/ui/src/components/useAgentStream.ts
@@ -21,7 +21,7 @@ export type StreamEvent =
 
 export type SendOptions = {
   mode?: "ask" | "build";
-  step?: "sources" | "views" | "triggers" | "agent";
+  step?: "sources" | "watch" | "agent";
 };
 
 export function useAgentStream() {

--- a/ui/src/components/useAgentStream.ts
+++ b/ui/src/components/useAgentStream.ts
@@ -1,0 +1,86 @@
+import { useCallback, useRef, useState } from "react";
+
+import { authHeader } from "../api";
+import type { Proposal } from "./proposals";
+
+// One streaming client for the in-app assistant, shared by the Ask chat and the AI-guided
+// project builder (TR-243). It owns the raw fetch to POST /api/agent/chat, the SSE parse and the
+// AbortController; what it does NOT own is the transcript. Each caller keeps its own message
+// shape and folds the events it receives into it, so Ask's markdown turns and the builder's
+// step panels can render the same stream differently.
+
+export type WireMessage = { role: "user" | "assistant"; content: string };
+
+export type StreamEvent =
+  | { type: "text"; text: string }
+  | { type: "tool"; id: string; name: string; input: unknown }
+  | { type: "tool_done"; id: string; ms: number; ok: boolean; preview: string }
+  | { type: "proposal"; proposal: Proposal }
+  | { type: "error"; detail: string }
+  | { type: "done" };
+
+export type SendOptions = {
+  mode?: "ask" | "build";
+  step?: "sources" | "views" | "triggers" | "agent";
+};
+
+export function useAgentStream() {
+  const [streaming, setStreaming] = useState(false);
+  const abortRef = useRef<AbortController | null>(null);
+
+  /** Send one turn and feed every server event to `onEvent` as it arrives. Resolves when the
+   *  stream ends, whether by `done`, an HTTP error (reported as an `error` event) or Stop (no
+   *  event: an aborted run is the user's choice, not a failure to report). */
+  const send = useCallback(async (messages: WireMessage[], onEvent: (e: StreamEvent) => void,
+                                  opts: SendOptions = {}) => {
+    if (abortRef.current) return;
+    setStreaming(true);
+    const ctl = new AbortController();
+    abortRef.current = ctl;
+    try {
+      const body: Record<string, unknown> = { messages };
+      if (opts.mode) body.mode = opts.mode;
+      if (opts.step) body.step = opts.step;
+      const res = await fetch("/api/agent/chat", {
+        method: "POST",
+        signal: ctl.signal,
+        headers: { "content-type": "application/json", ...authHeader() },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok || !res.body) {
+        onEvent({ type: "error", detail: await res.text().catch(() => res.statusText) });
+        return;
+      }
+      const reader = res.body.getReader();
+      const dec = new TextDecoder();
+      let buf = "";
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buf += dec.decode(value, { stream: true });
+        let idx;
+        while ((idx = buf.indexOf("\n\n")) >= 0) {
+          const chunk = buf.slice(0, idx); buf = buf.slice(idx + 2);
+          if (!chunk.startsWith("data: ")) continue;
+          const e = JSON.parse(chunk.slice(6));
+          if (e.type === "proposal") {
+            onEvent({ type: "proposal", proposal: { id: e.id, kind: e.kind, ...e.payload } as Proposal });
+          } else {
+            onEvent(e as StreamEvent);
+          }
+        }
+      }
+    } catch (err) {
+      if ((err as Error).name !== "AbortError") {
+        onEvent({ type: "error", detail: String((err as Error).message ?? err) });
+      }
+    } finally {
+      abortRef.current = null;
+      setStreaming(false);
+    }
+  }, []);
+
+  const stop = useCallback(() => abortRef.current?.abort(), []);
+
+  return { send, stop, streaming };
+}

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -30,6 +30,7 @@ import { TriggersPage, ViewsPage } from "./pages/ViewsTriggers";
 import Projects from "./pages/Projects";
 import ProjectNew from "./pages/ProjectNew";
 import ProjectDetail from "./pages/ProjectDetail";
+import ProjectNewAssist from "./pages/ProjectNewAssist";
 import ProjectNewCustom from "./pages/ProjectNewCustom";
 import ProjectNewGeneric from "./pages/ProjectNewGeneric";
 import ProjectNewSharedContext from "./pages/ProjectNewSharedContext";
@@ -62,6 +63,9 @@ const router = createBrowserRouter([
       { path: "projects/new", element: <ProjectNew /> },
       { path: "projects/new/shared_code_context", element: <ProjectNewSharedContext /> },
       { path: "projects/new/custom", element: <ProjectNewCustom /> },
+      // the AI-guided builder is not a template (it assembles a custom project), so it sits
+      // above the :template fallback
+      { path: "projects/new/assist", element: <ProjectNewAssist /> },
       { path: "projects/new/:template", element: <ProjectNewGeneric /> },
       { path: "projects/:id", element: <ProjectDetail /> },
       { path: "sources", element: <Sources /> },

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -278,7 +278,7 @@ export function RunsTable({ runs, runsError, agent, focusDispatch, focusRun, ope
 }) {
   if (runsError) return <ErrorState error={runsError} what="this agent’s runs" />;
   if (!runs?.length) {
-    return <p className="help">none yet; this agent runs when <span className="mono">{agent.trigger}</span> fires</p>;
+    return <div className="empty">no runs yet; this agent runs when <span className="mono">{agent.trigger}</span> fires</div>;
   }
   const isFocused = (r: AgentRun) =>
     (!!focusDispatch && r.dispatch_id === focusDispatch) || (!!focusRun && r.id === focusRun);

--- a/ui/src/pages/ProjectNew.tsx
+++ b/ui/src/pages/ProjectNew.tsx
@@ -85,6 +85,34 @@ export default function ProjectNew() {
         <div className="empty">No templates are registered on this instance yet.</div>
       )}
       <div className="uc-cards">
+        {/* Hand-written: the builder is not a template, it assembles a custom project one step at
+            a time with the assistant proposing each piece (ProjectNewAssist). */}
+        {rec && (
+          <div className="panel uc-card">
+            <div className="uc-card-main">
+              <div className="uc-card-title">Build with Tares</div>
+              <div className="help" style={{ marginTop: 2 }}>AI-guided</div>
+              <p className="help uc-card-desc">
+                Describe what you need in your own words. Tares proposes the sources, views, triggers
+                and agent from the connectors installed here; you confirm each one in place and fill
+                in what only you know.
+              </p>
+              <div className="uc-card-facts">
+                <div>
+                  <div className="lbl">you</div>
+                  <ul><li>say what you run and what should happen</li><li>fill in URLs, tokens and the Slack channel</li><li>apply or skip each proposal</li></ul>
+                </div>
+                <div>
+                  <div className="lbl">Tares sets up</div>
+                  <ul><li>the sources, tested before they are created</li><li>views and triggers grounded in your real data</li><li>an agent on the trigger, enabled and ready</li></ul>
+                </div>
+              </div>
+            </div>
+            <div className="uc-card-side">
+              <button className="primary" onClick={() => navigate("/projects/new/assist")}>Build</button>
+            </div>
+          </div>
+        )}
         {templates.map((r) => <TemplateCard key={r.key} r={r} />)}
         {rec && (
           <div className="panel uc-card">

--- a/ui/src/pages/ProjectNewAssist.tsx
+++ b/ui/src/pages/ProjectNewAssist.tsx
@@ -1,0 +1,560 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Link } from "react-router-dom";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+import { api } from "../api";
+import AgentForm from "../components/AgentForm";
+import { KeySetup, ToolRun } from "../components/AskChat";
+import type { ToolPart } from "../components/AskChat";
+import { Picker } from "../components/bits";
+import { applyProposal, ProposalBody, ProposalShell, proposalTitle } from "../components/proposals";
+import type { DecisionMap, Proposal } from "../components/proposals";
+import SourceForm from "../components/SourceForm";
+import TriggerEditor from "../components/TriggerEditor";
+import { useAgentStream } from "../components/useAgentStream";
+import type { StreamEvent, WireMessage } from "../components/useAgentStream";
+import ViewEditor from "../components/ViewEditor";
+import type { AgentPreset, BuiltinAgent, ConnectorSpec, Project, ProjectObjectKind, Source, Trigger, View, ViewFilter } from "../types";
+
+// The AI-guided project builder (TR-243 to TR-246): describe what you need in your own words,
+// the assistant proposes the pieces one step at a time, and you complete each proposal in the
+// same form you would use on that object's own page. Every Apply creates a real object through
+// its normal API and appends it to an ordinary `custom` project, so the result is a project like
+// any other and abandoning the page mid-way leaves real, editable objects behind by design.
+//
+// The assistant never creates anything: each build turn gets only that step's proposal tool
+// (tares/agent.py, tools_for) and the console fires the create call when the user clicks.
+// Secrets and Slack channels are never the model's to fill: a source proposal lists them in
+// `needs` and the form highlights them; an agent proposal picks only the delivery kind.
+
+type StepKey = "sources" | "views" | "triggers" | "agent";
+const STEPS: { key: StepKey; label: string }[] = [
+  { key: "sources", label: "Sources" },
+  { key: "views", label: "Views" },
+  { key: "triggers", label: "Triggers" },
+  { key: "agent", label: "Agent" },
+];
+const NEXT: Record<StepKey, StepKey | "done"> = { sources: "views", views: "triggers", triggers: "agent", agent: "done" };
+
+type Part = { type: "text"; text: string } | ToolPart | { type: "proposal"; proposal: Proposal };
+type Turn = { parts: Part[] };
+type StepState = { turns: Turn[] };
+
+/** The transcript the model sees. Proposals contribute their decision, so a later step knows
+ *  what was created and what the user declined. */
+const wireText = (t: Turn, decisions: DecisionMap) => t.parts.map((p) => {
+  if (p.type === "text") return p.text;
+  if (p.type === "proposal") {
+    const d = decisions[p.proposal.id];
+    const what = p.proposal.kind === "labels" ? `labels for ${p.proposal.source}` : `${p.proposal.kind} ${p.proposal.name}`;
+    return `\n[proposal: ${what}; ${d?.status === "applied" ? "created" : d?.status ?? "pending"}]\n`;
+  }
+  return "";
+}).join("").trim() || "[no answer]";
+
+const kindOf = (p: Proposal): ProjectObjectKind | null =>
+  p.kind === "labels" ? null : p.kind;
+
+export default function ProjectNewAssist() {
+  const [ready, setReady] = useState<boolean>();
+  const refreshKey = () => api.capabilities()
+    .then((c) => setReady(!!c.agent_key_configured)).catch(() => setReady(false));
+  useEffect(() => { refreshKey(); }, []);
+
+  const [goal, setGoal] = useState("");
+  const [projectName, setProjectName] = useState("");
+  const [step, setStep] = useState<StepKey | "describe" | "done">("describe");
+  const [states, setStates] = useState<Record<StepKey, StepState>>({
+    sources: { turns: [] }, views: { turns: [] }, triggers: { turns: [] }, agent: { turns: [] },
+  });
+  const [decisions, setDecisions] = useState<DecisionMap>({});
+  const [history, setHistory] = useState<WireMessage[]>([]);
+  const [refine, setRefine] = useState("");
+  const { send, stop, streaming } = useAgentStream();
+
+  // what this build has made so far; the project is created around the first source
+  const [project, setProject] = useState<Project>();
+  const [objects, setObjects] = useState<{ kind: ProjectObjectKind; name: string }[]>([]);
+  const [projectErr, setProjectErr] = useState<string>();
+
+  // reference data the forms need
+  const [specs, setSpecs] = useState<Record<string, ConnectorSpec>>();
+  const [existing, setExisting] = useState<Source[]>([]);
+  const refreshSources = () => api.sources().then(setExisting).catch(() => {});
+  useEffect(() => {
+    api.connectors().then(setSpecs).catch(() => setSpecs({}));
+    refreshSources();
+  }, []);
+
+  const created = (kind: ProjectObjectKind) => objects.filter((o) => o.kind === kind).map((o) => o.name);
+
+  const decide = (id: string, status: "applied" | "skipped" | "error", detail?: string) =>
+    setDecisions((d) => ({ ...d, [id]: { status, detail } }));
+
+  /** Create the project around the first object, append every later one. Throws with the API
+   *  error so the card shows it; the object itself already exists and stays.
+   *
+   *  Serialized through a promise chain and refs, not state: two cards applied in quick
+   *  succession would both see "no project yet" and try to create it twice, and the second
+   *  append would overwrite the first with a stale object list. */
+  const projectRef = useRef<Project>();
+  const objectsRef = useRef<{ kind: ProjectObjectKind; name: string }[]>([]);
+  const ownQueue = useRef<Promise<void>>(Promise.resolve());
+  const own = (kind: ProjectObjectKind, name: string) => {
+    const run = async () => {
+      const next = [...objectsRef.current, { kind, name }];
+      setProjectErr(undefined);
+      try {
+        if (!projectRef.current) {
+          const p = await api.createProject({ template: "custom", name: projectName.trim(), objects: next });
+          projectRef.current = p;
+          setProject(p);
+        } else {
+          await api.updateProject(projectRef.current.id, { objects: next });
+        }
+        objectsRef.current = next;
+        setObjects(next);
+      } catch (e) {
+        const msg = String((e as Error).message ?? e);
+        setProjectErr(`${kind} ${name} exists but could not be added to the project: ${msg}`);
+        throw e;
+      }
+    };
+    const p = ownQueue.current.then(run, run);
+    ownQueue.current = p.catch(() => {});
+    return p;
+  };
+
+  /** One build turn: push the user framing, stream the assistant's answer into this step. */
+  const turn = async (stepKey: StepKey, userText: string) => {
+    const messages: WireMessage[] = [...history, { role: "user", content: userText }];
+    const idx = states[stepKey].turns.length;
+    setStates((s) => ({ ...s, [stepKey]: { turns: [...s[stepKey].turns, { parts: [] }] } }));
+    const mut = (fn: (parts: Part[]) => Part[]) =>
+      setStates((s) => ({ ...s, [stepKey]: { turns: s[stepKey].turns.map((t, i) => i === idx ? { parts: fn(t.parts) } : t) } }));
+    const appendText = (text: string) => mut((parts) => {
+      const last = parts[parts.length - 1];
+      if (last && last.type === "text") return [...parts.slice(0, -1), { type: "text", text: last.text + text }];
+      return [...parts, { type: "text", text }];
+    });
+    let collected: Part[] = [];
+    const onEvent = (e: StreamEvent) => {
+      if (e.type === "text") appendText(e.text);
+      else if (e.type === "tool") mut((parts) => [...parts, { type: "tool", id: e.id, name: e.name, input: e.input }]);
+      else if (e.type === "tool_done") mut((parts) => parts.map((p) => p.type === "tool" && p.id === e.id ? { ...p, ms: e.ms, ok: e.ok, preview: e.preview } : p));
+      else if (e.type === "proposal") mut((parts) => [...parts, { type: "proposal", proposal: e.proposal }]);
+      else if (e.type === "error") appendText(`\n\n⚠️ ${e.detail}`);
+      // keep a local copy for the wire: state updates are async and the turn ends before they settle
+      if (e.type === "text") {
+        const last = collected[collected.length - 1];
+        if (last && last.type === "text") last.text += e.text; else collected.push({ type: "text", text: e.text });
+      } else if (e.type === "proposal") collected.push({ type: "proposal", proposal: e.proposal });
+    };
+    await send(messages, onEvent, { mode: "build", step: stepKey });
+    // the assistant's reply on the wire carries the proposals as pending; their decisions are
+    // folded in when the next turn is framed (see framing below)
+    setHistory([...messages, { role: "assistant", content: wireText({ parts: collected }, {}) }]);
+    collected = [];
+  };
+
+  const start = async () => {
+    setStep("sources");
+    await turn("sources", `Project: ${projectName.trim()}.\nGoal: ${goal.trim()}`);
+  };
+
+  /** Move on: tell the model what got created (with the decisions now known) and ask for the
+   *  next step's proposals. */
+  const advance = async () => {
+    if (step === "describe" || step === "done") return;
+    const next = NEXT[step];
+    // rewrite the last assistant message with the decisions, so skipped proposals are not
+    // reported as pending forever
+    const last = states[step].turns[states[step].turns.length - 1];
+    if (last) setHistory((h) => [...h.slice(0, -1), { role: "assistant", content: wireText(last, decisions) }]);
+    if (next === "done") { setStep("done"); return; }
+    setStep(next);
+    const framing = next === "views"
+      ? `Sources connected: ${created("source").join(", ") || "none"}. Now propose the views (and any labels they need) that correlate these sources for the goal. Check source_fields on each source first.`
+      : next === "triggers"
+      ? `Views created: ${created("view").join(", ") || "none"}. Now propose the triggers on these views for the goal.`
+      : `Triggers created: ${created("trigger").join(", ") || "none"}. Now propose the one Tares agent that runs when they fire, and its delivery kind.`;
+    await turn(next, framing);
+  };
+
+  const sendRefine = async () => {
+    if (step === "describe" || step === "done" || !refine.trim()) return;
+    const text = refine.trim();
+    setRefine("");
+    await turn(step, text);
+  };
+
+  if (ready === undefined) return <div className="dim">loading…</div>;
+  if (!ready) {
+    return (
+      <>
+        <PageHead />
+        <KeySetup onSaved={refreshKey} />
+      </>
+    );
+  }
+
+  const stepIndex = step === "describe" ? -1 : step === "done" ? STEPS.length : STEPS.findIndex((s) => s.key === step);
+  const pending = step !== "describe" && step !== "done"
+    ? states[step].turns.flatMap((t) => t.parts).filter((p): p is { type: "proposal"; proposal: Proposal } =>
+        p.type === "proposal" && !decisions[p.proposal.id]).length
+    : 0;
+  const proposalsInStep = step !== "describe" && step !== "done"
+    ? states[step].turns.flatMap((t) => t.parts).filter((p) => p.type === "proposal").length
+    : 0;
+
+  return (
+    <>
+      <PageHead />
+      <div className="builder-steps">
+        {STEPS.map((s, i) => (
+          <span key={s.key} className={"step" + (i === stepIndex ? " active" : i < stepIndex ? " done" : "")}>
+            <span className="n">{i + 1}</span>{s.label}
+            {i < stepIndex && created(s.key === "agent" ? "agent" : s.key.slice(0, -1) as ProjectObjectKind).length > 0 && (
+              <span className="badge ok">{created(s.key === "agent" ? "agent" : s.key.slice(0, -1) as ProjectObjectKind).length}</span>
+            )}
+          </span>
+        ))}
+      </div>
+
+      {/* Describe */}
+      <div className="panel">
+        <h2 style={{ marginTop: 0 }}>Describe</h2>
+        <label className="field">
+          <span className="lbl">project name<span className="req"> *</span></span>
+          <input type="text" value={projectName} onChange={(e) => setProjectName(e.target.value)}
+                 disabled={step !== "describe"} placeholder="e.g. checkout incidents" style={{ maxWidth: 420 }} />
+        </label>
+        <label className="field">
+          <span className="lbl">what you need<span className="req"> *</span></span>
+          <textarea value={goal} onChange={(e) => setGoal(e.target.value)} rows={3} disabled={step !== "describe"}
+                    placeholder="e.g. watch my payment service logs and wake an agent in Slack when checkouts fail"
+                    style={{ width: "100%", boxSizing: "border-box" }} />
+          <span className="help">
+            Name the systems you run and where they are. Tares proposes sources from the connectors
+            installed here, then views, triggers and an agent, one step at a time. Everything you
+            create is a real object you can edit on its own page.
+          </span>
+        </label>
+        {step === "describe" && (
+          <div className="btnrow">
+            <button className="primary" disabled={!goal.trim() || !projectName.trim() || streaming} onClick={start}>
+              Propose sources
+            </button>
+            <Link className="btn" to="/projects/new">Cancel</Link>
+          </div>
+        )}
+      </div>
+
+      {projectErr && <div className="alert error">{projectErr}</div>}
+
+      {/* One panel per step reached so far */}
+      {STEPS.filter((_, i) => i <= stepIndex && i < STEPS.length).map((s, i) => (
+        <div className="panel" key={s.key}>
+          <div className="pagehead" style={{ marginBottom: 8 }}>
+            <h2 style={{ margin: 0 }}>{s.label}</h2>
+            {i < stepIndex && <span className="badge ok">done</span>}
+          </div>
+          {states[s.key].turns.map((t, j) => (
+            <TurnView key={j} turn={t} decisions={decisions} decide={decide} own={own}
+                      thinking={streaming && s.key === step && j === states[s.key].turns.length - 1 && t.parts.length === 0}
+                      specs={specs ?? {}} existing={existing} refreshSources={refreshSources}
+                      sourceNames={[...new Set([...created("source"), ...existing.map((x) => x.name)])]}
+                      createdTriggers={created("trigger")}
+                      active={s.key === step} />
+          ))}
+          {s.key === step && !streaming && states[s.key].turns.length > 0 && proposalsInStep === 0 && (
+            <div className="empty">
+              {s.key === "sources"
+                ? <>No source was proposed. Say which systems you run and where (a container name, a URL, a repo), or <Link to="/sources/new">add a source by hand</Link> and come back to assemble the project from <Link to="/projects/new/custom">existing objects</Link>.</>
+                : <>Nothing was proposed for this step. Ask for what you have in mind below, or continue.</>}
+            </div>
+          )}
+          {s.key === step && (
+            <>
+              <div className="builder-refine">
+                <textarea value={refine} rows={1} placeholder="ask for a change, e.g. use the staging URL, or add the alerts too"
+                          onChange={(e) => setRefine(e.target.value)}
+                          onKeyDown={(e) => { if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); sendRefine(); } }} />
+                {streaming
+                  ? <button type="button" className="danger" onClick={stop}>Stop</button>
+                  : <button type="button" disabled={!refine.trim()} onClick={sendRefine}>Send</button>}
+              </div>
+              <div className="btnrow" style={{ marginTop: 12 }}>
+                <button className="primary" disabled={streaming || (s.key === "sources" && created("source").length === 0)}
+                        onClick={advance}
+                        title={s.key === "sources" && created("source").length === 0 ? "connect at least one source first" : undefined}>
+                  {NEXT[s.key] === "done" ? "Finish" : `Continue to ${STEPS[i + 1].label.toLowerCase()}`}
+                  {pending > 0 ? ` (${pending} undecided)` : ""}
+                </button>
+                {project && <Link className="btn" to={`/projects/${encodeURIComponent(project.id)}`}>Open the project so far</Link>}
+              </div>
+            </>
+          )}
+        </div>
+      ))}
+
+      {step === "done" && (
+        <div className="panel">
+          <h2 style={{ marginTop: 0 }}>Done</h2>
+          {project ? (
+            <>
+              <p>
+                <strong>{project.name}</strong> is set up with{" "}
+                {(["source", "view", "trigger", "agent"] as ProjectObjectKind[])
+                  .map((k) => ({ k, n: created(k).length })).filter((x) => x.n > 0)
+                  .map((x, i, arr) => <span key={x.k}>{i > 0 ? (i === arr.length - 1 ? " and " : ", ") : ""}{x.n} {x.k}{x.n === 1 ? "" : "s"}</span>)}.
+                The project page shows its objects, firings and agent runs.
+              </p>
+              <div className="btnrow">
+                <Link className="btn primary" to={`/projects/${encodeURIComponent(project.id)}`}>Open the project</Link>
+              </div>
+            </>
+          ) : (
+            <p className="help">Nothing was created. Start again with a fuller description, or <Link to="/projects/new">pick a template</Link>.</p>
+          )}
+        </div>
+      )}
+    </>
+  );
+}
+
+function PageHead() {
+  return (
+    <div className="pagehead">
+      <div>
+        <h1>Build with Tares</h1>
+        <p className="subtitle">
+          describe what you need; Tares proposes the sources, views, triggers and agent, and you
+          confirm each one in place. If you leave part way, what you created so far stays, real
+          and editable on its own page; the project page is where to pick it up.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+/** One assistant turn inside a step: text, the tool rail, and each proposal as a card the user
+ *  completes. Mirrors AskChat's Turn, with forms in place of Apply for sources and agents. */
+function TurnView({ turn, decisions, decide, own, thinking, specs, existing, refreshSources, sourceNames,
+                    createdTriggers, active }: {
+  turn: Turn; decisions: DecisionMap; thinking: boolean; active: boolean;
+  decide: (id: string, status: "applied" | "skipped" | "error", detail?: string) => void;
+  own: (kind: ProjectObjectKind, name: string) => Promise<void>;
+  specs: Record<string, ConnectorSpec>; existing: Source[]; refreshSources: () => void;
+  sourceNames: string[]; createdTriggers: string[];
+}) {
+  const blocks: ({ kind: "tools"; tools: ToolPart[] } | { kind: "part"; part: Part })[] = [];
+  for (const p of turn.parts) {
+    const last = blocks[blocks.length - 1];
+    if (p.type === "tool" && last && last.kind === "tools") last.tools.push(p);
+    else if (p.type === "tool") blocks.push({ kind: "tools", tools: [p] });
+    else blocks.push({ kind: "part", part: p });
+  }
+  return (
+    <div className="turn assistant" style={{ marginBottom: 8 }}>
+      {blocks.map((b, j) => {
+        if (b.kind === "tools") return <ToolRun key={j} tools={b.tools} />;
+        if (b.part.type === "text")
+          return <div key={j} className="md"><ReactMarkdown remarkPlugins={[remarkGfm]}>{b.part.text}</ReactMarkdown></div>;
+        if (b.part.type !== "proposal") return null;
+        const p = b.part.proposal;
+        const common = { decision: decisions[p.id], decide, own, active };
+        if (p.kind === "source")
+          return <SourceCard key={j} proposal={p} specs={specs} existing={existing} refreshSources={refreshSources} {...common} />;
+        if (p.kind === "agent")
+          return <AgentCard key={j} proposal={p} triggers={createdTriggers} {...common} />;
+        return <CatalogCard key={j} proposal={p} sourceNames={sourceNames} {...common} />;
+      })}
+      {thinking && <div className="dim">thinking…</div>}
+    </div>
+  );
+}
+
+type CardCommon = {
+  decision?: DecisionMap[string]; active: boolean;
+  decide: (id: string, status: "applied" | "skipped" | "error", detail?: string) => void;
+  own: (kind: ProjectObjectKind, name: string) => Promise<void>;
+};
+
+/** A proposed source as the connector form, prefilled, the `needs` fields highlighted. Test and
+ *  Create are the form's own; on create the project adopts the source. */
+function SourceCard({ proposal: p, specs, existing, refreshSources, decision, decide, own }: CardCommon & {
+  proposal: Extract<Proposal, { kind: "source" }>;
+  specs: Record<string, ConnectorSpec>; existing: Source[]; refreshSources: () => void;
+}) {
+  const known = Object.keys(specs).filter((k) => !specs[k].internal).sort();
+  const [connector, setConnector] = useState(p.connector);
+  const spec = specs[connector];
+  const unknown = Object.keys(specs).length > 0 && !specs[p.connector];
+  // the same name, unowned: adopt it instead of creating a second one
+  const twin = existing.find((s) => s.name === p.name && !s.owned_by);
+
+  // prefill from the proposal only while the connector is the proposed one; a switched
+  // connector starts from its own defaults. Fields in `needs` stay empty whatever the model sent.
+  const initial = useMemo(() => {
+    if (!spec) return undefined;
+    const config: Record<string, unknown> = {};
+    for (const f of spec.fields) {
+      if (f.secret || p.needs.includes(f.name)) continue;
+      if (connector === p.connector && p.config && p.config[f.name] !== undefined) config[f.name] = p.config[f.name];
+      else if (f.default != null && (f.type === "string" || f.type === "number")) config[f.name] = f.default;
+    }
+    return { name: p.name, type: "event_stream", poll: p.poll ?? spec.poll ?? "5s", config };
+  }, [spec, connector]);   // eslint-disable-line react-hooks/exhaustive-deps
+
+  const adopt = async () => {
+    try { await own("source", p.name); decide(p.id, "applied"); }
+    catch (e) { decide(p.id, "error", String((e as Error).message ?? e)); }
+  };
+
+  return (
+    <ProposalShell title={proposalTitle(p)} decision={decision} reasoning={p.reasoning}
+                   actions={(!decision || decision.status === "error") ? (
+                     <div className="btnrow"><button onClick={() => decide(p.id, "skipped")}>Skip</button></div>
+                   ) : null}>
+      <ProposalBody proposal={p} />
+      {(!decision || decision.status === "error") && (
+        <>
+          {unknown && (
+            <div className="alert error">
+              The connector <span className="mono">{p.connector}</span> is not installed here. Pick one below.
+            </div>
+          )}
+          {twin && (
+            <div className="alert">
+              A source named <span className="mono">{twin.name}</span> already exists and is not part of a project.{" "}
+              <button type="button" onClick={adopt}>Use the existing source</button>
+            </div>
+          )}
+          <div className="field">
+            <span className="lbl">connector</span>
+            <Picker value={connector} onChange={setConnector} options={known}
+                    labels={Object.fromEntries(known.map((k) => [k, specs[k].label ?? k]))} />
+          </div>
+          {spec && initial && (
+            <SourceForm key={connector} connector={connector} spec={spec} initial={initial}
+                        highlight={connector === p.connector ? p.needs : undefined}
+                        submitLabel="Create source"
+                        onSubmit={async (body) => {
+                          await api.createSource(body);
+                          refreshSources();
+                          try { await own("source", body.name); }
+                          catch (e) { decide(p.id, "error", String((e as Error).message ?? e)); return; }
+                          decide(p.id, "applied");
+                        }} />
+          )}
+        </>
+      )}
+    </ProposalShell>
+  );
+}
+
+/** A proposed view or trigger, or labels for a source: Apply as is, or Edit in the object's own
+ *  editor first. Either way the object is created through its API and appended to the project. */
+function CatalogCard({ proposal: p, sourceNames, decision, decide, own }: CardCommon & {
+  proposal: Extract<Proposal, { kind: "labels" | "view" | "trigger" }>;
+  sourceNames: string[];
+}) {
+  const [editing, setEditing] = useState(false);
+  const kind = kindOf(p);
+  const settle = async (name: string) => {
+    if (kind) {
+      try { await own(kind, name); }
+      catch (e) { decide(p.id, "error", String((e as Error).message ?? e)); return; }
+    }
+    decide(p.id, "applied");
+  };
+  const apply = async () => {
+    try { await applyProposal(p); }
+    catch (e) { decide(p.id, "error", String((e as Error).message ?? e)); return; }
+    await settle(p.kind === "labels" ? p.source : p.name);
+  };
+  const open = !decision || decision.status === "error";
+  return (
+    <ProposalShell title={proposalTitle(p)} decision={decision} reasoning={p.reasoning}
+                   actions={open ? (
+                     <div className="btnrow">
+                       {!editing && <button className="primary" onClick={apply}>{decision?.status === "error" ? "Retry" : "Apply"}</button>}
+                       {p.kind !== "labels" && <button onClick={() => setEditing((e) => !e)}>{editing ? "Close editor" : "Edit"}</button>}
+                       <button onClick={() => decide(p.id, "skipped")}>Skip</button>
+                     </div>
+                   ) : null}>
+      <ProposalBody proposal={p} />
+      {open && editing && p.kind === "view" && (
+        <ViewEditor prefill sourceNames={sourceNames}
+                    initial={{ name: p.name, key_field: p.key_field, sources: p.sources,
+                               filters: (p.filters ?? []) as unknown as ViewFilter[] } as View}
+                    onSaved={settle} onCancel={() => setEditing(false)} />
+      )}
+      {open && editing && p.kind === "trigger" && (
+        <TriggerEditor prefill presetView={p.view}
+                       initial={{ name: p.name, view: p.view, condition: p.condition,
+                                  emit: { kind: p.emit?.kind ?? p.name, context_window: p.emit?.context_window ?? "15m" },
+                                  cooldown: p.cooldown ?? "5m" } as Trigger}
+                       onSaved={settle} onCancel={() => setEditing(false)} />
+      )}
+    </ProposalShell>
+  );
+}
+
+/** The proposed agent as the agent form, prefilled. Create, then enable (which checks a key
+ *  resolves), then the project adopts it. */
+function AgentCard({ proposal: p, triggers, decision, decide, own }: CardCommon & {
+  proposal: Extract<Proposal, { kind: "agent" }>; triggers: string[];
+}) {
+  const [bundle, setBundle] = useState<{ presets: AgentPreset[]; models: string[]; default_model: string;
+    slack_workspace: boolean; default_max_rounds: number; default_max_rounds_with_mcp: number;
+    max_rounds_limit: number; key_configured: boolean }>();
+  const [allTriggers, setAllTriggers] = useState<string[]>();
+  const [note, setNote] = useState<string>();
+  useEffect(() => {
+    api.builtinAgents().then(setBundle).catch(() => {});
+    api.triggers().then((ts) => setAllTriggers(ts.map((t) => t.name))).catch(() => setAllTriggers(triggers));
+  }, []);   // eslint-disable-line react-hooks/exhaustive-deps
+
+  const initial: BuiltinAgent = {
+    name: p.name, trigger: p.trigger, prompt: p.prompt, enabled: false, slack_configured: false,
+    model: p.model ?? "", slack_channel: "", webhook_url: "", webhook_token_configured: false,
+    mcp_servers: [], max_rounds: p.max_rounds ?? null, budget_usd: p.budget_usd ?? null,
+    effective_max_rounds: p.max_rounds ?? 6,
+  };
+  const open = !decision || decision.status === "error";
+  const triggerNames = [...new Set([...(allTriggers ?? []), ...triggers])];
+  return (
+    <ProposalShell title={proposalTitle(p)} decision={decision} reasoning={p.reasoning}
+                   actions={open ? <div className="btnrow"><button onClick={() => decide(p.id, "skipped")}>Skip</button></div> : null}>
+      <ProposalBody proposal={p} />
+      {note && <div className="alert">{note}</div>}
+      {open && !triggerNames.includes(p.trigger) && (
+        <div className="alert">
+          The proposed trigger <span className="mono">{p.trigger}</span> does not exist; pick one of yours in the form.
+        </div>
+      )}
+      {open && bundle && allTriggers && (
+        <AgentForm prefill deliveryKind={p.delivery.kind} initial={initial}
+                   presetTrigger={triggerNames.includes(p.trigger) ? p.trigger : undefined}
+                   triggers={triggerNames} presets={bundle.presets} models={bundle.models}
+                   defaultModel={bundle.default_model} slackWorkspace={bundle.slack_workspace}
+                   defaultMaxRounds={bundle.default_max_rounds} defaultMaxRoundsWithMcp={bundle.default_max_rounds_with_mcp}
+                   maxRoundsLimit={bundle.max_rounds_limit}
+                   onSaved={async (name) => {
+                     // enable through the same endpoint the agent page uses: it refuses without a
+                     // key, so the agent cannot look enabled and then fail on the first firing
+                     try { await api.enableBuiltinAgent(name); }
+                     catch (e) { setNote(`Created, but not enabled: ${String((e as Error).message ?? e)}. Enable it on the agent's page once a key is set.`); }
+                     try { await own("agent", name); }
+                     catch (e) { decide(p.id, "error", String((e as Error).message ?? e)); return; }
+                     decide(p.id, "applied");
+                   }}
+                   onCancel={() => decide(p.id, "skipped")} />
+      )}
+      {open && (!bundle || !allTriggers) && <div className="dim">loading the agent form…</div>}
+    </ProposalShell>
+  );
+}

--- a/ui/src/pages/ProjectNewAssist.tsx
+++ b/ui/src/pages/ProjectNewAssist.tsx
@@ -572,7 +572,8 @@ function AgentCard({ proposal: p, triggers, decision, decide, own }: CardCommon 
 
   const initial: BuiltinAgent = {
     name: p.name, trigger: p.trigger, prompt: p.prompt, enabled: false, slack_configured: false,
-    model: p.model ?? "", slack_channel: "", webhook_url: "", webhook_token_configured: false,
+    model: p.model ?? "", slack_channel: "",
+    webhook_url: p.delivery.kind === "webhook" ? (p.delivery.url ?? "") : "", webhook_token_configured: false,
     mcp_servers: [], max_rounds: p.max_rounds ?? null, budget_usd: p.budget_usd ?? null,
     effective_max_rounds: p.max_rounds ?? 6,
   };

--- a/ui/src/pages/ProjectNewAssist.tsx
+++ b/ui/src/pages/ProjectNewAssist.tsx
@@ -29,14 +29,14 @@ import type { AgentPreset, BuiltinAgent, ConnectorSpec, Project, ProjectObjectKi
 // Secrets and Slack channels are never the model's to fill: a source proposal lists them in
 // `needs` and the form highlights them; an agent proposal picks only the delivery kind.
 
-type StepKey = "sources" | "views" | "triggers" | "agent";
-const STEPS: { key: StepKey; label: string }[] = [
-  { key: "sources", label: "Sources" },
-  { key: "views", label: "Views" },
-  { key: "triggers", label: "Triggers" },
-  { key: "agent", label: "Agent" },
+type StepKey = "sources" | "watch" | "agent";
+// Views and triggers are one step: the user thinks "what should fire" as one question.
+const STEPS: { key: StepKey; label: string; kinds: ProjectObjectKind[] }[] = [
+  { key: "sources", label: "Sources", kinds: ["source"] },
+  { key: "watch", label: "Views and triggers", kinds: ["view", "trigger"] },
+  { key: "agent", label: "Agent", kinds: ["agent"] },
 ];
-const NEXT: Record<StepKey, StepKey | "done"> = { sources: "views", views: "triggers", triggers: "agent", agent: "done" };
+const NEXT: Record<StepKey, StepKey | "done"> = { sources: "watch", watch: "agent", agent: "done" };
 
 type Part = { type: "text"; text: string } | ToolPart | { type: "proposal"; proposal: Proposal };
 type Turn = { parts: Part[] };
@@ -67,7 +67,7 @@ export default function ProjectNewAssist() {
   const [projectName, setProjectName] = useState("");
   const [step, setStep] = useState<StepKey | "describe" | "done">("describe");
   const [states, setStates] = useState<Record<StepKey, StepState>>({
-    sources: { turns: [] }, views: { turns: [] }, triggers: { turns: [] }, agent: { turns: [] },
+    sources: { turns: [] }, watch: { turns: [] }, agent: { turns: [] },
   });
   const [decisions, setDecisions] = useState<DecisionMap>({});
   const [history, setHistory] = useState<WireMessage[]>([]);
@@ -175,11 +175,9 @@ export default function ProjectNewAssist() {
     if (last) setHistory((h) => [...h.slice(0, -1), { role: "assistant", content: wireText(last, decisions) }]);
     if (next === "done") { setStep("done"); return; }
     setStep(next);
-    const framing = next === "views"
-      ? `Sources connected: ${created("source").join(", ") || "none"}. Now propose the views (and any labels they need) that correlate these sources for the goal. Check source_fields on each source first.`
-      : next === "triggers"
-      ? `Views created: ${created("view").join(", ") || "none"}. Now propose the triggers on these views for the goal.`
-      : `Triggers created: ${created("trigger").join(", ") || "none"}. Now propose the one Tares agent that runs when they fire, and its delivery kind.`;
+    const framing = next === "watch"
+      ? `Sources connected: ${created("source").join(", ") || "none"}. Now the views and triggers: what to correlate and what should fire, for the goal. Check source_fields on each source first. Ask me what you need to know before proposing thresholds or conditions I have not stated.`
+      : `Views created: ${created("view").join(", ") || "none"}; triggers created: ${created("trigger").join(", ") || "none"}. Now propose the one Tares agent that runs when they fire, and its delivery kind.`;
     await turn(next, framing);
   };
 
@@ -208,6 +206,10 @@ export default function ProjectNewAssist() {
   const proposalsInStep = step !== "describe" && step !== "done"
     ? states[step].turns.flatMap((t) => t.parts).filter((p) => p.type === "proposal").length
     : 0;
+  // A turn with text and no cards is the assistant asking: make the box read as the answer box.
+  const lastTurn = step !== "describe" && step !== "done" ? states[step].turns[states[step].turns.length - 1] : undefined;
+  const asking = !!lastTurn && !streaming && lastTurn.parts.some((p) => p.type === "text")
+    && !lastTurn.parts.some((p) => p.type === "proposal");
 
   return (
     <>
@@ -216,8 +218,8 @@ export default function ProjectNewAssist() {
         {STEPS.map((s, i) => (
           <span key={s.key} className={"step" + (i === stepIndex ? " active" : i < stepIndex ? " done" : "")}>
             <span className="n">{i + 1}</span>{s.label}
-            {i < stepIndex && created(s.key === "agent" ? "agent" : s.key.slice(0, -1) as ProjectObjectKind).length > 0 && (
-              <span className="badge ok">{created(s.key === "agent" ? "agent" : s.key.slice(0, -1) as ProjectObjectKind).length}</span>
+            {i < stepIndex && s.kinds.some((k) => created(k).length > 0) && (
+              <span className="badge ok">{s.kinds.reduce((n, k) => n + created(k).length, 0)}</span>
             )}
           </span>
         ))}
@@ -269,7 +271,7 @@ export default function ProjectNewAssist() {
                       createdTriggers={created("trigger")}
                       active={s.key === step} />
           ))}
-          {s.key === step && !streaming && states[s.key].turns.length > 0 && proposalsInStep === 0 && (
+          {s.key === step && !streaming && states[s.key].turns.length > 0 && proposalsInStep === 0 && !asking && (
             <div className="empty">
               {s.key === "sources"
                 ? <>No source was proposed. Say which systems you run and where (a container name, a URL, a repo), or <Link to="/sources/new">add a source by hand</Link> and come back to assemble the project from <Link to="/projects/new/custom">existing objects</Link>.</>
@@ -279,7 +281,8 @@ export default function ProjectNewAssist() {
           {s.key === step && (
             <>
               <div className="builder-refine">
-                <textarea value={refine} rows={1} placeholder="ask for a change, e.g. use the staging URL, or add the alerts too"
+                <textarea value={refine} rows={asking ? 2 : 1} autoFocus={asking}
+                          placeholder={asking ? "answer here, then Send" : "ask for a change, e.g. use the staging URL, or add the alerts too"}
                           onChange={(e) => setRefine(e.target.value)}
                           onKeyDown={(e) => { if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); sendRefine(); } }} />
                 {streaming

--- a/ui/src/pages/ProjectNewAssist.tsx
+++ b/ui/src/pages/ProjectNewAssist.tsx
@@ -5,6 +5,7 @@ import remarkGfm from "remark-gfm";
 
 import { api } from "../api";
 import AgentForm from "../components/AgentForm";
+import IngestSetup from "../components/IngestSetup";
 import { KeySetup, ToolRun } from "../components/AskChat";
 import type { ToolPart } from "../components/AskChat";
 import { Picker } from "../components/bits";
@@ -391,6 +392,12 @@ function SourceCard({ proposal: p, specs, existing, refreshSources, decision, de
   const known = Object.keys(specs).filter((k) => !specs[k].internal).sort();
   const [connector, setConnector] = useState(p.connector);
   const spec = specs[connector];
+  // After Create the form goes away, but a push source is useless until something posts to it:
+  // keep the ingest URL, the setup snippet and a link to the source on the card. Same show-once
+  // ingest key as the Sources page mints on a secured instance.
+  const [made, setMade] = useState<{ name: string; connector: string; ingestKey: string; authKey?: string; keyErr?: string }>();
+  const [authOn, setAuthOn] = useState(false);
+  useEffect(() => { api.health().then((h) => setAuthOn(h.auth_required)).catch(() => {}); }, []);
   const unknown = Object.keys(specs).length > 0 && !specs[p.connector];
   // the same name, unowned: adopt it instead of creating a second one
   const twin = existing.find((s) => s.name === p.name && !s.owned_by);
@@ -419,6 +426,9 @@ function SourceCard({ proposal: p, specs, existing, refreshSources, decision, de
                      <div className="btnrow"><button onClick={() => decide(p.id, "skipped")}>Skip</button></div>
                    ) : null}>
       <ProposalBody proposal={p} />
+      {decision?.status === "applied" && (
+        <CreatedSource made={made} name={p.name} specs={specs} />
+      )}
       {(!decision || decision.status === "error") && (
         <>
           {unknown && (
@@ -442,8 +452,14 @@ function SourceCard({ proposal: p, specs, existing, refreshSources, decision, de
                         highlight={connector === p.connector ? p.needs : undefined}
                         submitLabel="Create source"
                         onSubmit={async (body) => {
-                          await api.createSource(body);
+                          const res = await api.createSource(body);
                           refreshSources();
+                          let authKey: string | undefined, keyErr: string | undefined;
+                          if (spec.mode === "push" && authOn) {
+                            try { authKey = (await api.createKey(`ingest: ${body.name}`, ["ingest"])).secret; }
+                            catch (e) { keyErr = String((e as Error).message ?? e); }
+                          }
+                          setMade({ name: body.name, connector: body.connector, ingestKey: res.ingest_key || body.name, authKey, keyErr });
                           try { await own("source", body.name); }
                           catch (e) { decide(p.id, "error", String((e as Error).message ?? e)); return; }
                           decide(p.id, "applied");
@@ -452,6 +468,39 @@ function SourceCard({ proposal: p, specs, existing, refreshSources, decision, de
         </>
       )}
     </ProposalShell>
+  );
+}
+
+/** What an applied source card keeps showing: where it lives, and for a push source the ingest
+ *  URL and setup snippet, because nothing arrives until a producer posts to it. */
+function CreatedSource({ made, name, specs }: {
+  made?: { name: string; connector: string; ingestKey: string; authKey?: string; keyErr?: string };
+  name: string; specs: Record<string, ConnectorSpec>;
+}) {
+  const [copied, setCopied] = useState(false);
+  const n = made?.name ?? name;
+  const push = made ? specs[made.connector]?.mode === "push" : false;
+  const url = made ? (made.connector === "otlp" ? `${window.location.origin}/v1/logs` : `${window.location.origin}/ingest/${made.ingestKey}`) : "";
+  return (
+    <div style={{ margin: "0 0 10px" }}>
+      <p className="help" style={{ margin: "0 0 6px" }}>
+        Created. <Link to={`/sources/${encodeURIComponent(n)}`}>Open the source</Link>
+        {push ? " to see events as they arrive." : " to see its first poll."}
+      </p>
+      {push && made && (
+        <>
+          <div className="field">
+            <span className="lbl">send events here</span>
+            <span className="mono" style={{ wordBreak: "break-all" }}>{url}</span>{" "}
+            <button type="button" onClick={() => { navigator.clipboard?.writeText(url); setCopied(true); setTimeout(() => setCopied(false), 1500); }}>
+              {copied ? "copied" : "copy"}
+            </button>
+          </div>
+          {made.keyErr && <div className="alert error">could not mint an ingest key: {made.keyErr}. Create one under Settings.</div>}
+          <IngestSetup connector={made.connector} url={url} authKey={made.authKey} />
+        </>
+      )}
+    </div>
   );
 }
 

--- a/ui/src/pages/ProjectShell.tsx
+++ b/ui/src/pages/ProjectShell.tsx
@@ -536,7 +536,7 @@ export default function ProjectShell({ s, id, reload, template }: {
                 })}
               </tbody>
             </table>
-          ) : !dispatchesError && <p className="help">no firings yet across this project's triggers</p>}
+          ) : !dispatchesError && <div className="empty">no firings yet across this project's triggers</div>}
         </>
       )}
 

--- a/ui/src/pages/ProjectShell.tsx
+++ b/ui/src/pages/ProjectShell.tsx
@@ -494,7 +494,7 @@ export default function ProjectShell({ s, id, reload, template }: {
               })}
             </tbody>
           </table>
-        ) : <p className="help">nothing ingested yet across this project's sources</p>
+        ) : <div className="empty">nothing ingested yet across this project's sources</div>
       )}
 
       {tab === "firings" && (

--- a/ui/src/pages/ProjectShell.tsx
+++ b/ui/src/pages/ProjectShell.tsx
@@ -7,10 +7,11 @@ import TriggerEditor from "../components/TriggerEditor";
 import ViewEditor from "../components/ViewEditor";
 import { Combo, Picker, ErrorState, TimeAgo, usePolling } from "../components/bits";
 import AgentForm from "../components/AgentForm";
+import IngestEndpoint from "../components/IngestEndpoint";
 import InfoDialog, { HelpButton } from "../components/InfoDialog";
 import { SessionsPanel } from "../components/ChallengerSessions";
 import { RunsTable } from "./AgentDetail";
-import type { ProjectSummary, Template, RecipeActionOption } from "../types";
+import type { ConnectorSpec, ProjectSummary, Template, RecipeActionOption, Source } from "../types";
 
 // The page for every project: what a project really is, on one page, driven by the live APIs
 // plus the template's summary. Setup (sources, views and triggers, the latter two editable in
@@ -51,6 +52,7 @@ export default function ProjectShell({ s, id, reload, template }: {
 
   const names = (kind: string) => s.objects.filter((o) => o.kind === kind).map((o) => o.name);
   const { data: sources, reload: reloadSources } = usePolling(() => api.sources(), 10000);
+  const { data: specs } = usePolling(() => api.connectors(), 600000);
   const { data: views, reload: reloadViews } = usePolling(() => api.views(), 10000);
   const { data: triggers, reload: reloadTriggers } = usePolling(() => api.triggers(), 10000);
   const { data: dispatches, error: dispatchesError } = usePolling(() => api.dispatches(100), 10000);
@@ -321,19 +323,9 @@ export default function ProjectShell({ s, id, reload, template }: {
           <h2>Sources</h2>
           {mySources.length ? (
             <table>
-              <thead><tr><th>source</th><th>type</th><th>status</th><th className="num">events</th><th>last ingest</th></tr></thead>
+              <thead><tr><th style={{ width: 24 }}></th><th>source</th><th>type</th><th>status</th><th className="num">events</th><th>last ingest</th></tr></thead>
               <tbody>
-                {mySources.map((x) => (
-                  <tr key={x.name} className="clickable" onClick={() => navigate(`/sources/${encodeURIComponent(x.name)}`)}>
-                    <td className="mono">{x.name}</td>
-                    <td><span className="chip">{x.connector}</span></td>
-                    <td>{x.paused ? <span className="badge paused">paused</span>
-                      : x.health?.last_error ? <span className="badge error" title={x.health.last_error}>error</span>
-                      : <span className="badge ok">ok</span>}</td>
-                    <td className="num">{(x.health?.events_total ?? 0).toLocaleString()}</td>
-                    <td><TimeAgo ts={x.health?.last_ingest ?? null} /></td>
-                  </tr>
-                ))}
+                {mySources.map((x) => <SourceRow key={x.name} x={x} spec={specs?.[x.connector]} />)}
               </tbody>
             </table>
           ) : <p className="help">none in this project</p>}
@@ -609,6 +601,55 @@ export default function ProjectShell({ s, id, reload, template }: {
 
 // One view, as its own page shows it (key field, sources, filters, author, usage), with the same
 // in-place editor. "+ trigger" preselects this view on the trigger form.
+/** One source, folded: the row is the health line; opening it shows what a producer needs (the
+ *  ingest endpoint for a push source, the polled target for a poll one) with a Configure button
+ *  to the source page. A builder-made project is looked at here first, and a push source is
+ *  nothing until something posts to it, so the address has to be one click away, not one page. */
+function SourceRow({ x, spec }: { x: Source; spec?: ConnectorSpec }) {
+  const navigate = useNavigate();
+  const [open, setOpen] = useState(false);
+  const push = spec?.mode === "push";
+  // the polled target in plain fields: non-secret string/number values the connector declares
+  const shown = (spec?.fields ?? [])
+    .filter((f) => !f.secret && (f.type === "string" || f.type === "number") && x.config?.[f.name] !== undefined && x.config?.[f.name] !== "")
+    .map((f) => ({ name: f.name, value: String(x.config[f.name]) }));
+  return (
+    <>
+      <tr className="clickable" onClick={() => setOpen((o) => !o)}>
+        <td className="dim">{open ? "▾" : "▸"}</td>
+        <td className="mono">{x.name}</td>
+        <td><span className="chip">{x.connector}</span></td>
+        <td>{x.paused ? <span className="badge paused">paused</span>
+          : x.health?.last_error ? <span className="badge error" title={x.health.last_error}>error</span>
+          : <span className="badge ok">ok</span>}</td>
+        <td className="num">{(x.health?.events_total ?? 0).toLocaleString()}</td>
+        <td><TimeAgo ts={x.health?.last_ingest ?? null} /></td>
+      </tr>
+      {open && (
+        <tr>
+          <td></td>
+          <td colSpan={5} style={{ paddingTop: 10, paddingBottom: 14 }}>
+            {push ? <IngestEndpoint source={x} /> : shown.length > 0 ? (
+              <table style={{ marginBottom: 10 }}>
+                <tbody>
+                  {shown.map((f) => (
+                    <tr key={f.name}><td className="help" style={{ width: 180 }}>{f.name}</td><td className="mono" style={{ wordBreak: "break-all" }}>{f.value}</td></tr>
+                  ))}
+                  <tr><td className="help">poll</td><td className="mono">{x.poll}</td></tr>
+                </tbody>
+              </table>
+            ) : <p className="help">polls every {x.poll}</p>}
+            {x.health?.last_error && <div className="alert error" style={{ marginBottom: 10 }}>{x.health.last_error}</div>}
+            <div className="btnrow">
+              <button className="primary" onClick={() => navigate(`/sources/${encodeURIComponent(x.name)}`)}>Configure</button>
+            </div>
+          </td>
+        </tr>
+      )}
+    </>
+  );
+}
+
 function ViewPanel({ v, sourceNames, watchers, onSaved }: {
   v: import("../types").View; sourceNames: string[]; watchers: number; onSaved: () => void;
 }) {

--- a/ui/src/pages/SourceDetail.tsx
+++ b/ui/src/pages/SourceDetail.tsx
@@ -4,7 +4,7 @@ import { Link, useNavigate, useParams } from "react-router-dom";
 import { api } from "../api";
 import ConfirmDialog from "../components/ConfirmDialog";
 import ProjectBadge from "../components/ProjectBadge";
-import IngestSetup from "../components/IngestSetup";
+import IngestEndpoint from "../components/IngestEndpoint";
 import SourceForm from "../components/SourceForm";
 import { ErrorState, StatusBadge, TimeAgo, ruleSummary, usePolling } from "../components/bits";
 import type { ConnectorSpec, Source } from "../types";
@@ -366,42 +366,3 @@ function FieldsPanel({ name, source }: { name: string; source: Source }) {
   );
 }
 
-function CopyableUrl({ url }: { url: string }) {
-  const [copied, setCopied] = useState(false);
-  return (
-    <div className="ingest-url">
-      <code className="mono">{url}</code>
-      <button onClick={() => {
-        navigator.clipboard?.writeText(url);
-        setCopied(true);
-        setTimeout(() => setCopied(false), 1500);
-      }}>{copied ? "copied" : "copy"}</button>
-    </div>
-  );
-}
-
-// The full, copyable ingest URL — built from the browser's own origin, so it's correct wherever the
-// console is served. The URL is an address (always shown here); on a secured instance IngestSetup
-// adds the auth-key guidance. OTLP uses the /v1/* endpoints (source chosen by header), no path key.
-function IngestEndpoint({ source }: { source: Source }) {
-  const origin = window.location.origin;
-  if (source.connector === "otlp") {
-    return (
-      <div className="card ingest-card">
-        <div className="k">OTLP endpoint</div>
-        <CopyableUrl url={`${origin}/v1/logs`} />
-        <p className="muted">Point an OTLP/HTTP exporter here (also <span className="mono">/v1/traces</span>, <span className="mono">/v1/metrics</span>).</p>
-        <IngestSetup connector="otlp" url={`${origin}/v1/logs`} />
-      </div>
-    );
-  }
-  const url = `${origin}/ingest/${source.ingest_key || source.name}`;
-  return (
-    <div className="card ingest-card">
-      <div className="k">ingest endpoint · POST</div>
-      <CopyableUrl url={url} />
-      <p className="muted">Point your producer (e.g. a Vercel log drain) at this URL.</p>
-      <IngestSetup connector={source.connector} url={url} />
-    </div>
-  );
-}

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -393,7 +393,8 @@ thead th {
 }
 thead th.num { text-align: right; }
 tbody td { padding: 10px 14px; border-bottom: 1px solid var(--line); vertical-align: top; }
-tbody tr:last-child td { border-bottom: none; }
+/* direct children only: a table nested inside the last row (a folded source on the project page) keeps its own row lines */
+tbody > tr:last-child > td { border-bottom: none; }
 tbody tr.clickable { cursor: pointer; }
 tbody tr.clickable:hover { background: var(--row-hover); }
 tbody tr.sel, tbody tr.sel:hover { background: var(--accent-soft); }

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -557,6 +557,18 @@ label.field .help, div.field > .help { display: block; font-size: 12px; color: v
 .fld-ctrl { display: flex; flex-direction: column; }
 .fld-row.invalid input, .fld-row.invalid select, .fld-row.invalid textarea { border-color: var(--err); background: var(--err-soft); }
 .fld-row.invalid .help { color: var(--err); }
+/* a builder proposal's `needs`: the fields only the user can fill (a token, a URL) */
+.fld-row.needs input, .fld-row.needs select, .fld-row.needs textarea { border-color: var(--accent); background: var(--accent-soft); }
+
+/* The AI-guided project builder (ProjectNewAssist): one column of step panels; the strip on top
+   says where you are. */
+.builder-steps { display: flex; gap: 6px; flex-wrap: wrap; margin: 0 0 14px; }
+.builder-steps .step { display: inline-flex; align-items: center; gap: 6px; padding: 4px 10px; border: 1px solid var(--line); font-size: 12px; color: var(--ink-soft); }
+.builder-steps .step.active { border-color: var(--accent); color: var(--ink); }
+.builder-steps .step.done { color: var(--ok); border-color: var(--ok-border); }
+.builder-steps .step .n { font-family: var(--mono); font-size: 11px; }
+.builder-refine { display: flex; gap: 8px; align-items: flex-start; margin-top: 10px; }
+.builder-refine textarea { flex: 1; min-height: 38px; }
 /* field grouping (postgres) */
 .fld-group { margin: 4px 0; }
 .fld-group-head h3 { margin: 20px 0 2px; font-size: 15px; font-weight: 600; }


### PR DESCRIPTION
Linear: AI-guided project builder (TR-242 to TR-247).

## What

A new way to create a project: "Build with Tares" on the new-project gallery, at `/projects/new/assist`. Describe what you need; the assistant proposes the pieces one step at a time, and you complete each proposal in the object's own form. Every Apply creates a real object through its normal API and adds it to an ordinary `custom` project, so the result renders on ProjectShell like any other project and leaving part way keeps what was created.

Steps: Describe, Sources, Views and triggers (one step: the user thinks "what should fire" as one question), Agent, Done.

## Backend

- `POST /api/agent/chat` takes `mode: "build"` and `step` (`sources`, `watch`, `agent`). No new endpoints.
- Two new proposal tools in `tares/agent.py`: `propose_source` (non-secret config plus a `needs` list of fields the user must fill) and `propose_agent` (delivery kind, plus a webhook URL only when the user typed one).
- `tools_for(mode, step)` gives each build step only its own proposal tools, so an out-of-order card is impossible at the schema level. The build guidance is a section appended to the existing system prompt.
- The build prompt makes the model ask before it guesses: up to three short questions and no cards when the goal leaves a real choice open (which API, which places, which thresholds, what the agent should do), and never restate a card as text.

## Console

- Shared `useAgentStream` hook (fetch, SSE parse, Stop); AskChat refactored onto it, behaviour preserved.
- `ProposalShell` and `ProposalBody` extracted from the Ask cards; `source` and `agent` proposal kinds added.
- Source cards render `SourceForm` inline, prefilled, with the `needs` fields marked and a connector switcher; after Create the card keeps the ingest URL and setup snippet. View and trigger cards apply directly or open the existing editors (`prefill` prop). The agent card renders `AgentForm` prefilled, then creates, enables and adopts.
- Project page: source rows fold open to the ingest endpoint (push) or polled target (poll) with a Configure button; `IngestEndpoint` moved to a shared component. Framed empty states for runs, firings and events. The last-row table border rule no longer reaches into nested tables.

## Tests

`tests/test_agent_build.py` (toolsets, schemas, prompt, endpoint) and `tests/test_builder_flow.py` (the real create-then-append sequence through the API, ownership, name collision, enable, delete releases), both in CI. Walked end to end against the demo stack and a weather webhook example on the local console.

## Not in this PR

The product docs page (docs repo). A generic HTTP poll connector came up in testing as the better fit for "poll an external API"; that is a new connector, separate work.