### PR TITLE
Delete takes dependents along

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Backend — install + tests
         run: |
           pip install -e .
-          for t in test_labels test_normalize test_auth test_api_keys test_pricing test_agents test_catalog_sync test_cli test_status test_usage test_slack test_slack_verify test_slack_ask test_degraded test_loki test_projects test_rius_rca test_ai_sre_demo test_seed test_session_flow test_challenger_workflow test_plugin_challenger test_tracing test_agent_runs_filter; do
+          for t in test_labels test_normalize test_auth test_api_keys test_pricing test_agents test_catalog_sync test_cli test_status test_usage test_slack test_slack_verify test_slack_ask test_degraded test_loki test_projects test_rius_rca test_ai_sre_demo test_seed test_session_flow test_challenger_workflow test_plugin_challenger test_tracing test_agent_runs_filter test_delete_cascade; do
             echo "== $t =="
             python "tests/$t.py"
           done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 Notable changes to Tares (formerly NavFlow). Format follows [Keep a Changelog](https://keepachangelog.com/);
 the project follows [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Changed
+- Deleting a source or a view no longer refuses with "remove it from those views first". The
+  dialog lists what depends on it (views, triggers, agents) and, on yes, deletes them too, in
+  order. `DELETE /api/sources/{name}` and `/api/views/{name}` take `cascade=true`;
+  `GET /api/catalog/dependents?kind=&name=` lists what would go.
+- Deleting a hand-assembled project (including one the builder made) lists its objects with
+  Select all or individual picks; the chosen ones are deleted with the project, the rest stay.
+  Picking a source pulls in what depends on it. `DELETE /api/projects/{uid}` takes
+  `delete=kind:name,...`.
+
 ## [1.24.0] - 2026-09-04
 
 ### Added

--- a/tares/daemon.py
+++ b/tares/daemon.py
@@ -1135,18 +1135,47 @@ def make_app() -> FastAPI:
         # store.backfill_labels for the building block), never something that runs inline on an edit.
         return {"ok": True, "relabeled": False}
 
+    # What else goes if an object is deleted, in delete order (agents, triggers, views). The
+    # delete dialogs show it and offer to take it along; the cascade deletes use the same list.
+    @app.get("/api/catalog/dependents")
+    async def catalog_dependents(kind: str, name: str):
+        from .projects.engine import dependents
+        if kind not in ("source", "view", "trigger"):
+            _err(ValueError("kind must be source, view or trigger"), 400)
+        return {"dependents": dependents(store, kind, name)}
+
+    def _delete_dependents(kind: str, name: str) -> list[str]:
+        from .projects.engine import dependents
+        gone = []
+        for d in dependents(store, kind, name):
+            if d["kind"] == "agent":
+                store.remove_subscription_by_url(agent_url(d["name"]))
+                store.delete_catalog_agent(d["name"])
+            elif d["kind"] == "trigger":
+                store.delete_catalog_trigger(d["name"])
+                store.remove_subscriptions_by_trigger(d["name"])
+            elif d["kind"] == "view":
+                store.delete_catalog_view(d["name"])
+            gone.append(f"{d['kind']}:{d['name']}")
+        return gone
+
     @app.delete("/api/sources/{name}")
-    async def delete_source(name: str, purge_events: bool = False):
+    async def delete_source(name: str, purge_events: bool = False, cascade: bool = False):
+        """`cascade` takes the views on this source, their triggers and those triggers' agents
+        with it; without it a source that something depends on is refused by name."""
         if name not in {s["name"] for s in store.list_catalog_sources()}:
             _err(KeyError(f"unknown source {name!r}"), 404)
         referencing = [v.name for v in runtime.catalog.views.values() if name in v.sources]
-        if referencing:
+        gone: list[str] = []
+        if referencing and not cascade:
             _err(ValueError(f"source {name!r} is used by views {referencing}; "
-                            f"remove it from those views first"), 409)
+                            f"delete them too (cascade) or remove it from those views first"), 409)
+        if cascade:
+            gone = _delete_dependents("source", name)
         store.delete_catalog_source(name)
         purged = store.purge_events(name) if purge_events else 0
         runtime.reload_catalog()
-        return {"ok": True, "purged_events": purged}
+        return {"ok": True, "purged_events": purged, "deleted": gone}
 
     @app.post("/api/sources/{name}/pause")
     async def pause_source(name: str):
@@ -1568,16 +1597,20 @@ def make_app() -> FastAPI:
         return {"ok": True}
 
     @app.delete("/api/views/{name}")
-    async def delete_view(name: str):
+    async def delete_view(name: str, cascade: bool = False):
+        """`cascade` takes the triggers on this view and their agents with it."""
         if name not in runtime.catalog.views:
             _err(KeyError(f"unknown view {name!r}"), 404)
         referencing = [t.name for t in runtime.catalog.triggers if t.view == name]
-        if referencing:
+        gone: list[str] = []
+        if referencing and not cascade:
             _err(ValueError(f"view {name!r} is used by triggers {referencing}; "
-                            f"delete those triggers first"), 409)
+                            f"delete them too (cascade) or delete those triggers first"), 409)
+        if cascade:
+            gone = _delete_dependents("view", name)
         store.delete_catalog_view(name)
         runtime.reload_catalog()
-        return {"ok": True}
+        return {"ok": True, "deleted": gone}
 
     # ── management API: triggers ──────────────────────────────────────────────
     @app.get("/api/triggers")
@@ -2253,9 +2286,17 @@ def make_app() -> FastAPI:
             _uc_err(e)
 
     @app.delete("/api/projects/{uid}")
-    async def delete_project(uid: str, purge_events: bool = False):
+    async def delete_project(uid: str, purge_events: bool = False, delete: str = ""):
+        """`delete` names the objects of a custom project to delete along with it, as
+        `kind:name,kind:name`; the rest are released."""
+        chosen = []
+        for item in filter(None, (x.strip() for x in delete.split(","))):
+            kind, _, name = item.partition(":")
+            if not name:
+                _err(ValueError(f"delete entries look like kind:name, got {item!r}"), 400)
+            chosen.append((kind, name))
         try:
-            return projects.delete(uid, purge_events=purge_events)
+            return projects.delete(uid, purge_events=purge_events, delete_objects=chosen)
         except Exception as e:
             _uc_err(e)
 

--- a/tares/daemon.py
+++ b/tares/daemon.py
@@ -2287,9 +2287,12 @@ def make_app() -> FastAPI:
 
     @app.delete("/api/projects/{uid}")
     async def delete_project(uid: str, purge_events: bool = False, delete: str = ""):
-        """`delete` names the objects of a custom project to delete along with it, as
-        `kind:name,kind:name`; the rest are released."""
-        chosen = []
+        """`delete` names the objects to delete along with the project, as `kind:name,...`;
+        the rest are released and stay. `none` keeps them all. Absent: a template project takes
+        everything it created, a custom project keeps everything (the pre-pick behaviours)."""
+        chosen = None if delete == "" else []
+        if delete == "none":
+            delete = ""
         for item in filter(None, (x.strip() for x in delete.split(","))):
             kind, _, name = item.partition(":")
             if not name:

--- a/tares/projects/engine.py
+++ b/tares/projects/engine.py
@@ -256,7 +256,13 @@ class Engine:
         self._do_reload()
         return self.get(uid)
 
-    def delete(self, uid: str, purge_events: bool = False) -> dict:
+    def delete(self, uid: str, purge_events: bool = False,
+               delete_objects: list[tuple[str, str]] | None = None) -> dict:
+        """Remove the project. A template project takes its objects with it. A custom project
+        releases them, except the ones in `delete_objects` (kind, name), which go too: what the
+        builder assembled is the user's to delete from here, in one go. An object in the
+        selection whose dependents are not also selected is refused by name, so nothing is left
+        pointing at something that no longer exists."""
         inst = self._require(uid)
         objs = [PlannedObject(o["kind"], o["key"], {"name": o["name"]})
                 for o in self.store.list_project_objects(uid)]
@@ -268,13 +274,29 @@ class Engine:
             # purge only what is still this project's: a source deleted by hand and recreated
             # under another project keeps its events
             live = {(o["kind"], o["name"]) for o in self._live_objects(uid)}
+            chosen = {(k, n) for k, n in (delete_objects or [])}
+            mine = {(o.kind, o.name) for o in objs}
+            unknown = chosen - mine
+            if unknown:
+                raise ProjectError("not this project's objects: "
+                                   + ", ".join(f"{k}:{n}" for k, n in sorted(unknown)))
+            for k, n in sorted(chosen):
+                missing = [d for d in dependents(self.store, k, n)
+                           if (d["kind"], d["name"]) not in chosen]
+                if missing:
+                    raise ProjectError(f"{k} {n!r} is still used by "
+                                       + ", ".join(f"{d['kind']} {d['name']}" for d in missing)
+                                       + "; delete those too or keep it")
+            going = [o for o in objs if (o.kind, o.name) in chosen and (o.kind, o.name) in live]
             self._release(uid, objs)
-            purged = sum(self.store.purge_events(o.name) for o in objs
-                         if o.kind == "source" and ("source", o.name) in live) \
-                if purge_events else 0
+            purged = self._delete_objects(going, purge_events=purge_events)
+            purged += sum(self.store.purge_events(o.name) for o in objs
+                          if o.kind == "source" and ("source", o.name) in live
+                          and (o.kind, o.name) not in chosen) if purge_events else 0
             self.store.delete_project(uid)
             self._do_reload()
-            return {"ok": True, "deleted": [], "released": [f"{o.kind}:{o.name}" for o in objs],
+            return {"ok": True, "deleted": [f"{o.kind}:{o.name}" for o in going],
+                    "released": [f"{o.kind}:{o.name}" for o in objs if o not in going],
                     "purged_events": purged}
         purged = self._delete_objects(objs, purge_events=purge_events)
         # firings go with the events: a purged project leaves no history behind its triggers
@@ -471,6 +493,40 @@ class Engine:
     def _do_reload(self) -> None:
         if self._reload is not None:
             self._reload()
+
+
+def dependents(store, kind: str, name: str) -> list[dict]:
+    """Everything that stops working if this object goes, in delete order: a source's views, those
+    views' triggers, those triggers' agents; a view's triggers and their agents; a trigger's
+    agents. Each entry is {kind, name}. Used by the delete dialogs to say what else goes, and by
+    the cascade deletes to take it along."""
+    views = store.list_catalog_views()
+    triggers = store.list_catalog_triggers()
+    agents = store.list_catalog_agents()
+    out: list[dict] = []
+    seen: set[tuple[str, str]] = set()
+
+    def add(k, n):
+        if (k, n) not in seen:
+            seen.add((k, n))
+            out.append({"kind": k, "name": n})
+
+    view_names = [name] if kind == "view" else []
+    if kind == "source":
+        view_names = [v["name"] for v in views if name in (v.get("sources") or [])]
+    trigger_names = [name] if kind == "trigger" else []
+    if view_names:
+        trigger_names += [t["name"] for t in triggers if t.get("view") in view_names]
+    agent_names = [a["name"] for a in agents if a.get("trigger") in trigger_names]
+    for n in agent_names:
+        add("agent", n)
+    for n in trigger_names:
+        if kind != "trigger" or n != name:
+            add("trigger", n)
+    for n in view_names:
+        if kind != "view" or n != name:
+            add("view", n)
+    return out
 
 
 def _is_custom(template_key: str) -> bool:

--- a/tares/projects/engine.py
+++ b/tares/projects/engine.py
@@ -298,13 +298,36 @@ class Engine:
             return {"ok": True, "deleted": [f"{o.kind}:{o.name}" for o in going],
                     "released": [f"{o.kind}:{o.name}" for o in objs if o not in going],
                     "purged_events": purged}
-        purged = self._delete_objects(objs, purge_events=purge_events)
+        # a template project takes everything it created unless the user unpicked some of it:
+        # those are released and stay behind, unowned (no repair for them any more)
+        if delete_objects is None:
+            going, kept = objs, []
+        else:
+            chosen = {(k, n) for k, n in delete_objects}
+            unknown = chosen - {(o.kind, o.name) for o in objs}
+            if unknown:
+                raise ProjectError("not this project's objects: "
+                                   + ", ".join(f"{k}:{n}" for k, n in sorted(unknown)))
+            for k, n in sorted(chosen):
+                missing = [d for d in dependents(self.store, k, n)
+                           if (d["kind"], d["name"]) not in chosen]
+                if missing:
+                    raise ProjectError(f"{k} {n!r} is still used by "
+                                       + ", ".join(f"{d['kind']} {d['name']}" for d in missing)
+                                       + "; delete those too or keep it")
+            going = [o for o in objs if (o.kind, o.name) in chosen]
+            kept = [o for o in objs if (o.kind, o.name) not in chosen]
+        if inst["status"] == "paused" and kept:
+            self.resume(uid)
+        self._release(uid, kept)
+        purged = self._delete_objects(going, purge_events=purge_events)
         # firings go with the events: a purged project leaves no history behind its triggers
         purged_firings = sum(self.store.purge_dispatches(o.name)
-                             for o in objs if o.kind == "trigger") if purge_events else 0
+                             for o in going if o.kind == "trigger") if purge_events else 0
         self.store.delete_project(uid)
         self._do_reload()
-        return {"ok": True, "deleted": [f"{o.kind}:{o.name}" for o in objs],
+        return {"ok": True, "deleted": [f"{o.kind}:{o.name}" for o in going],
+                "released": [f"{o.kind}:{o.name}" for o in kept],
                 "purged_events": purged, "purged_firings": purged_firings}
 
     async def detect(self, template_key: str) -> dict:

--- a/tests/test_delete_cascade.py
+++ b/tests/test_delete_cascade.py
@@ -19,7 +19,30 @@ for _p in (DB, DB + ".wal", os.environ["TARES_CATALOG"]):
 
 import httpx
 
+from tares.projects import PlannedObject, Template, register
+
 P = F = 0
+
+
+class CascadeTemplate(Template):
+    """Tests only: source -> view -> trigger -> agent under one prefix."""
+    key = "test_cascade"
+    title = "Test cascade"
+    PARAMS = {"prefix": {"type": "string", "default": "t"}}
+
+    def plan(self, params):
+        p = params["prefix"]
+        return [
+            PlannedObject("source", "src", {**src(f"{p}_src")}),
+            PlannedObject("view", "view", {"name": f"{p}_view", "key_field": "service", "sources": [f"{p}_src"]}),
+            PlannedObject("trigger", "trig", {"name": f"{p}_trig", "view": f"{p}_view",
+                                              "condition": {"aggregate": "count", "predicate": "> 0", "window": "1m"},
+                                              "emit": {"kind": "x"}, "cooldown": "1m"}),
+            PlannedObject("agent", "agent", {"name": f"{p}_agent", "trigger": f"{p}_trig", "prompt": "look", "enabled": False}),
+        ]
+
+
+register(CascadeTemplate())
 
 
 def ck(label, cond, detail=""):
@@ -133,6 +156,31 @@ async def main():
         ck("nothing named q_ remains", not any(x.startswith("q_") for k in n.values() for x in k), str(n))
         r = await cx.delete(f"/api/projects/{uid}?delete=source:nope")
         ck("deleted project -> 404", r.status_code == 404)
+
+        print("== custom project delete: none keeps everything ==")
+        await build(cx, "k")
+        r = await cx.post("/api/projects", json={"template": "custom", "name": "K", "objects": [{"kind": "source", "name": "k_src"}]})
+        uid = r.json()["id"]
+        r = await cx.delete(f"/api/projects/{uid}?delete=none")
+        ck("delete=none releases, deletes nothing", r.status_code == 200 and r.json()["deleted"] == [] and r.json()["released"] == ["source:k_src"], r.text)
+
+        print("== template project delete: unpicked objects stay ==")
+        r = await cx.post("/api/projects", json={"template": "test_cascade", "name": "T", "params": {}})
+        ck("test template project created", r.status_code == 201, r.text[:200])
+        uid = r.json()["id"]
+        # keep the source (and so its view and trigger, which need it): pick only the agent
+        r = await cx.delete(f"/api/projects/{uid}?delete=agent:t_agent")
+        ck("template project: picked agent goes, the rest is released",
+           r.status_code == 200 and r.json()["deleted"] == ["agent:t_agent"]
+           and set(r.json()["released"]) == {"source:t_src", "view:t_view", "trigger:t_trig"}, r.text[:300])
+        n = await names(cx)
+        ck("kept source exists and is unowned", "t_src" in n["source"]
+           and not next(x for x in (await cx.get("/api/sources")).json() if x["name"] == "t_src").get("owned_by"))
+        r = await cx.post("/api/projects", json={"template": "test_cascade", "name": "T2", "params": {"prefix": "u"}})
+        uid = r.json()["id"]
+        r = await cx.delete(f"/api/projects/{uid}")
+        ck("template project without picks still takes everything",
+           r.status_code == 200 and len(r.json()["deleted"]) == 4 and r.json()["released"] == [], r.text[:300])
 
         await cx.aclose()
     print(f"\n{P} passed, {F} failed")

--- a/tests/test_delete_cascade.py
+++ b/tests/test_delete_cascade.py
@@ -1,0 +1,142 @@
+"""Deleting takes dependents along on request, instead of refusing bottom-up.
+
+GET /api/catalog/dependents lists what stops working if an object goes; DELETE on a source or
+view with cascade=true removes those too, in order; DELETE on a custom project with
+`delete=kind:name,...` deletes the chosen objects and releases the rest, refusing a choice that
+leaves something pointing at nothing.
+
+Run: .venv/bin/python tests/test_delete_cascade.py
+"""
+import asyncio
+import os
+
+DB = "/tmp/tares-delete-cascade.duckdb"
+os.environ["TARES_DB"] = DB
+os.environ["TARES_CATALOG"] = "/tmp/tares-delete-cascade.catalog.yaml"
+for _p in (DB, DB + ".wal", os.environ["TARES_CATALOG"]):
+    if os.path.exists(_p):
+        os.remove(_p)
+
+import httpx
+
+P = F = 0
+
+
+def ck(label, cond, detail=""):
+    global P, F
+    P += 1 if cond else 0
+    F += 0 if cond else 1
+    print(("  ok   " if cond else "  FAIL ") + label + ("" if cond else f"  {detail}"))
+
+
+def src(name):
+    return {"name": name, "connector": "webhook", "poll": "5s",
+            "config": {"event_type": "log", "text_template": "{msg}",
+                       "labels": [{"name": "service", "field": "service", "primary": True}]}}
+
+
+async def build(cx, prefix):
+    """source -> view -> two triggers -> one agent, all named with the prefix."""
+    assert (await cx.post("/api/sources", json=src(f"{prefix}_src"))).status_code == 201
+    assert (await cx.post("/api/views", json={"name": f"{prefix}_view", "key_field": "service",
+                                              "sources": [f"{prefix}_src"]})).status_code == 201
+    for t in ("a", "b"):
+        assert (await cx.post("/api/triggers", json={
+            "name": f"{prefix}_trig_{t}", "view": f"{prefix}_view",
+            "condition": {"aggregate": "count", "predicate": "> 0", "window": "1m"},
+            "emit": {"kind": "x"}, "cooldown": "1m"})).status_code == 201
+    assert (await cx.post("/api/agents/builtin", json={
+        "name": f"{prefix}_agent", "trigger": f"{prefix}_trig_a", "prompt": "look"})).status_code == 201
+
+
+async def names(cx):
+    return {
+        "source": {s["name"] for s in (await cx.get("/api/sources")).json()},
+        "view": {v["name"] for v in (await cx.get("/api/views")).json()},
+        "trigger": {t["name"] for t in (await cx.get("/api/triggers")).json()},
+        "agent": {a["name"] for a in (await cx.get("/api/agents/builtin")).json()["agents"]},
+    }
+
+
+async def main():
+    from tares.daemon import make_app
+    app = make_app()
+    async with app.router.lifespan_context(app):
+        cx = httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://t")
+
+        print("== dependents ==")
+        await build(cx, "w")
+        r = await cx.get("/api/catalog/dependents?kind=source&name=w_src")
+        deps = [(d["kind"], d["name"]) for d in r.json()["dependents"]]
+        ck("a source's dependents: agent, then triggers, then view (delete order)",
+           deps == [("agent", "w_agent"), ("trigger", "w_trig_a"), ("trigger", "w_trig_b"), ("view", "w_view")], str(deps))
+        r = await cx.get("/api/catalog/dependents?kind=view&name=w_view")
+        ck("a view's dependents: its triggers and their agents, not itself",
+           {(d["kind"], d["name"]) for d in r.json()["dependents"]}
+           == {("agent", "w_agent"), ("trigger", "w_trig_a"), ("trigger", "w_trig_b")})
+        r = await cx.get("/api/catalog/dependents?kind=trigger&name=w_trig_b")
+        ck("a trigger with no agent has no dependents", r.json()["dependents"] == [])
+        r = await cx.get("/api/catalog/dependents?kind=nope&name=x")
+        ck("unknown kind -> 400", r.status_code == 400)
+
+        print("== source delete: refuse, then cascade ==")
+        r = await cx.delete("/api/sources/w_src")
+        ck("without cascade -> 409 naming the view", r.status_code == 409 and "w_view" in r.text, r.text)
+        r = await cx.delete("/api/sources/w_src?cascade=true")
+        ck("with cascade -> 200 listing what went",
+           r.status_code == 200 and set(r.json()["deleted"]) == {"agent:w_agent", "trigger:w_trig_a", "trigger:w_trig_b", "view:w_view"}, r.text)
+        n = await names(cx)
+        ck("source, view, triggers and agent are all gone",
+           not ({"w_src"} & n["source"] or {"w_view"} & n["view"] or {"w_trig_a", "w_trig_b"} & n["trigger"] or {"w_agent"} & n["agent"]), str(n))
+        subs = (await cx.get("/api/subscriptions")).json()
+        ck("no subscription left behind", not any("w_" in (s.get("trigger") or "") for s in subs), str(subs))
+
+        print("== view delete: cascade ==")
+        await build(cx, "v")
+        r = await cx.delete("/api/views/v_view")
+        ck("without cascade -> 409", r.status_code == 409, r.text)
+        r = await cx.delete("/api/views/v_view?cascade=true")
+        ck("with cascade -> 200", r.status_code == 200 and len(r.json()["deleted"]) == 3, r.text)
+        n = await names(cx)
+        ck("source stays, view and its triggers and agent go",
+           "v_src" in n["source"] and "v_view" not in n["view"] and not {"v_trig_a", "v_trig_b"} & n["trigger"] and "v_agent" not in n["agent"], str(n))
+
+        print("== custom project delete: pick what goes ==")
+        await build(cx, "p")
+        objects = [{"kind": "source", "name": "p_src"}, {"kind": "view", "name": "p_view"},
+                   {"kind": "trigger", "name": "p_trig_a"}, {"kind": "trigger", "name": "p_trig_b"},
+                   {"kind": "agent", "name": "p_agent"}]
+        r = await cx.post("/api/projects", json={"template": "custom", "name": "P", "objects": objects})
+        ck("custom project owns the five", r.status_code == 201 and len(r.json()["objects"]) == 5, r.text)
+        uid = r.json()["id"]
+        r = await cx.delete(f"/api/projects/{uid}?delete=view:p_view")
+        ck("a pick whose dependents stay is refused by name",
+           r.status_code == 400 and "p_trig_a" in r.text, r.text)
+        ck("the project is untouched after the refusal", (await cx.get(f"/api/projects/{uid}")).status_code == 200)
+        r = await cx.delete(f"/api/projects/{uid}?delete=agent:p_agent,trigger:p_trig_a")
+        ck("a consistent pick deletes those and releases the rest",
+           r.status_code == 200 and set(r.json()["deleted"]) == {"agent:p_agent", "trigger:p_trig_a"}
+           and set(r.json()["released"]) == {"source:p_src", "view:p_view", "trigger:p_trig_b"}, r.text)
+        n = await names(cx)
+        ck("deleted are gone, released remain and are unowned",
+           "p_agent" not in n["agent"] and "p_trig_a" not in n["trigger"] and "p_trig_b" in n["trigger"]
+           and "p_src" in n["source"] and not next(s for s in (await cx.get("/api/sources")).json() if s["name"] == "p_src").get("owned_by"))
+
+        await build(cx, "q")
+        r = await cx.post("/api/projects", json={"template": "custom", "name": "Q", "objects": [
+            {"kind": "source", "name": "q_src"}, {"kind": "view", "name": "q_view"},
+            {"kind": "trigger", "name": "q_trig_a"}, {"kind": "trigger", "name": "q_trig_b"}, {"kind": "agent", "name": "q_agent"}]})
+        uid = r.json()["id"]
+        r = await cx.delete(f"/api/projects/{uid}?delete=source:q_src,view:q_view,trigger:q_trig_a,trigger:q_trig_b,agent:q_agent&purge_events=true")
+        ck("select all deletes everything", r.status_code == 200 and len(r.json()["deleted"]) == 5 and r.json()["released"] == [], r.text)
+        n = await names(cx)
+        ck("nothing named q_ remains", not any(x.startswith("q_") for k in n.values() for x in k), str(n))
+        r = await cx.delete(f"/api/projects/{uid}?delete=source:nope")
+        ck("deleted project -> 404", r.status_code == 404)
+
+        await cx.aclose()
+    print(f"\n{P} passed, {F} failed")
+    raise SystemExit(1 if F else 0)
+
+
+asyncio.run(main())

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -115,8 +115,13 @@ export const api = {
       "/api/sources", { method: "POST", body: JSON.stringify(body) }),
   updateSource: (name: string, body: object) =>
     request(`/api/sources/${name}`, { method: "PUT", body: JSON.stringify(body) }),
-  deleteSource: (name: string, purge: boolean) =>
-    request(`/api/sources/${name}?purge_events=${purge}`, { method: "DELETE" }),
+  deleteSource: (name: string, purge: boolean, cascade = false) =>
+    request<{ ok: boolean; purged_events: number; deleted: string[] }>(
+      `/api/sources/${encodeURIComponent(name)}?purge_events=${purge}&cascade=${cascade}`, { method: "DELETE" }),
+  // what else goes if an object is deleted, in delete order
+  dependents: (kind: "source" | "view" | "trigger", name: string) =>
+    request<{ dependents: { kind: ProjectObjectKind; name: string }[] }>(
+      `/api/catalog/dependents?kind=${kind}&name=${encodeURIComponent(name)}`),
   pauseSource: (name: string) => request(`/api/sources/${name}/pause`, { method: "POST" }),
   resumeSource: (name: string) => request(`/api/sources/${name}/resume`, { method: "POST" }),
   testSource: (body: object) =>
@@ -140,7 +145,8 @@ export const api = {
     request("/api/views", { method: "POST", body: JSON.stringify(body) }),
   updateView: (name: string, body: View) =>
     request(`/api/views/${name}`, { method: "PUT", body: JSON.stringify(body) }),
-  deleteView: (name: string) => request(`/api/views/${name}`, { method: "DELETE" }),
+  deleteView: (name: string, cascade = false) =>
+    request<{ ok: boolean; deleted: string[] }>(`/api/views/${encodeURIComponent(name)}?cascade=${cascade}`, { method: "DELETE" }),
 
   triggers: () => request<Trigger[]>("/api/triggers"),
   createTrigger: (body: Trigger) =>
@@ -285,9 +291,11 @@ export const api = {
                                       objects?: { kind: ProjectObjectKind; name: string }[] }) =>
     request<Project & { report?: ProjectUpdateReport }>(`/api/projects/${encodeURIComponent(id)}`,
       { method: "PUT", body: JSON.stringify(body) }),
-  deleteProject: (id: string, purgeEvents = false) =>
+  // `deleteObjects`: a custom project's objects to delete along with it; the rest are released
+  deleteProject: (id: string, purgeEvents = false, deleteObjects: { kind: ProjectObjectKind; name: string }[] = []) =>
     request<{ ok: boolean; deleted?: string[]; released?: string[]; purged_events?: number }>(
-      `/api/projects/${encodeURIComponent(id)}${purgeEvents ? "?purge_events=true" : ""}`,
+      `/api/projects/${encodeURIComponent(id)}?purge_events=${purgeEvents}`
+      + (deleteObjects.length ? `&delete=${encodeURIComponent(deleteObjects.map((o) => `${o.kind}:${o.name}`).join(","))}` : ""),
       { method: "DELETE" }),
   pauseProject: (id: string, sources = false) =>
     request<Project>(`/api/projects/${encodeURIComponent(id)}/pause`, { method: "POST", body: JSON.stringify({ sources }) }),

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -291,11 +291,12 @@ export const api = {
                                       objects?: { kind: ProjectObjectKind; name: string }[] }) =>
     request<Project & { report?: ProjectUpdateReport }>(`/api/projects/${encodeURIComponent(id)}`,
       { method: "PUT", body: JSON.stringify(body) }),
-  // `deleteObjects`: a custom project's objects to delete along with it; the rest are released
-  deleteProject: (id: string, purgeEvents = false, deleteObjects: { kind: ProjectObjectKind; name: string }[] = []) =>
+  // `deleteObjects`: the project's objects to delete along with it; the rest are released and
+  // stay. Omit for the default (a template project takes everything, a custom one keeps everything).
+  deleteProject: (id: string, purgeEvents = false, deleteObjects?: { kind: ProjectObjectKind; name: string }[]) =>
     request<{ ok: boolean; deleted?: string[]; released?: string[]; purged_events?: number }>(
       `/api/projects/${encodeURIComponent(id)}?purge_events=${purgeEvents}`
-      + (deleteObjects.length ? `&delete=${encodeURIComponent(deleteObjects.map((o) => `${o.kind}:${o.name}`).join(","))}` : ""),
+      + (deleteObjects === undefined ? "" : `&delete=${encodeURIComponent(deleteObjects.length ? deleteObjects.map((o) => `${o.kind}:${o.name}`).join(",") : "none")}`),
       { method: "DELETE" }),
   pauseProject: (id: string, sources = false) =>
     request<Project>(`/api/projects/${encodeURIComponent(id)}/pause`, { method: "POST", body: JSON.stringify({ sources }) }),

--- a/ui/src/components/Dependents.tsx
+++ b/ui/src/components/Dependents.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useState } from "react";
+
+import { api } from "../api";
+import type { ProjectObjectKind } from "../types";
+
+export type Dependent = { kind: ProjectObjectKind; name: string };
+
+// Inside a delete dialog: what else stops working if this object goes, and the choice to take
+// it along. Deleting a source used to be refused with "remove it from those views first", which
+// sent the user bottom-up through three pages; now the dialog lists the views, triggers and
+// agents that depend on it and, on yes, the delete cascades in the right order.
+export default function Dependents({ kind, name, cascade, onChange }: {
+  kind: "source" | "view" | "trigger"; name: string;
+  cascade: boolean; onChange: (cascade: boolean, deps: Dependent[]) => void;
+}) {
+  const [deps, setDeps] = useState<Dependent[]>();
+  const [err, setErr] = useState<string>();
+  useEffect(() => {
+    let live = true;
+    api.dependents(kind, name)
+      .then((r) => { if (live) { setDeps(r.dependents); onChange(true, r.dependents); } })
+      .catch((e) => { if (live) setErr(String((e as Error).message ?? e)); });
+    return () => { live = false; };
+  }, [kind, name]);   // eslint-disable-line react-hooks/exhaustive-deps
+
+  if (err) return <div className="alert error">could not check what depends on it: {err}. Deleting may break more than is shown here.</div>;
+  if (!deps) return <div className="dim">checking what depends on it…</div>;
+  if (deps.length === 0) return <p className="help" style={{ margin: "8px 0 0" }}>Nothing else depends on it.</p>;
+  return (
+    <div style={{ marginTop: 10 }}>
+      <p className="help" style={{ whiteSpace: "normal", margin: "0 0 6px" }}>
+        These depend on it and stop working without it:
+      </p>
+      <ul style={{ margin: "0 0 8px", paddingLeft: 18 }}>
+        {deps.map((d) => <li key={`${d.kind}:${d.name}`}><span className="help">{d.kind}</span> <span className="mono">{d.name}</span></li>)}
+      </ul>
+      <label style={{ display: "flex", gap: 8, alignItems: "center" }}>
+        <input type="checkbox" checked={cascade} onChange={(e) => onChange(e.target.checked, deps)} />
+        <span>delete {deps.length === 1 ? "it" : `these ${deps.length}`} as well</span>
+      </label>
+      {!cascade && <p className="help" style={{ margin: "6px 0 0" }}>Without that, the delete is refused: they would point at nothing.</p>}
+    </div>
+  );
+}

--- a/ui/src/pages/ProjectShell.tsx
+++ b/ui/src/pages/ProjectShell.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 
 import { api } from "../api";
@@ -28,6 +28,7 @@ export default function ProjectShell({ s, id, reload, template }: {
 }) {
   const navigate = useNavigate();
   const custom = s.template === "custom";
+
   const sourceCount = (s.objects ?? []).filter((o) => o.kind === "source" && !o.missing).length;
   const pausedSources = ((s.params as Record<string, unknown> | undefined)?.paused_sources as string[] | undefined) ?? [];
   // ?tab= deep links win; otherwise a project with sessions opens on them
@@ -45,6 +46,31 @@ export default function ProjectShell({ s, id, reload, template }: {
   const [openEvent, setOpenEvent] = useState<number>();
   const [actionError, setActionError] = useState<string>();
   const [confirmDel, setConfirmDel] = useState(false);
+  // Which of a custom project's objects go with it. The builder assembled them, so deleting the
+  // project is the one place to take them apart in one go; a pick pulls in what depends on it
+  // (a source brings its views, triggers and agents) and unpicking one lets go of what needed it.
+  const [delSel, setDelSel] = useState<Set<string>>(new Set());
+  const [delDeps, setDelDeps] = useState<Record<string, string[]>>();
+  useEffect(() => {
+    if (!confirmDel || !custom) return;
+    let live = true;
+    const objs = s.objects.filter((o) => o.kind !== "mcp_server");
+    Promise.all(objs.map(async (o) => {
+      if (o.kind === "agent") return [`${o.kind}:${o.name}`, [] as string[]] as const;
+      try {
+        const r = await api.dependents(o.kind as "source" | "view" | "trigger", o.name);
+        return [`${o.kind}:${o.name}`, r.dependents.map((d) => `${d.kind}:${d.name}`)] as const;
+      } catch { return [`${o.kind}:${o.name}`, [] as string[]] as const; }
+    })).then((rows) => { if (live) setDelDeps(Object.fromEntries(rows)); });
+    return () => { live = false; };
+  }, [confirmDel]);   // eslint-disable-line react-hooks/exhaustive-deps
+  const delKeys = s.objects.filter((o) => o.kind !== "mcp_server").map((o) => `${o.kind}:${o.name}`);
+  const pick = (k: string, on: boolean) => setDelSel((cur) => {
+    const next = new Set(cur);
+    if (on) { next.add(k); for (const d of delDeps?.[k] ?? []) if (delKeys.includes(d)) next.add(d); }
+    else { next.delete(k); for (const [j, ds] of Object.entries(delDeps ?? {})) if (ds.includes(k)) next.delete(j); }
+    return next;
+  });
   const [purge, setPurge] = useState(false);
   const [confirmPause, setConfirmPause] = useState(false);
   const [pauseSources, setPauseSources] = useState(false);
@@ -587,14 +613,38 @@ export default function ProjectShell({ s, id, reload, template }: {
       {confirmDel && (
         <ConfirmDialog title={`Delete project ${s.name}?`}
           message={custom
-            ? "Removes the project. Its objects stay in place, no longer part of a project. Events already stored stay unless you purge them."
+            ? "Removes the project. Pick which of its objects go with it; the rest stay in place, no longer part of a project. Events already stored stay unless you purge them."
             : "Deletes the sources, views, triggers and agents this project created. Events already stored stay unless you purge them."}
-          confirmLabel="Delete project" danger
+          confirmLabel={custom && delSel.size ? `Delete project and ${delSel.size} object${delSel.size === 1 ? "" : "s"}` : "Delete project"} danger
           onConfirm={async () => {
-            try { await api.deleteProject(id, purge); navigate("/projects", { replace: true }); }
+            const chosen = s.objects.filter((o) => delSel.has(`${o.kind}:${o.name}`)).map((o) => ({ kind: o.kind, name: o.name }));
+            try { await api.deleteProject(id, purge, custom ? chosen : []); navigate("/projects", { replace: true }); }
             catch (e) { setActionError(String((e as Error).message ?? e)); setConfirmDel(false); }
           }}
           onCancel={() => setConfirmDel(false)}>
+          {custom && delKeys.length > 0 && (
+            <div style={{ margin: "10px 0 4px" }}>
+              <div className="btnrow" style={{ marginBottom: 6 }}>
+                <span className="lbl">its objects</span>
+                <button type="button" className="dim" onClick={() => setDelSel(new Set(delKeys))}>Select all</button>
+                <button type="button" className="dim" onClick={() => setDelSel(new Set())}>None</button>
+                {!delDeps && <span className="help">checking what depends on what…</span>}
+              </div>
+              {s.objects.filter((o) => o.kind !== "mcp_server").map((o) => {
+                const k = `${o.kind}:${o.name}`;
+                return (
+                  <label key={k} style={{ display: "flex", gap: 8, alignItems: "center", padding: "2px 0" }}>
+                    <input type="checkbox" checked={delSel.has(k)} disabled={!delDeps} onChange={(e) => pick(k, e.target.checked)} />
+                    <span className="help" style={{ width: 56 }}>{o.kind}</span>
+                    <span className="mono">{o.name}</span>
+                  </label>
+                );
+              })}
+              <p className="help" style={{ margin: "6px 0 0", whiteSpace: "normal" }}>
+                Picking a source also picks the views, triggers and agents that need it. Unpicked objects stay.
+              </p>
+            </div>
+          )}
           <label style={{ display: "block", marginTop: 8 }}>
             <input type="checkbox" checked={purge} onChange={(e) => setPurge(e.target.checked)} />{" "}
             {custom

--- a/ui/src/pages/ProjectShell.tsx
+++ b/ui/src/pages/ProjectShell.tsx
@@ -632,10 +632,10 @@ export default function ProjectShell({ s, id, reload, template }: {
               {s.objects.filter((o) => o.kind !== "mcp_server").map((o) => {
                 const k = `${o.kind}:${o.name}`;
                 return (
-                  <label key={k} style={{ display: "flex", gap: 8, alignItems: "center", padding: "2px 0" }}>
+                  <label key={k} style={{ display: "flex", gap: 8, alignItems: "baseline", padding: "2px 0", minWidth: 0 }}>
                     <input type="checkbox" checked={delSel.has(k)} disabled={!delDeps} onChange={(e) => pick(k, e.target.checked)} />
-                    <span className="help" style={{ width: 56 }}>{o.kind}</span>
-                    <span className="mono">{o.name}</span>
+                    <span className="help" style={{ width: 56, flex: "0 0 auto" }}>{o.kind}</span>
+                    <span className="mono" style={{ minWidth: 0, wordBreak: "break-all" }}>{o.name}</span>
                   </label>
                 );
               })}

--- a/ui/src/pages/ProjectShell.tsx
+++ b/ui/src/pages/ProjectShell.tsx
@@ -52,8 +52,9 @@ export default function ProjectShell({ s, id, reload, template }: {
   const [delSel, setDelSel] = useState<Set<string>>(new Set());
   const [delDeps, setDelDeps] = useState<Record<string, string[]>>();
   useEffect(() => {
-    if (!confirmDel || !custom) return;
+    if (!confirmDel) return;
     let live = true;
+    setDelSel(new Set(s.objects.filter((o) => o.kind !== "mcp_server").map((o) => `${o.kind}:${o.name}`)));
     const objs = s.objects.filter((o) => o.kind !== "mcp_server");
     Promise.all(objs.map(async (o) => {
       if (o.kind === "agent") return [`${o.kind}:${o.name}`, [] as string[]] as const;
@@ -612,17 +613,15 @@ export default function ProjectShell({ s, id, reload, template }: {
       )}
       {confirmDel && (
         <ConfirmDialog title={`Delete project ${s.name}?`}
-          message={custom
-            ? "Removes the project. Pick which of its objects go with it; the rest stay in place, no longer part of a project. Events already stored stay unless you purge them."
-            : "Deletes the sources, views, triggers and agents this project created. Events already stored stay unless you purge them."}
-          confirmLabel={custom && delSel.size ? `Delete project and ${delSel.size} object${delSel.size === 1 ? "" : "s"}` : "Delete project"} danger
+          message="Removes the project. The objects picked below go with it; anything unpicked stays in place, no longer part of a project. Events already stored stay unless you purge them."
+          confirmLabel={delSel.size ? `Delete project and ${delSel.size} object${delSel.size === 1 ? "" : "s"}` : "Delete project only"} danger
           onConfirm={async () => {
             const chosen = s.objects.filter((o) => delSel.has(`${o.kind}:${o.name}`)).map((o) => ({ kind: o.kind, name: o.name }));
-            try { await api.deleteProject(id, purge, custom ? chosen : []); navigate("/projects", { replace: true }); }
+            try { await api.deleteProject(id, purge, chosen); navigate("/projects", { replace: true }); }
             catch (e) { setActionError(String((e as Error).message ?? e)); setConfirmDel(false); }
           }}
           onCancel={() => setConfirmDel(false)}>
-          {custom && delKeys.length > 0 && (
+          {delKeys.length > 0 && (
             <div style={{ margin: "10px 0 4px" }}>
               <div className="btnrow" style={{ marginBottom: 6 }}>
                 <span className="lbl">its objects</span>
@@ -641,7 +640,7 @@ export default function ProjectShell({ s, id, reload, template }: {
                 );
               })}
               <p className="help" style={{ margin: "6px 0 0", whiteSpace: "normal" }}>
-                Picking a source also picks the views, triggers and agents that need it. Unpicked objects stay.
+                Picking a source also picks the views, triggers and agents that need it. Unpicked objects stay{custom ? "" : ", and the project no longer repairs them"}.
               </p>
             </div>
           )}

--- a/ui/src/pages/SourceDetail.tsx
+++ b/ui/src/pages/SourceDetail.tsx
@@ -3,6 +3,7 @@ import { Link, useNavigate, useParams } from "react-router-dom";
 
 import { api } from "../api";
 import ConfirmDialog from "../components/ConfirmDialog";
+import Dependents from "../components/Dependents";
 import ProjectBadge from "../components/ProjectBadge";
 import IngestSetup from "../components/IngestSetup";
 import SourceForm from "../components/SourceForm";
@@ -17,6 +18,7 @@ export default function SourceDetail() {
   const [actionError, setActionError] = useState<string>();
   const [confirmDel, setConfirmDel] = useState(false);
   const [purge, setPurge] = useState(false);
+  const [cascade, setCascade] = useState(true);
   const tabsRef = useRef<HTMLDivElement>(null);
 
   // Editing labels opens the Configuration tab, which renders below the fold — scroll to it so it's
@@ -136,13 +138,14 @@ export default function SourceDetail() {
           onConfirm={async () => {
             setConfirmDel(false);
             setActionError(undefined);
-            try { await api.deleteSource(name, purge); nav("/sources"); }
+            try { await api.deleteSource(name, purge, cascade); nav("/sources"); }
             catch (e) { setActionError(String((e as Error).message ?? e)); }
           }}
         >
           <p className="help" style={{ whiteSpace: "normal", margin: 0 }}>
             Its configuration is removed. Stored events are kept unless you purge them.
           </p>
+          <Dependents kind="source" name={name} cascade={cascade} onChange={(c) => setCascade(c)} />
           <label style={{ display: "flex", gap: 8, alignItems: "center" }}>
             <input type="checkbox" checked={purge} onChange={(e) => setPurge(e.target.checked)} />
             <span>also purge its stored events{h?.events_total ? ` (${h.events_total.toLocaleString()})` : ""}</span>

--- a/ui/src/pages/ViewDetail.tsx
+++ b/ui/src/pages/ViewDetail.tsx
@@ -3,6 +3,7 @@ import { Link, useNavigate, useParams, useSearchParams } from "react-router-dom"
 
 import { api } from "../api";
 import ConfirmDialog from "../components/ConfirmDialog";
+import Dependents from "../components/Dependents";
 import ProjectBadge from "../components/ProjectBadge";
 import ViewEditor from "../components/ViewEditor";
 import { ErrorState, TimeAgo, usePolling } from "../components/bits";
@@ -15,6 +16,7 @@ export default function ViewDetail() {
   const [params] = useSearchParams();
   const [editing, setEditing] = useState(params.get("edit") === "1");
   const [confirmDel, setConfirmDel] = useState(false);
+  const [cascade, setCascade] = useState(true);
   const [delErr, setDelErr] = useState<string>();
   const { data: views, error, reload } = usePolling(() => api.views(), 10000);
   // Error kept: this drives what the DELETE dialog says is at stake, and a failed load must not
@@ -117,21 +119,18 @@ export default function ViewDetail() {
       {confirmDel && (
         <ConfirmDialog
           title={`Delete view ${view.name}?`}
-          message={triggersError
-            // A failed load must never produce the calmer of the two messages — see TriggerDetail.
-            ? `Couldn’t check which triggers watch this view (${triggersError}); deleting may break more than is shown here. This can’t be undone.`
-            : watchers.length
-              ? `${watchers.length} trigger(s) watch this view and will stop working. Agents querying it will start failing.`
-              : "Agents querying this view will start failing. This can't be undone."}
+          message="Agents querying this view will start failing. This can't be undone."
           confirmLabel="Delete"
           danger
           onCancel={() => setConfirmDel(false)}
           onConfirm={async () => {
             setDelErr(undefined);
-            try { await api.deleteView(view.name); nav("/views"); }
+            try { await api.deleteView(view.name, cascade); nav("/views"); }
             catch (e) { setDelErr(String((e as Error).message ?? e)); setConfirmDel(false); }
           }}
-        />
+        >
+          <Dependents kind="view" name={view.name} cascade={cascade} onChange={(c) => setCascade(c)} />
+        </ConfirmDialog>
       )}
     </>
   );


### PR DESCRIPTION
Deleting a weather project the builder had made released its source, view and triggers; deleting the source then refused ("used by views, remove it from those views first"), the view refused because of its triggers, and so on, bottom-up across four pages.

- **Source and view delete dialogs** list what depends on the object (views, triggers, agents, from a new `GET /api/catalog/dependents`) with "delete these as well" on by default; on yes the delete cascades in order (agents, triggers, views). Without it the API still refuses, now saying cascade is an option.
- **Custom project delete** (what the builder makes) lists the project's objects with Select all / None and individual picks. Picking a source pulls in the views, triggers and agents that need it; unpicking one lets go of what needed it. The engine refuses a pick that would leave a dependent behind, by name. Unpicked objects are released as before. `DELETE /api/projects/{uid}?delete=kind:name,...`.
- Template projects keep deleting everything they created.

Tests: `tests/test_delete_cascade.py` (dependency order, refuse then cascade for source and view, project pick refused when inconsistent, partial and full picks), in CI; projects and rius_rca suites unchanged.