### PR TITLE
Agent runs: filter by status, Show more

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Backend — install + tests
         run: |
           pip install -e .
-          for t in test_labels test_normalize test_auth test_api_keys test_pricing test_agents test_catalog_sync test_cli test_status test_usage test_slack test_slack_verify test_slack_ask test_degraded test_loki test_projects test_rius_rca test_ai_sre_demo test_seed test_session_flow test_challenger_workflow test_plugin_challenger test_tracing; do
+          for t in test_labels test_normalize test_auth test_api_keys test_pricing test_agents test_catalog_sync test_cli test_status test_usage test_slack test_slack_verify test_slack_ask test_degraded test_loki test_projects test_rius_rca test_ai_sre_demo test_seed test_session_flow test_challenger_workflow test_plugin_challenger test_tracing test_agent_runs_filter; do
             echo "== $t =="
             python "tests/$t.py"
           done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ the project follows [Semantic Versioning](https://semver.org/).
 - The root span of a traced run carries `tares.instance` and `tares.agent` as span attributes,
   not only on the resource, so a backend's span view shows which instance sent it.
 
+### Added
+- Runs on an agent's page and on a project's Agents tab can be filtered to successful or failed
+  runs only, and "Show more" pages past the first fifty. `GET /api/agents/builtin/{name}/runs`
+  takes `status` and `offset`.
+
 ### Fixed
 - Edit on a project built from a template without its own wizard (Rius RCA among them) opened the
   create form and said "this instance has no project named rius_rca". The form now loads the

--- a/tares/daemon.py
+++ b/tares/daemon.py
@@ -1789,13 +1789,20 @@ def make_app() -> FastAPI:
             _err(ValueError(f"the agent is already running for {run['key']!r}"), 409)
         return {"ok": True, "run_id": rid, "rerun_of": run_id}
 
+    _RUN_STATUSES = {"running", "ok", "empty", "failed", "capped", "exhausted"}
+
     @app.get("/api/agents/builtin/{name}/runs")
-    async def builtin_agent_runs(name: str, limit: int = 50):
+    async def builtin_agent_runs(name: str, limit: int = 50, offset: int = 0, status: str = ""):
         """The operational record — status, duration, errors. Distinct from findings, which are
-        events on the entity's timeline; a failed run must never look like a conclusion."""
+        events on the entity's timeline; a failed run must never look like a conclusion.
+        `status` narrows to one run status; `offset` pages (a capped agent's list is mostly
+        capped rows, and the ok runs are what a reader looks for, TR-267)."""
         if store.get_catalog_agent(name) is None:
             _err(KeyError(f"unknown agent {name!r}"), 404)
-        return store.list_agent_runs(name, limit=min(limit, 200))
+        if status and status not in _RUN_STATUSES:
+            _err(ValueError(f"status must be one of {', '.join(sorted(_RUN_STATUSES))}"), 400)
+        return store.list_agent_runs(name, limit=min(max(1, limit), 200), offset=offset,
+                                     status=status or None)
 
     # ── the Anthropic key: a stored key wins, env is the fallback ────────────
     @app.get("/api/settings/anthropic-key")

--- a/tares/store.py
+++ b/tares/store.py
@@ -1038,18 +1038,26 @@ class Store:
                                  "FROM agent_runs WHERE agent = ?", [agent]).fetchone()
         return (int(r[0]), int(r[1])) if r else (0, 0)
 
-    def list_agent_runs(self, agent: str | None = None, limit: int = 50) -> list[dict]:
+    def list_agent_runs(self, agent: str | None = None, limit: int = 50, offset: int = 0,
+                        status: str | None = None) -> list[dict]:
+        """Newest first. `status` narrows to one run status (ok, failed, capped, ...); `offset`
+        pages, so a console can show more without re-reading what it has."""
         sql = ("SELECT id, agent, trigger, dispatch_id, key_value, status, rounds, tool_calls, "
                "started_at, duration_ms, finding, error, external_tools, max_rounds, "
                "model, input_tokens, output_tokens, cache_creation_input_tokens, "
                "cache_read_input_tokens, cost_usd "
                "FROM agent_runs ")
-        params: list = []
+        where, params = [], []
         if agent:
-            sql += "WHERE agent = ? "
+            where.append("agent = ?")
             params.append(agent)
-        sql += "ORDER BY started_at DESC LIMIT ?"
-        params.append(int(limit))
+        if status:
+            where.append("status = ?")
+            params.append(status)
+        if where:
+            sql += "WHERE " + " AND ".join(where) + " "
+        sql += "ORDER BY started_at DESC LIMIT ? OFFSET ?"
+        params += [int(limit), max(0, int(offset))]
         with self._lock:
             rows = self.con.execute(sql, params).fetchall()
         return [

--- a/tests/test_agent_runs_filter.py
+++ b/tests/test_agent_runs_filter.py
@@ -1,0 +1,88 @@
+"""Runs list paging and status filter (TR-267): GET /api/agents/builtin/{name}/runs takes
+`status` and `offset`, so a console can show only the successful runs of an agent whose list is
+mostly capped rows, and keep paging past the first page.
+
+Run: .venv/bin/python tests/test_agent_runs_filter.py
+"""
+import asyncio
+import os
+
+DB = "/tmp/tares-runs-filter.duckdb"
+os.environ["TARES_DB"] = DB
+os.environ["TARES_CATALOG"] = "/tmp/tares-runs-filter.catalog.yaml"
+for _p in (DB, DB + ".wal", os.environ["TARES_CATALOG"]):
+    if os.path.exists(_p):
+        os.remove(_p)
+
+import httpx
+
+P = F = 0
+
+
+def ck(label, cond, detail=""):
+    global P, F
+    P += 1 if cond else 0
+    F += 0 if cond else 1
+    print(("  ok   " if cond else "  FAIL ") + label + ("" if cond else f"  {detail}"))
+
+
+async def main():
+    from tares.daemon import make_app
+    app = make_app()
+    async with app.router.lifespan_context(app):
+        cx = httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://t")
+        store = app.state.store
+
+        r = await cx.post("/api/sources", json={
+            "name": "evt", "connector": "webhook", "poll": "5s",
+            "config": {"event_type": "log", "text_template": "{msg}",
+                       "labels": [{"name": "service", "field": "service", "primary": True}]}})
+        ck("source", r.status_code == 201, r.text)
+        r = await cx.post("/api/views", json={"name": "v", "key_field": "service", "sources": ["evt"]})
+        ck("view", r.status_code == 201, r.text)
+        r = await cx.post("/api/triggers", json={
+            "name": "t", "view": "v", "condition": {"aggregate": "count", "predicate": "> 0", "window": "1m"},
+            "emit": {"kind": "x"}, "cooldown": "1m"})
+        ck("trigger", r.status_code == 201, r.text)
+        r = await cx.post("/api/agents/builtin", json={"name": "a", "trigger": "t", "prompt": "look"})
+        ck("agent", r.status_code == 201, r.text)
+
+        # 60 capped, 7 ok, 3 failed, newest last so ordering is observable
+        statuses = ["capped"] * 60 + ["ok"] * 7 + ["failed"] * 3
+        for i, st in enumerate(statuses):
+            rid = f"run{i:03d}"
+            store.start_agent_run(rid, "a", "t", f"d{i}", f"svc{i}", "h", 6)
+            store.finish_agent_run(rid, st, rounds=1 if st == "ok" else 0,
+                                   finding="found" if st == "ok" else None,
+                                   error="boom" if st == "failed" else None)
+
+        print("== default page ==")
+        page = (await cx.get("/api/agents/builtin/a/runs")).json()
+        ck("default limit is 50, newest first", len(page) == 50 and page[0]["id"] == "run069", str(len(page)))
+
+        print("== status filter ==")
+        ok = (await cx.get("/api/agents/builtin/a/runs?status=ok")).json()
+        ck("status=ok returns only the ok runs", len(ok) == 7 and all(x["status"] == "ok" for x in ok), str(len(ok)))
+        failed = (await cx.get("/api/agents/builtin/a/runs?status=failed")).json()
+        ck("status=failed returns only the failed runs", len(failed) == 3 and all(x["status"] == "failed" for x in failed))
+        r = await cx.get("/api/agents/builtin/a/runs?status=nope")
+        ck("unknown status -> 400", r.status_code == 400, r.text)
+
+        print("== paging ==")
+        first = (await cx.get("/api/agents/builtin/a/runs?limit=50&offset=0")).json()
+        second = (await cx.get("/api/agents/builtin/a/runs?limit=50&offset=50")).json()
+        ids = [x["id"] for x in first] + [x["id"] for x in second]
+        ck("offset pages through all 70 with no overlap", len(second) == 20 and len(set(ids)) == 70, str(len(second)))
+        ok2 = (await cx.get("/api/agents/builtin/a/runs?status=ok&limit=5&offset=5")).json()
+        ck("filter and offset combine", len(ok2) == 2 and all(x["status"] == "ok" for x in ok2), str(ok2))
+        big = (await cx.get("/api/agents/builtin/a/runs?limit=1000")).json()
+        ck("limit is capped at 200 (here: everything)", len(big) == 70)
+
+        r = await cx.get("/api/agents/builtin/ghost/runs")
+        ck("unknown agent -> 404", r.status_code == 404)
+        await cx.aclose()
+    print(f"\n{P} passed, {F} failed")
+    raise SystemExit(1 if F else 0)
+
+
+asyncio.run(main())

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -165,8 +165,9 @@ export const api = {
   deleteBuiltinAgent: (name: string) => request(`/api/agents/builtin/${name}`, { method: "DELETE" }),
   enableBuiltinAgent: (name: string) => request(`/api/agents/builtin/${name}/enable`, { method: "POST" }),
   disableBuiltinAgent: (name: string) => request(`/api/agents/builtin/${name}/disable`, { method: "POST" }),
-  builtinAgentRuns: (name: string, limit = 20) =>
-    request<AgentRun[]>(`/api/agents/builtin/${name}/runs?limit=${limit}`),
+  builtinAgentRuns: (name: string, limit = 20, offset = 0, status = "") =>
+    request<AgentRun[]>(`/api/agents/builtin/${encodeURIComponent(name)}/runs?limit=${limit}&offset=${offset}`
+      + (status ? `&status=${encodeURIComponent(status)}` : "")),
   rerunAgentRun: (name: string, runId: string) =>
     request<{ ok: boolean; run_id: string }>(
       `/api/agents/builtin/${encodeURIComponent(name)}/runs/${encodeURIComponent(runId)}/rerun`,

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -7,7 +7,7 @@ import { api } from "../api";
 import AgentForm from "../components/AgentForm";
 import ConfirmDialog from "../components/ConfirmDialog";
 import ProjectBadge from "../components/ProjectBadge";
-import { ErrorState, TimeAgo, fmtCost, fmtTokens, usePolling } from "../components/bits";
+import { ErrorState, Picker, TimeAgo, fmtCost, fmtTokens, usePolling } from "../components/bits";
 import type { AgentRun, BuiltinAgent } from "../types";
 
 // Everything about one Tares agent, run like an operational surface rather than a config sheet:
@@ -192,7 +192,7 @@ export default function AgentDetail() {
       )}
 
       {tab === "runs" && (
-        <RunsTable runs={runs} runsError={runsError} agent={agent}
+        <RunsPanel name={name} agent={agent}
                    focusDispatch={focusDispatch} focusRun={focusRun}
                    openRun={openRun} setOpenRun={setOpenRun} />
       )}
@@ -267,10 +267,72 @@ export default function AgentDetail() {
   );
 }
 
-export function RunsTable({ runs, runsError, agent, focusDispatch, focusRun, openRun, setOpenRun }: {
+const RUNS_PAGE = 50;
+type RunFilter = "" | "ok" | "failed";
+const RUN_FILTERS: RunFilter[] = ["", "ok", "failed"];
+const RUN_FILTER_LABELS: Record<string, string> = { "": "all runs", ok: "successful only", failed: "failed only" };
+
+/** The runs list with its controls: a status filter and Show more. A capped agent's list is
+ *  mostly capped rows and the ok runs are what a reader looks for (TR-267), so the filter is
+ *  server-side and paging continues past the first page rather than stopping at a cap.
+ *
+ *  The newest page is polled; older pages are fetched once with an offset and kept until the
+ *  filter changes. A run that lands while paging shifts the offsets by one, so the two are
+ *  merged by id. */
+export function RunsPanel({ name, agent, focusDispatch, focusRun, openRun, setOpenRun }: {
+  name: string;
+  agent: BuiltinAgent;
+  focusDispatch?: string;
+  focusRun?: string;
+  openRun: string | undefined;
+  setOpenRun: (id: string | undefined) => void;
+}) {
+  const [filter, setFilter] = useState<RunFilter>("");
+  const [older, setOlder] = useState<AgentRun[]>([]);
+  const [hasMore, setHasMore] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const { data: head, error, reload } = usePolling(() => api.builtinAgentRuns(name, RUNS_PAGE, 0, filter), 10000);
+  useEffect(() => { setOlder([]); setHasMore(true); reload(); }, [filter]);   // eslint-disable-line react-hooks/exhaustive-deps
+
+  const seen = new Set<string>();
+  const runs = head === undefined ? undefined
+    : [...head, ...older].filter((r) => (seen.has(r.id) ? false : (seen.add(r.id), true)));
+  const more = async () => {
+    if (!runs) return;
+    setLoadingMore(true);
+    try {
+      const page = await api.builtinAgentRuns(name, RUNS_PAGE, runs.length, filter);
+      setOlder((o) => [...o, ...page]);
+      setHasMore(page.length >= RUNS_PAGE);
+    } catch { setHasMore(false); }
+    setLoadingMore(false);
+  };
+  const empty = filter === "ok" ? "no successful runs yet"
+    : filter === "failed" ? "no failed runs"
+    : <>no runs yet; this agent runs when <span className="mono">{agent.trigger}</span> fires</>;
+  return (
+    <>
+      <div className="btnrow" style={{ marginBottom: 8 }}>
+        <Picker value={filter} onChange={(v) => setFilter(v as RunFilter)} options={RUN_FILTERS}
+                labels={RUN_FILTER_LABELS} ariaLabel="filter runs" />
+      </div>
+      <RunsTable runs={runs} runsError={error} agent={agent} emptyText={empty}
+                 focusDispatch={focusDispatch} focusRun={focusRun}
+                 openRun={openRun} setOpenRun={setOpenRun} />
+      {runs && runs.length >= RUNS_PAGE && hasMore && (
+        <div className="btnrow" style={{ marginTop: 8 }}>
+          <button onClick={more} disabled={loadingMore}>{loadingMore ? "loading…" : "Show more"}</button>
+        </div>
+      )}
+    </>
+  );
+}
+
+export function RunsTable({ runs, runsError, agent, emptyText, focusDispatch, focusRun, openRun, setOpenRun }: {
   runs: AgentRun[] | undefined;
   runsError: string | undefined;
   agent: BuiltinAgent;
+  emptyText?: React.ReactNode;
   focusDispatch?: string;
   focusRun?: string;
   openRun: string | undefined;
@@ -278,7 +340,7 @@ export function RunsTable({ runs, runsError, agent, focusDispatch, focusRun, ope
 }) {
   if (runsError) return <ErrorState error={runsError} what="this agent’s runs" />;
   if (!runs?.length) {
-    return <p className="help">none yet; this agent runs when <span className="mono">{agent.trigger}</span> fires</p>;
+    return <div className="empty">{emptyText ?? <>no runs yet; this agent runs when <span className="mono">{agent.trigger}</span> fires</>}</div>;
   }
   const isFocused = (r: AgentRun) =>
     (!!focusDispatch && r.dispatch_id === focusDispatch) || (!!focusRun && r.id === focusRun);

--- a/ui/src/pages/ProjectShell.tsx
+++ b/ui/src/pages/ProjectShell.tsx
@@ -9,7 +9,7 @@ import { Combo, Picker, ErrorState, TimeAgo, usePolling } from "../components/bi
 import AgentForm from "../components/AgentForm";
 import InfoDialog, { HelpButton } from "../components/InfoDialog";
 import { SessionsPanel } from "../components/ChallengerSessions";
-import { RunsTable } from "./AgentDetail";
+import { RunsPanel } from "./AgentDetail";
 import type { ProjectSummary, Template, RecipeActionOption } from "../types";
 
 // The page for every project: what a project really is, on one page, driven by the live APIs
@@ -740,7 +740,7 @@ function AgentSection({ name, focusDispatch, triggerInProject, onShowTrigger }: 
   const [openRun, setOpenRun] = useState<string>();
   const [editing, setEditing] = useState(false);
   const { data, error, reload } = usePolling(() => api.builtinAgents(), 10000);
-  const { data: runs, error: runsError } = usePolling(() => api.builtinAgentRuns(name, 50), 10000);
+  const { data: runs } = usePolling(() => api.builtinAgentRuns(name, 1), 10000);   // the latest, for the overview row
   const [err, setErr] = useState<string>();
   if (error) return <div className="alert error">{error}</div>;
   if (!data) return <div className="dim">loading…</div>;
@@ -818,7 +818,7 @@ function AgentSection({ name, focusDispatch, triggerInProject, onShowTrigger }: 
         </div>
       )}
       <h3 style={{ margin: "12px 0 6px" }}>Runs</h3>
-      <RunsTable runs={runs} runsError={runsError} agent={agent}
+      <RunsPanel name={name} agent={agent}
                  focusDispatch={focusDispatch} focusRun={undefined}
                  openRun={openRun} setOpenRun={setOpenRun} />
     </div>


### PR DESCRIPTION
Linear: TR-267.

The Rius RCA agent's runs list is mostly capped rows, and the list stopped at fifty, so the runs worth reading were hard to find.

- `GET /api/agents/builtin/{name}/runs` takes `status` (one of running, ok, empty, failed, capped, exhausted; 400 otherwise) and `offset`. Store query gains the same two.
- Console: a `RunsPanel` above the runs table on the agent page and on the project Agents tab, with a picker (all runs, successful only, failed only) and a Show more button. The newest page is polled; older pages are fetched once with an offset and merged by id, so a run landing while paging does not duplicate a row. Empty states name the filter ("no successful runs yet").
- The runs empty state is the framed box the table uses.
- `tests/test_agent_runs_filter.py` (paging, filter, combined, bad status), added to CI.