### PR TITLE
Landing screen: one question, sentences for inspiration, the demo as an offer

### DIFF
--- a/tares/projects/ai_sre_demo.py
+++ b/tares/projects/ai_sre_demo.py
@@ -61,6 +61,8 @@ class AiSreDemo(Template):
     description = ("Watch a small demo system, correlate its metrics, logs and alerts on one timeline, "
                    "and let an agent write the first incident note when Prometheus fires.")
     tags = ("demo",)
+    sentence = ("show me an agent watching a small service: metrics, logs and alerts on one "
+                "timeline, and a first incident note when something breaks")
     guide = {"label": "Build an AI SRE guide", "url": "https://docs.glassflow.ai/tares/guides/ai-sre"}
 
     PARAMS = {

--- a/tares/projects/base.py
+++ b/tares/projects/base.py
@@ -46,6 +46,10 @@ class Template:
     tags: tuple = ()
     # An optional walkthrough the console links next to the description: {label, url}.
     guide: dict | None = None
+    # What a person would type to get this template, in the first person ("watch my checkout
+    # logs and tell me in Slack when payments fail"). The landing screen offers it as a starter;
+    # empty means the template is not offered there.
+    sentence: str = ""
     # Steps a user must do outside Tares before Start (start a stack, export a key), each
     # {title, text?, command?}; the wizard shows them above the Start button.
     SETUP: list = []
@@ -124,7 +128,8 @@ class Template:
     def describe(self) -> dict:
         return {"key": self.key, "title": self.title, "description": self.description,
                 "params": self.PARAMS, "tags": list(self.tags), "setup": list(self.SETUP),
-                "actions": list(self.ACTIONS), "guide": dict(self.guide) if self.guide else None}
+                "actions": list(self.ACTIONS), "guide": dict(self.guide) if self.guide else None,
+                "sentence": self.sentence}
 
 
 def _iso(v):

--- a/tares/projects/challenger_workflow.py
+++ b/tares/projects/challenger_workflow.py
@@ -69,6 +69,8 @@ class ChallengerWorkflow(Template):
                    "keep the whole exchange on one session timeline, and get a session summary "
                    "with memory proposals when the session ends.")
     tags = ()
+    sentence = ("challenge Claude Code's plan and every commit on my laptop, and summarise "
+                "each session when it ends")
     guide = {"label": "Challenger workflow guide",
              "url": "https://docs.glassflow.ai/tares/guides/challenger-workflow"}
 

--- a/tares/projects/shared_code_context.py
+++ b/tares/projects/shared_code_context.py
@@ -138,6 +138,8 @@ def _norm_repo(value) -> str:
 class SharedCodeContext(Template):
     key = "shared_code_context"
     title = "Shared code context"
+    sentence = ("watch my code repos and keep one shared context repo up to date, opening a "
+                "pull request when something changes")
     description = ("Keep one repository of shared context current: Tares watches commits across "
                    "your code repos and an agent updates the context repo when something changes.")
     guide = {"label": "Shared code context guide",

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -87,6 +87,8 @@ async def main():
             keys = [x["key"] for x in r.json()["templates"]]
             check("test template listed with params", "test_demo" in keys and
                   any("apps" in x["params"] for x in r.json()["templates"]), r.text)
+            check("every template carries a sentence field (the landing screen's starters)",
+                  all("sentence" in x for x in r.json()["templates"]), r.text[:200])
 
             print("== create ==")
             r = await cx.post("/api/projects", json={"template": "nope", "params": {}})

--- a/ui/src/pages/Home.tsx
+++ b/ui/src/pages/Home.tsx
@@ -1,8 +1,9 @@
-import { useEffect } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { useState } from "react";
+import { Link } from "react-router-dom";
 
 import { api } from "../api";
 import { ErrorState, TimeAgo, fmtCost, fmtTokens, formatBytes, usePolling } from "../components/bits";
+import Landing from "./Landing";
 import type { ModelUsage, Usage, Project } from "../types";
 
 // The instance at a glance. This exists because the numbers that describe the WHOLE instance —
@@ -18,24 +19,36 @@ import type { ModelUsage, Usage, Project } from "../types";
 // Degraded state is NOT surfaced here — AuthGate already renders a global banner when /health is
 // anything but ok, and a second copy would just be one more thing to keep in sync.
 
-// An instance with no sources has nothing for Overview to say — every number is zero. On the
-// first landing of a page load we send that user to Sources, where the next step actually is.
-// Once per page load only (module flag, not state): clicking Overview in the nav afterwards must
-// still show the page, and polling must not bounce you away if sources later drop to zero.
-let emptyRedirectDone = false;
+// A cell with no project of the user's own lands on the landing screen instead (Landing.tsx):
+// one question, answered by typing. The seeded demo does not count as theirs. Someone who runs
+// sources without projects and wants the numbers can skip it; the choice is remembered in this
+// browser only (a per-viewer convenience, nothing the cell needs to know).
+const SKIP_KEY = "tares_skip_landing";
+const skipLanding = () => { try { return localStorage.getItem(SKIP_KEY) === "1"; } catch { return false; } };
 
 export default function Home() {
   const { data: u, error: usageError, reload: reloadUsage } = usePolling(() => api.usage(), 30000);
   const { data: sources, error: sourcesError } = usePolling(() => api.sources(), 30000);
   const { data: uc } = usePolling(() => api.projects(), 30000);
   const { data: mu, error: muError, reload: reloadMu } = usePolling(() => api.modelUsage(30), 30000);
-  const navigate = useNavigate();
+  const { data: rec } = usePolling(() => api.templates(), 60000);
+  const [skipped, setSkipped] = useState(skipLanding);
 
-  useEffect(() => {
-    if (emptyRedirectDone || !sources) return;   // a failed load never counts as "no sources"
-    emptyRedirectDone = true;
-    if (sources.length === 0) navigate("/sources", { replace: true });
-  }, [sources, navigate]);
+  const own = uc?.projects.filter((p) => p.template !== "ai_sre_demo") ?? [];
+  // ?landing previews the screen on a cell that already has projects
+  const preview = new URLSearchParams(window.location.search).has("landing");
+  if (uc && ((own.length === 0 && !skipped) || preview)) {
+    return (
+      <>
+        <Landing templates={rec?.templates ?? []} projects={uc.projects} />
+        <p className="help" style={{ textAlign: "center" }}>
+          <button type="button" className="dim" onClick={() => { try { localStorage.setItem(SKIP_KEY, "1"); } catch { /* private mode */ } setSkipped(true); }}>
+            Skip, show the instance overview
+          </button>
+        </p>
+      </>
+    );
+  }
 
   const onDisk = u ? u.db_bytes + u.wal_bytes : 0;
   // Both are null together, but it's the denominator that decides whether a percentage means

--- a/ui/src/pages/Landing.tsx
+++ b/ui/src/pages/Landing.tsx
@@ -25,7 +25,7 @@ const WORDS: [RegExp, string][] = [
   [/\b(github|repos?|repositor(y|ies)|commits?|pull requests?|prs?)\b/i, "github"],
   [/\b(vercel|next\.?js|deploys?|deployments?)\b/i, "vercel"],
   [/\b(otlp|opentelemetry|otel|traces?|spans?)\b/i, "otlp"],
-  [/\b(webhook|api|post|json|endpoint|payload)\b/i, "webhook"],
+  [/\b(webhook|json|endpoint|payload|http post)\b/i, "webhook"],
   [/\b(claude code|claude)\b/i, "claude_code"],
 ];
 // Delivery words: not connectors, but the screen should still show it heard them.
@@ -42,7 +42,8 @@ const COMMON: string[] = [
   "tell me when a city in Germany gets storm winds, from a public weather API",
 ];
 
-const STOP = new Set(["the", "and", "when", "with", "that", "this", "from", "into", "what", "your", "my", "an", "a", "to", "of", "on", "in", "it", "is", "me", "for", "one"]);
+// Words every goal shares are not a match: only the nouns of their world count.
+const STOP = new Set(["the", "and", "when", "with", "that", "this", "from", "into", "what", "your", "my", "an", "a", "to", "of", "on", "in", "it", "is", "me", "for", "one", "watch", "agent", "tell", "wake", "show", "its", "something", "every", "each"]);
 const words = (t: string) => new Set(t.toLowerCase().split(/[^a-z0-9]+/).filter((w) => w.length > 2 && !STOP.has(w)));
 
 /** How many of the typed words a sentence shares; the sentences reorder by it while typing. */

--- a/ui/src/pages/Landing.tsx
+++ b/ui/src/pages/Landing.tsx
@@ -77,7 +77,8 @@ export default function Landing({ templates, projects }: { templates: Template[]
   const sentences = useMemo(() => {
     const fromTemplates = templates.filter((t) => t.sentence).map((t) => ({ text: t.sentence!, template: t.key }));
     const all = [...fromTemplates, ...COMMON.map((text) => ({ text, template: "" }))];
-    return all.map((s, i) => ({ ...s, i, score: overlap(typed, s.text) }))
+    // one shared word is noise ("service" matches almost anything); two is a real neighbour
+    return all.map((s, i) => { const n = overlap(typed, s.text); return { ...s, i, score: n >= 2 ? n : 0 }; })
       .sort((a, b) => b.score - a.score || a.i - b.i);
   }, [templates, typed]);
 
@@ -137,7 +138,7 @@ export default function Landing({ templates, projects }: { templates: Template[]
       <div className="landing-starters">
         <div className="help">Or start from one of these</div>
         {sentences.map((s) => (
-          <button key={s.text} type="button" className={"starter" + (s.score > 0 ? " near" : "")}
+          <button key={s.text} type="button" className="starter"
                   onClick={() => { setGoal(s.text); box.current?.focus(); }}>
             {s.text}
           </button>

--- a/ui/src/pages/Landing.tsx
+++ b/ui/src/pages/Landing.tsx
@@ -1,0 +1,172 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+
+import { api } from "../api";
+import type { ConnectorSpec, Project, Template } from "../types";
+
+// The screen a new cell lands on (TR-257): one question, answered by typing. Shown by Home while
+// the cell has no project of the user's own; the seeded demo does not count.
+//
+// It is a conversation that has not started yet, not a form. As the user types, the screen
+// answers: the connectors they name light up under the box, the starter sentences reorder to the
+// closest ones, and the button says back what it understood. Nothing here asks the user to know
+// a source from a view. Three doors, one builder: describe it, paste your last incident, or
+// start the demo. Templates live behind the sentences; the gallery stays one click away under
+// Projects for people who already know what they want.
+
+// Words a person types, mapped to the connector that carries that signal. Only connectors
+// installed on this cell light up; the map is the vocabulary, the cell decides what exists.
+const WORDS: [RegExp, string][] = [
+  [/\b(docker|container|compose)\b/i, "docker_logs"],
+  [/\b(prometheus|metrics?|latency|p95|p99|cpu|memory)\b/i, "prometheus"],
+  [/\b(alerts?|alerting|alertmanager|pager|on-?call)\b/i, "prometheus_alerts"],
+  [/\b(loki|grafana)\b/i, "loki"],
+  [/\b(postgres|postgresql|database|table|sql|rows?)\b/i, "postgres"],
+  [/\b(github|repos?|repositor(y|ies)|commits?|pull requests?|prs?)\b/i, "github"],
+  [/\b(vercel|next\.?js|deploys?|deployments?)\b/i, "vercel"],
+  [/\b(otlp|opentelemetry|otel|traces?|spans?)\b/i, "otlp"],
+  [/\b(webhook|api|post|json|endpoint|payload)\b/i, "webhook"],
+  [/\b(claude code|claude)\b/i, "claude_code"],
+];
+// Delivery words: not connectors, but the screen should still show it heard them.
+const DELIVERY: [RegExp, string][] = [
+  [/\bslack\b/i, "Slack"],
+  [/\b(email|e-mail|mail)\b/i, "email"],
+  [/\b(webhook|post (it|the finding) to|callback)\b/i, "webhook"],
+];
+
+// Goals people arrive with that no template covers; the builder takes them from scratch.
+const COMMON: string[] = [
+  "watch my payment service logs and wake an agent in Slack when checkouts fail",
+  "when a deploy makes my API slower, wake an agent that finds the commit",
+  "tell me when a city in Germany gets storm winds, from a public weather API",
+];
+
+const STOP = new Set(["the", "and", "when", "with", "that", "this", "from", "into", "what", "your", "my", "an", "a", "to", "of", "on", "in", "it", "is", "me", "for", "one"]);
+const words = (t: string) => new Set(t.toLowerCase().split(/[^a-z0-9]+/).filter((w) => w.length > 2 && !STOP.has(w)));
+
+/** How many of the typed words a sentence shares; the sentences reorder by it while typing. */
+function overlap(typed: Set<string>, sentence: string) {
+  if (!typed.size) return 0;
+  let n = 0;
+  for (const w of words(sentence)) if (typed.has(w)) n++;
+  return n;
+}
+
+const shorten = (t: string, n = 44) => (t.length <= n ? t : t.slice(0, n - 1).replace(/\s+\S*$/, "") + "…");
+
+export default function Landing({ templates, projects }: { templates: Template[]; projects: Project[] }) {
+  const navigate = useNavigate();
+  const [goal, setGoal] = useState("");
+  const [paste, setPaste] = useState("");
+  const [pasting, setPasting] = useState(false);
+  const [specs, setSpecs] = useState<Record<string, ConnectorSpec>>({});
+  const box = useRef<HTMLTextAreaElement>(null);
+  useEffect(() => { api.connectors().then(setSpecs).catch(() => {}); }, []);
+  useEffect(() => { box.current?.focus(); }, []);
+
+  const typed = useMemo(() => words(goal), [goal]);
+  // what the screen heard: installed connectors the words point at, and where the finding goes
+  const heard = useMemo(() => {
+    const out: string[] = [];
+    for (const [re, key] of WORDS) if (re.test(goal) && specs[key] && !specs[key].internal && !out.includes(key)) out.push(key);
+    return out;
+  }, [goal, specs]);
+  const delivery = useMemo(() => DELIVERY.filter(([re]) => re.test(goal)).map(([, d]) => d), [goal]);
+
+  const sentences = useMemo(() => {
+    const fromTemplates = templates.filter((t) => t.sentence).map((t) => ({ text: t.sentence!, template: t.key }));
+    const all = [...fromTemplates, ...COMMON.map((text) => ({ text, template: "" }))];
+    return all.map((s, i) => ({ ...s, i, score: overlap(typed, s.text) }))
+      .sort((a, b) => b.score - a.score || a.i - b.i);
+  }, [templates, typed]);
+
+  const demo = projects.find((p) => p.template === "ai_sre_demo");
+  const demoTemplate = templates.find((t) => t.key === "ai_sre_demo");
+
+  const enough = words(goal).size >= 3;
+  const go = () => {
+    if (!goal.trim()) return;
+    navigate("/projects/new/assist", { state: { goal: goal.trim() } });
+  };
+  const goIncident = () => {
+    if (!paste.trim()) return;
+    navigate("/projects/new/assist", { state: { goal: paste.trim(), incident: true } });
+  };
+
+  return (
+    <div className="landing">
+      <h1 className="landing-title">Always-on agents for your systems.</h1>
+      <p className="landing-sub">Give it your data, tell it what to watch for, see it act.</p>
+
+      <form className="landing-ask" onSubmit={(e) => { e.preventDefault(); go(); }}>
+        <label className="landing-q" htmlFor="landing-goal">
+          What should your agent keep an eye on, and what should it do when something is wrong?
+        </label>
+        <textarea id="landing-goal" ref={box} rows={3} value={goal}
+                  placeholder="watch my checkout service logs and wake an agent in Slack when payments fail"
+                  onChange={(e) => setGoal(e.target.value)}
+                  onKeyDown={(e) => { if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); go(); } }} />
+        {/* what the screen heard, before anything is pressed */}
+        <div className="landing-heard">
+          {heard.map((k) => <span key={k} className="chip">{specs[k]?.label ?? k}</span>)}
+          {delivery.map((d) => <span key={d} className="chip lbl">finding to {d}</span>)}
+          {goal.trim() && heard.length === 0 && (
+            <span className="help">say where it runs: a container, a Prometheus URL, a repo, a table, or an API you can post from</span>
+          )}
+        </div>
+        <div className="btnrow">
+          <button className="primary" disabled={!goal.trim()}>
+            {enough ? `Show me: ${shorten(goal.trim())}` : "Show me"}
+          </button>
+          {!pasting && (
+            <button type="button" className="dim" onClick={() => setPasting(true)}>or paste your last alert or incident thread</button>
+          )}
+        </div>
+      </form>
+
+      {pasting && (
+        <form className="landing-ask" onSubmit={(e) => { e.preventDefault(); goIncident(); }}>
+          <label className="landing-q" htmlFor="landing-paste">Paste the alert, the Slack thread, or the postmortem.</label>
+          <textarea id="landing-paste" rows={6} value={paste} autoFocus className="mono"
+                    placeholder={"[FIRING] HighErrorRate on checkout-api\n502s at 14:02, found by a customer at 15:30 ..."}
+                    onChange={(e) => setPaste(e.target.value)} />
+          <span className="help">It goes to the assistant like any message and is not stored beyond the project's goal.</span>
+          <div className="btnrow">
+            <button className="primary" disabled={!paste.trim()}>Show me what would have caught it</button>
+            <button type="button" onClick={() => setPasting(false)}>Cancel</button>
+          </div>
+        </form>
+      )}
+
+      <div className="landing-starters">
+        <div className="help">Or start from one of these</div>
+        {sentences.map((s) => (
+          <button key={s.text} type="button" className={"starter" + (s.score > 0 ? " near" : "")}
+                  onClick={() => { setGoal(s.text); box.current?.focus(); }}>
+            {s.text}
+          </button>
+        ))}
+      </div>
+
+      {demoTemplate && (
+        <div className="panel landing-demo">
+          <div>
+            <strong>Want to see one run before you bring your data?</strong>
+            <p className="help" style={{ margin: "4px 0 0", whiteSpace: "normal" }}>
+              The demo is a small service, an agent watching it, and a button to break it. Remove it any time.
+            </p>
+          </div>
+          {demo
+            ? <Link className="btn" to={`/projects/${encodeURIComponent(demo.id)}`}>Open the demo</Link>
+            : <button onClick={() => navigate("/projects/new/ai_sre_demo")}>Start the demo</button>}
+        </div>
+      )}
+
+      <p className="help landing-foot">
+        Know exactly what you want? <Link to="/projects/new">Pick a template</Link> or{" "}
+        <Link to="/sources/new">add a source</Link>.
+      </p>
+    </div>
+  );
+}

--- a/ui/src/pages/Landing.tsx
+++ b/ui/src/pages/Landing.tsx
@@ -8,8 +8,8 @@ import type { ConnectorSpec, Project, Template } from "../types";
 // the cell has no project of the user's own; the seeded demo does not count.
 //
 // It is a conversation that has not started yet, not a form. As the user types, the screen
-// answers: the connectors they name light up under the box, the starter sentences reorder to the
-// closest ones, and the button says back what it understood. Nothing here asks the user to know
+// answers: the connectors they name light up under the box, and the starter sentences reorder to the
+// closest ones. Nothing here asks the user to know
 // a source from a view. Three doors, one builder: describe it, paste your last incident, or
 // start the demo. Templates live behind the sentences; the gallery stays one click away under
 // Projects for people who already know what they want.
@@ -19,7 +19,8 @@ import type { ConnectorSpec, Project, Template } from "../types";
 const WORDS: [RegExp, string][] = [
   [/\b(docker|container|compose)\b/i, "docker_logs"],
   [/\b(prometheus|metrics?|latency|p95|p99|cpu|memory)\b/i, "prometheus"],
-  [/\b(alerts?|alerting|alertmanager|pager|on-?call)\b/i, "prometheus_alerts"],
+  // "alert me" is what the user wants done, not a source; only the product names count here
+  [/\b(alertmanager|prometheus alerts?|alerting rules?)\b/i, "prometheus_alerts"],
   [/\b(loki|grafana)\b/i, "loki"],
   [/\b(postgres|postgresql|database|table|sql|rows?)\b/i, "postgres"],
   [/\b(github|repos?|repositor(y|ies)|commits?|pull requests?|prs?)\b/i, "github"],
@@ -54,8 +55,6 @@ function overlap(typed: Set<string>, sentence: string) {
   return n;
 }
 
-const shorten = (t: string, n = 44) => (t.length <= n ? t : t.slice(0, n - 1).replace(/\s+\S*$/, "") + "…");
-
 export default function Landing({ templates, projects }: { templates: Template[]; projects: Project[] }) {
   const navigate = useNavigate();
   const [goal, setGoal] = useState("");
@@ -85,7 +84,6 @@ export default function Landing({ templates, projects }: { templates: Template[]
   const demo = projects.find((p) => p.template === "ai_sre_demo");
   const demoTemplate = templates.find((t) => t.key === "ai_sre_demo");
 
-  const enough = words(goal).size >= 3;
   const go = () => {
     if (!goal.trim()) return;
     navigate("/projects/new/assist", { state: { goal: goal.trim() } });
@@ -101,9 +99,7 @@ export default function Landing({ templates, projects }: { templates: Template[]
       <p className="landing-sub">Give it your data, tell it what to watch for, see it act.</p>
 
       <form className="landing-ask" onSubmit={(e) => { e.preventDefault(); go(); }}>
-        <label className="landing-q" htmlFor="landing-goal">
-          What should your agent keep an eye on, and what should it do when something is wrong?
-        </label>
+        <label className="landing-q" htmlFor="landing-goal">What do you want to build?</label>
         <textarea id="landing-goal" ref={box} rows={3} value={goal}
                   placeholder="watch my checkout service logs and wake an agent in Slack when payments fail"
                   onChange={(e) => setGoal(e.target.value)}
@@ -117,9 +113,7 @@ export default function Landing({ templates, projects }: { templates: Template[]
           )}
         </div>
         <div className="btnrow">
-          <button className="primary" disabled={!goal.trim()}>
-            {enough ? `Show me: ${shorten(goal.trim())}` : "Show me"}
-          </button>
+          <button className="primary" disabled={!goal.trim()}>Show me</button>
           {!pasting && (
             <button type="button" className="dim" onClick={() => setPasting(true)}>or paste your last alert or incident thread</button>
           )}

--- a/ui/src/pages/ProjectNewAssist.tsx
+++ b/ui/src/pages/ProjectNewAssist.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
@@ -57,14 +57,26 @@ const wireText = (t: Turn, decisions: DecisionMap) => t.parts.map((p) => {
 const kindOf = (p: Proposal): ProjectObjectKind | null =>
   p.kind === "labels" ? null : p.kind;
 
+/** A project name from the first content words of the goal, editable until the project exists. */
+const NAME_STOP = new Set(["the", "and", "when", "with", "that", "this", "from", "into", "what", "your", "my", "an", "a", "to", "of", "on", "in", "it", "is", "me", "for", "watch", "tell", "wake", "agent", "want", "please"]);
+function nameFromGoal(goal: string, incident: boolean): string {
+  const ws = goal.toLowerCase().split(/[^a-z0-9-]+/).filter((w) => w.length > 2 && !NAME_STOP.has(w)).slice(0, 4);
+  const base = ws.join(" ") || "my project";
+  return incident ? `catch ${base}` : base;
+}
+
 export default function ProjectNewAssist() {
   const [ready, setReady] = useState<boolean>();
   const refreshKey = () => api.capabilities()
     .then((c) => setReady(!!c.agent_key_configured)).catch(() => setReady(false));
   useEffect(() => { refreshKey(); }, []);
 
-  const [goal, setGoal] = useState("");
-  const [projectName, setProjectName] = useState("");
+  // Handed over from the landing screen (Landing.tsx): the goal already typed, so the builder
+  // starts its first turn on arrival and the user never sees an empty box. `incident` means the
+  // text is a pasted alert or thread, framed for the model as something to have caught.
+  const handoff = (useLocation().state ?? {}) as { goal?: string; incident?: boolean };
+  const [goal, setGoal] = useState(handoff.goal ?? "");
+  const [projectName, setProjectName] = useState(handoff.goal ? nameFromGoal(handoff.goal, !!handoff.incident) : "");
   const [step, setStep] = useState<StepKey | "describe" | "done">("describe");
   const [states, setStates] = useState<Record<StepKey, StepState>>({
     sources: { turns: [] }, watch: { turns: [] }, agent: { turns: [] },
@@ -161,8 +173,20 @@ export default function ProjectNewAssist() {
 
   const start = async () => {
     setStep("sources");
-    await turn("sources", `Project: ${projectName.trim()}.\nGoal: ${goal.trim()}`);
+    const framing = handoff.incident
+      ? `Project: ${projectName.trim()}.\nThis is an incident I had, pasted as it was written:\n\n${goal.trim()}\n\nPropose the project that would have caught it: the sources that carry the signal it shows, named the way the paste names things. Say in one sentence when it would have fired. Ask me only what the paste does not say.`
+      : `Project: ${projectName.trim()}.\nGoal: ${goal.trim()}`;
+    await turn("sources", framing);
   };
+
+  // arriving from the landing screen: start at once, once, when the key is known to be there
+  const autoStarted = useRef(false);
+  useEffect(() => {
+    if (ready && handoff.goal && step === "describe" && !autoStarted.current) {
+      autoStarted.current = true;
+      start();
+    }
+  }, [ready]);   // eslint-disable-line react-hooks/exhaustive-deps
 
   /** Move on: tell the model what got created (with the decisions now known) and ask for the
    *  next step's proposals. */
@@ -231,7 +255,8 @@ export default function ProjectNewAssist() {
         <label className="field">
           <span className="lbl">project name<span className="req"> *</span></span>
           <input type="text" value={projectName} onChange={(e) => setProjectName(e.target.value)}
-                 disabled={step !== "describe"} placeholder="e.g. checkout incidents" style={{ maxWidth: 420 }} />
+                 disabled={!!project} placeholder="e.g. checkout incidents" style={{ maxWidth: 420 }} />
+          {handoff.goal && !project && <span className="help">proposed from what you typed; change it any time before the first object is created</span>}
         </label>
         <label className="field">
           <span className="lbl">what you need<span className="req"> *</span></span>

--- a/ui/src/pages/ProjectNewAssist.tsx
+++ b/ui/src/pages/ProjectNewAssist.tsx
@@ -58,7 +58,7 @@ const kindOf = (p: Proposal): ProjectObjectKind | null =>
   p.kind === "labels" ? null : p.kind;
 
 /** A project name from the first content words of the goal, editable until the project exists. */
-const NAME_STOP = new Set(["the", "and", "when", "with", "that", "this", "from", "into", "what", "your", "my", "an", "a", "to", "of", "on", "in", "it", "is", "me", "for", "watch", "tell", "wake", "agent", "want", "please"]);
+const NAME_STOP = new Set(["the", "and", "when", "with", "that", "this", "from", "into", "what", "your", "my", "an", "a", "to", "of", "on", "in", "it", "its", "is", "me", "for", "watch", "tell", "wake", "agent", "want", "please", "show", "then", "also"]);
 function nameFromGoal(goal: string, incident: boolean): string {
   const ws = goal.toLowerCase().split(/[^a-z0-9-]+/).filter((w) => w.length > 2 && !NAME_STOP.has(w)).slice(0, 4);
   const base = ws.join(" ") || "my project";

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -1358,6 +1358,5 @@ pre.payload {
 .landing-ask textarea.mono { font-family: var(--mono); font-size: 13px; }
 .landing-heard { min-height: 26px; display: flex; flex-wrap: wrap; gap: 6px; align-items: center; margin: 8px 0 10px; }
 .landing-starters { display: flex; flex-direction: column; gap: 6px; margin-bottom: 18px; }
-.landing-starters .starter.near { border-color: var(--accent); }
 .landing-demo { display: flex; align-items: center; justify-content: space-between; gap: 24px; margin-bottom: 14px; }
 .landing-foot { text-align: center; }

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -1347,3 +1347,17 @@ pre.payload {
 .uc-setup-cmd pre { margin: 0; padding: 8px 10px; border: 1px solid var(--line); background: var(--wash); font-size: 12px; flex: 1; overflow-x: auto; white-space: pre; }
 .uc-actions { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; }
 .uc-setup-done .uc-setup-title { color: var(--ink-soft); }
+
+/* The landing screen (Landing.tsx): one question, centred, nothing else asking for attention. */
+.landing { max-width: 760px; margin: 24px auto 0; }
+.landing-title { font-size: 28px; margin: 0 0 4px; }
+.landing-sub { color: var(--ink-soft); margin: 0 0 28px; font-size: 15px; }
+.landing-ask { background: var(--panel); border: 1px solid var(--line); padding: 18px 20px; margin-bottom: 18px; }
+.landing-q { display: block; font-weight: 600; margin-bottom: 10px; }
+.landing-ask textarea { width: 100%; box-sizing: border-box; font: inherit; font-size: 15px; padding: 10px 12px; }
+.landing-ask textarea.mono { font-family: var(--mono); font-size: 13px; }
+.landing-heard { min-height: 26px; display: flex; flex-wrap: wrap; gap: 6px; align-items: center; margin: 8px 0 10px; }
+.landing-starters { display: flex; flex-direction: column; gap: 6px; margin-bottom: 18px; }
+.landing-starters .starter.near { border-color: var(--accent); }
+.landing-demo { display: flex; align-items: center; justify-content: space-between; gap: 24px; margin-bottom: 14px; }
+.landing-foot { text-align: center; }

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -442,6 +442,8 @@ export interface Template {
   // The card's you/Tares bullets, in the mode the daemon is running in (a hosted demo stack
   // says different things than a local docker one). Absent on older daemons.
   facts?: { you: string[]; tares: string[] };
+  // what a person would type to get this template, first person; the landing screen's starters
+  sentence?: string;
 }
 export interface McpServer {
   name: string; url: string; auth_header: string; auth_value_configured: boolean;


### PR DESCRIPTION
Linear: TR-257. Stacked on #112 (the builder); merge that first.

A new cell lands on one question instead of the projects gallery. `Home` renders `Landing` while the cell has no project of the user's own (the seeded AI SRE demo does not count); `?landing` previews it anywhere; a "Skip, show the instance overview" link remembers the choice in that browser.

- One box, "What do you want to build?". As you type, the installed connectors you name light up under it (Docker logs, Prometheus, "finding to Slack"); the starter sentences reorder when one shares two or more real words with the text. No outline, no changing button text.
- Starters: each template declares a first-person `sentence` in `describe()` (new field on the Template base), plus three common goals with no template. Clicking one types it into the box.
- Three doors: describe it; "or paste your last alert or incident thread", which frames the paste for the assistant as something to have caught; the demo as an offer, linking to the seeded project or its wizard.
- Show me lands in the builder with the goal filled and the first turn already running; the project name is proposed from the goal and stays editable until the first object exists.

Test: `test_projects.py` checks every template carries `sentence`.