### PR TITLE
Builder proposes a template as one card

### DIFF
--- a/tares/agent.py
+++ b/tares/agent.py
@@ -54,6 +54,20 @@ TOOLS = [
      "input_schema": {"type": "object", "properties": {
          "name": {"type": "string"}, "limit": {"type": "integer", "default": 20}},
          "required": ["name"]}},
+    {"name": "list_templates",
+     "description": "The project templates installed here: key, title, what each sets up, its "
+                    "parameters (with help text, required, secret) and the sentence a user would "
+                    "type to get it. A template creates its whole project in one step; prefer one "
+                    "over assembling the same thing from parts.",
+     "input_schema": {"type": "object", "properties": {}}},
+    {"name": "detect_template",
+     "description": "Ask a template to look at the environment (running containers, reachable "
+                    "services) and propose parameter values. Returns {params, found, missing, "
+                    "notes}. Call it before proposing a template so the user confirms detected "
+                    "values instead of typing them.",
+     "input_schema": {"type": "object", "properties": {
+         "key": {"type": "string", "description": "the template key from list_templates"}},
+         "required": ["key"]}},
     {"name": "query",
      "description": "Pull one correlated, time-ordered timeline for an entity from a view. Select "
                     "the entity by `key` or by `where` ({label: value}). Needs an existing view "
@@ -175,6 +189,21 @@ BUILD_PROPOSAL_TOOLS = [
                                   "secret, plus anything you would otherwise have to guess"},
          "reasoning": {"type": "string"}},
          "required": ["name", "connector", "needs", "reasoning"]}},
+    {"name": "propose_project",
+     "description": "Propose a whole project from an installed template, as its prefilled form "
+                    "the user will confirm. Use it when the goal is what a template sets up "
+                    "(compare with the template's sentence and description) instead of building "
+                    "the same thing from parts. `params` holds the values you know: what the user "
+                    "said, or what detect_template found. Every secret and every value you would "
+                    "have to guess goes in `needs`, never in `params`.",
+     "input_schema": {"type": "object", "properties": {
+         "template": {"type": "string", "description": "the template key from list_templates"},
+         "name": {"type": "string", "description": "a short project name"},
+         "params": {"type": "object", "description": "parameter values, keyed by parameter name"},
+         "needs": {"type": "array", "items": {"type": "string"},
+                   "description": "parameter names the user must fill themselves"},
+         "reasoning": {"type": "string"}},
+         "required": ["template", "name", "needs", "reasoning"]}},
     {"name": "propose_agent",
      "description": "Propose the Tares agent that runs when the trigger fires, as a prefilled "
                     "agent form the user will review. `trigger` must be a trigger that exists or "
@@ -202,12 +231,14 @@ BUILD_PROPOSAL_TOOLS = [
 ]
 _ALL_PROPOSALS = {t["name"]: t for t in PROPOSAL_TOOLS + BUILD_PROPOSAL_TOOLS}
 _PROPOSAL_KIND = {"propose_labels": "labels", "propose_view": "view", "propose_trigger": "trigger",
-                  "propose_source": "source", "propose_agent": "agent"}
+                  "propose_source": "source", "propose_agent": "agent",
+                  "propose_project": "project"}
 
 # Which proposal tools each build step gets. The step-scoped toolset is what makes an out-of-order
 # proposal impossible: a views turn cannot emit a trigger card because the tool is not there.
 BUILD_STEPS = {
-    "sources": ["propose_source"],
+    # a whole project from a template is proposed on the first step, in place of its parts
+    "sources": ["propose_source", "propose_project"],
     # views and triggers are one step: a view exists to be watched, and the user thinks about
     # "what should fire" as one question, not two pages
     "watch": ["propose_view", "propose_labels", "propose_trigger"],
@@ -261,6 +292,10 @@ async def _execute_tool(name: str, args: dict, headers: dict) -> tuple[bool, str
         elif name == "recent_events":
             r = await cx.get(f"/api/sources/{args.get('name', '')}/events",
                              params={"limit": int(args.get("limit", 20))})
+        elif name == "list_templates":
+            r = await cx.get("/api/projects/templates")
+        elif name == "detect_template":
+            r = await cx.post(f"/api/projects/templates/{args.get('key', '')}/detect")
         elif name == "query":
             body = {"view": args.get("view"), "window": args.get("window", "15m"), "client": "in-app-agent"}
             if args.get("key"):
@@ -355,7 +390,13 @@ propose NOTHING in that turn; the user answers in the box under your message and
 the next turn. When the goal already says enough, propose directly. Never fill a gap with a \
 default the user did not choose and present it as theirs.
 
-· SOURCES: map the user's goal onto the INSTALLED connectors only. Call list_connectors first and \
+· TEMPLATES FIRST: call list_templates on the sources step. If the goal is what a template sets \
+up (its sentence or description says the same thing in other words), do not assemble it from \
+parts: ask for the parameters only the user knows, call detect_template for the rest, and make \
+ONE propose_project card. If the console says the user picked a template, that is the answer; \
+gather its parameters and propose it. Templates set up everything at once, so after that card \
+there is nothing left to propose on any step.
+· SOURCES: otherwise, map the user's goal onto the INSTALLED connectors only. Call list_connectors first and \
 pick from what it returns; never name a connector it does not list. If nothing installed fits \
 part of the goal, say so in one sentence rather than forcing a poor match. One propose_source \
 card per source. Put in `config` only the non-secret values the user actually told you (a URL \

--- a/tares/agent.py
+++ b/tares/agent.py
@@ -60,6 +60,11 @@ TOOLS = [
                     "type to get it. A template creates its whole project in one step; prefer one "
                     "over assembling the same thing from parts.",
      "input_schema": {"type": "object", "properties": {}}},
+    {"name": "list_projects",
+     "description": "The projects that already exist here, with the template each came from. A "
+                    "template's project usually exists at most once (its objects have fixed "
+                    "names), so check before proposing one.",
+     "input_schema": {"type": "object", "properties": {}}},
     {"name": "detect_template",
      "description": "Ask a template to look at the environment (running containers, reachable "
                     "services) and propose parameter values. Returns {params, found, missing, "
@@ -294,6 +299,8 @@ async def _execute_tool(name: str, args: dict, headers: dict) -> tuple[bool, str
                              params={"limit": int(args.get("limit", 20))})
         elif name == "list_templates":
             r = await cx.get("/api/projects/templates")
+        elif name == "list_projects":
+            r = await cx.get("/api/projects")
         elif name == "detect_template":
             r = await cx.post(f"/api/projects/templates/{args.get('key', '')}/detect")
         elif name == "query":
@@ -394,8 +401,11 @@ default the user did not choose and present it as theirs.
 up (its sentence or description says the same thing in other words), do not assemble it from \
 parts: ask for the parameters only the user knows, call detect_template for the rest, and make \
 ONE propose_project card. If the console says the user picked a template, that is the answer; \
-gather its parameters and propose it. Templates set up everything at once, so after that card \
-there is nothing left to propose on any step.
+gather its parameters and propose it. Check list_projects first: if a project from that template \
+already exists, say so and point at it instead of proposing another; a second one cannot be \
+created. Templates set up everything at once, so after that card there is nothing left to \
+propose on any step. The console shows the template's setup steps after the user presses Start: \
+do not list them, and say "press Start", never "apply the card".
 · SOURCES: otherwise, map the user's goal onto the INSTALLED connectors only. Call list_connectors first and \
 pick from what it returns; never name a connector it does not list. If nothing installed fits \
 part of the goal, say so in one sentence rather than forcing a poor match. One propose_source \

--- a/tares/daemon.py
+++ b/tares/daemon.py
@@ -2209,6 +2209,17 @@ def make_app() -> FastAPI:
     async def project_templates():
         return {"templates": projects.list_templates()}
 
+    # By key, hidden templates included: the gallery list leaves out templates a person does not
+    # pick (rius_rca is created by the Rius control plane), but the Edit page of a project built
+    # on one still has to render its form.
+    @app.get("/api/projects/templates/{key}")
+    async def project_template(key: str):
+        from .projects.registry import get_template
+        try:
+            return get_template(key).describe()
+        except ProjectError:
+            _err(KeyError(f"unknown template {key!r}"), 404)
+
     @app.get("/api/projects")
     async def list_projects():
         return {"projects": projects.list()}

--- a/tests/test_agent_build.py
+++ b/tests/test_agent_build.py
@@ -69,8 +69,8 @@ ck("propose_source config is an object, poll optional",
 pj = by_name["propose_project"]["input_schema"]
 ck("propose_project requires template, name, needs, reasoning",
    set(pj["required"]) == {"template", "name", "needs", "reasoning"}, str(pj["required"]))
-ck("read tools include list_templates and detect_template",
-   {"list_templates", "detect_template"} <= READ)
+ck("read tools include list_templates, list_projects and detect_template",
+   {"list_templates", "list_projects", "detect_template"} <= READ)
 ag = by_name["propose_agent"]["input_schema"]
 ck("propose_agent requires name, trigger, prompt, delivery, reasoning",
    set(ag["required"]) == {"name", "trigger", "prompt", "delivery", "reasoning"}, str(ag["required"]))

--- a/tests/test_agent_build.py
+++ b/tests/test_agent_build.py
@@ -44,7 +44,7 @@ ck("ask mode is the read tools plus the catalog cards",
 ck("ask mode never offers the build-only cards",
    not names(agent.tools_for()) & {"propose_source", "propose_agent"})
 expected = {
-    "sources": {"propose_source"},
+    "sources": {"propose_source", "propose_project"},
     "watch": {"propose_view", "propose_labels", "propose_trigger"},
     "agent": {"propose_agent"},
 }
@@ -66,6 +66,11 @@ ck("propose_source needs is a list of field names",
    and src["properties"]["needs"]["items"]["type"] == "string")
 ck("propose_source config is an object, poll optional",
    src["properties"]["config"]["type"] == "object" and "poll" not in src["required"])
+pj = by_name["propose_project"]["input_schema"]
+ck("propose_project requires template, name, needs, reasoning",
+   set(pj["required"]) == {"template", "name", "needs", "reasoning"}, str(pj["required"]))
+ck("read tools include list_templates and detect_template",
+   {"list_templates", "detect_template"} <= READ)
 ag = by_name["propose_agent"]["input_schema"]
 ck("propose_agent requires name, trigger, prompt, delivery, reasoning",
    set(ag["required"]) == {"name", "trigger", "prompt", "delivery", "reasoning"}, str(ag["required"]))
@@ -79,7 +84,7 @@ ck("every proposal tool requires reasoning",
 ck("every proposal tool maps to a card kind",
    set(agent._PROPOSAL_KIND) == ALL_PROPOSALS, str(set(agent._PROPOSAL_KIND) ^ ALL_PROPOSALS))
 ck("card kinds are the object kinds the console knows",
-   set(agent._PROPOSAL_KIND.values()) == {"labels", "view", "trigger", "source", "agent"})
+   set(agent._PROPOSAL_KIND.values()) == {"labels", "view", "trigger", "source", "agent", "project"})
 
 print("== prompts ==")
 base, build = agent.system_prompt(), agent.system_prompt("build")
@@ -88,7 +93,7 @@ ck("build prompt is the ask prompt plus the build section",
    build.startswith(base) and "BUILD MODE" in build)
 for marker in ("ASK BEFORE YOU GUESS", "INSTALLED connectors", "`needs`", "source_fields",
                "One card per object", "propose NOTHING in that turn",
-               "ask what the agent should do", "delivery.url"):
+               "ask what the agent should do", "delivery.url", "TEMPLATES FIRST"):
     ck(f"build prompt says: {marker}", marker in build)
 
 

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -267,6 +267,8 @@ export const api = {
 
   // ── Projects: templates instantiated with params; each instance owns ordinary objects ──
   templates: () => request<{ templates: Template[] }>("/api/projects/templates"),
+  // by key, hidden templates included (the gallery list leaves those out)
+  template: (key: string) => request<Template>(`/api/projects/templates/${encodeURIComponent(key)}`),
   projects: () => request<{ projects: Project[] }>("/api/projects"),
   project: (id: string) => request<Project>(`/api/projects/${encodeURIComponent(id)}`),
   // Accepted memory: only what a user accepted is ever written (a proposal is just text until then).

--- a/ui/src/components/TemplateParams.tsx
+++ b/ui/src/components/TemplateParams.tsx
@@ -1,0 +1,83 @@
+import { Picker } from "./bits";
+import type { RecipeParam, Template } from "../types";
+
+// A template's parameters as form fields, for the builder's project card (the assistant proposed
+// a whole template; the user confirms its values here). Mirrors the generic wizard's field
+// rendering: strings, numbers, booleans and choices get inputs; lists and objects are JSON.
+// Kept separate from ProjectNewGeneric so this card can be dropped without touching the wizard.
+
+export type Detected = { params: Record<string, unknown>; found: Record<string, string>;
+                         missing: Record<string, string>; notes: string[] };
+
+/** A param value as the form shows it. */
+export function paramText(p: RecipeParam, v: unknown): string {
+  if (v === undefined || v === null || v === "") {
+    if (p.default == null) return p.type === "bool" ? "false" : "";
+    return typeof p.default === "string" ? p.default : JSON.stringify(p.default);
+  }
+  if (p.type === "bool") return v ? "true" : "false";
+  if (p.type === "list" || p.type === "json") return typeof v === "string" ? v : JSON.stringify(v, null, 2);
+  return String(v);
+}
+
+/** The form values back into the shape POST /api/projects takes. Throws on bad JSON. */
+export function paramsBody(template: Template, vals: Record<string, string>): Record<string, unknown> {
+  const params: Record<string, unknown> = {};
+  for (const [k, p] of Object.entries(template.params)) {
+    const v = vals[k] ?? "";
+    if (v === "" && !p.required) continue;
+    if (p.type === "number") params[k] = Number(v);
+    else if (p.type === "bool") params[k] = v === "true";
+    else if (p.type === "list" || p.type === "json") params[k] = v ? JSON.parse(v) : undefined;
+    else params[k] = v;
+  }
+  return params;
+}
+
+export default function TemplateParams({ template, vals, setVals, needs, models, defaultModel, detected }: {
+  template: Template;
+  vals: Record<string, string>;
+  setVals: (v: Record<string, string>) => void;
+  needs?: string[];            // params the user must fill: highlighted, never prefilled
+  models: string[];
+  defaultModel: string;
+  detected?: Detected;
+}) {
+  return (
+    <>
+      {Object.entries(template.params).map(([k, p]) => {
+        const mine = needs?.includes(k);
+        return (
+          <label className={"field" + (mine ? " needs" : "")} key={k}>
+            <span className="lbl">
+              {p.label ?? k}{p.required && <span className="req"> *</span>}
+              {mine && <span className="badge" style={{ marginLeft: 8 }}>yours to fill</span>}
+            </span>
+            {p.type === "bool" ? (
+              <Picker value={vals[k] ?? "false"} onChange={(v) => setVals({ ...vals, [k]: v })}
+                      options={["true", "false"]} ariaLabel={k} />
+            ) : k === "model" ? (
+              <Picker value={vals[k] ?? ""} onChange={(v) => setVals({ ...vals, [k]: v })}
+                      options={["", ...models.filter((m) => m !== defaultModel)]}
+                      labels={{ "": defaultModel ? `${defaultModel} · instance default` : "instance default" }}
+                      ariaLabel="model" />
+            ) : p.choices?.length ? (
+              <Picker value={vals[k] ?? ""} onChange={(v) => setVals({ ...vals, [k]: v })}
+                      options={p.choices} ariaLabel={k} />
+            ) : p.type === "list" || p.type === "json" ? (
+              <textarea className="mono" rows={4} value={vals[k] ?? ""}
+                        onChange={(e) => setVals({ ...vals, [k]: e.target.value })} placeholder="JSON" />
+            ) : (
+              <input type={p.secret ? "password" : p.type === "number" ? "number" : "text"} className="mono"
+                     autoComplete={p.secret ? "new-password" : undefined} value={vals[k] ?? ""}
+                     onChange={(e) => setVals({ ...vals, [k]: e.target.value })} />
+            )}
+            {p.help && <span className="help">{p.help}</span>}
+            {detected?.found[k] && <span className="help" style={{ color: "var(--ok)" }}>detected: {detected.found[k]}</span>}
+            {detected?.missing[k] && <span className="help" style={{ color: "var(--warn, var(--err))" }}>not detected: {detected.missing[k]}</span>}
+          </label>
+        );
+      })}
+    </>
+  );
+}

--- a/ui/src/components/proposals.tsx
+++ b/ui/src/components/proposals.tsx
@@ -266,9 +266,9 @@ export function ProposalBody({ proposal }: { proposal: Proposal }) {
       {proposal.kind === "project" && (
         <p style={{ margin: "0 0 8px" }}>
           from the template <span className="chip mono">{proposal.template}</span>
-          {Object.keys(proposal.params ?? {}).length > 0 && (
+          {Object.entries(proposal.params ?? {}).filter(([, v]) => v !== "" && v !== null && v !== undefined).length > 0 && (
             <> · prefilled{" "}
-              {Object.entries(proposal.params ?? {}).map(([k, v]) => (
+              {Object.entries(proposal.params ?? {}).filter(([, v]) => v !== "" && v !== null && v !== undefined).map(([k, v]) => (
                 <span key={k} className="chip mono" title={typeof v === "string" ? v : JSON.stringify(v)}>{k}</span>
               ))}
             </>

--- a/ui/src/components/proposals.tsx
+++ b/ui/src/components/proposals.tsx
@@ -23,6 +23,8 @@ export type Proposal =
       emit?: { kind?: string; context_window?: string }; cooldown?: string; reasoning: string }
   | { id: string; kind: "source"; name: string; connector: string; poll?: string;
       config?: Record<string, unknown>; needs: string[]; reasoning: string }
+  | { id: string; kind: "project"; template: string; name: string; params?: Record<string, unknown>;
+      needs: string[]; reasoning: string }
   | { id: string; kind: "agent"; name: string; trigger: string; prompt: string; model?: string;
       max_rounds?: number; budget_usd?: number;
       delivery: { kind: "slack" | "webhook" | "none"; url?: string };   // url only when the user typed it
@@ -52,7 +54,7 @@ export type DecisionMap = Record<string, { status: Decision; detail?: string }>;
 /** Apply one proposal via the normal management APIs. Throws with a readable message. Source
  *  and agent cards are not applied here: they become forms on the builder page. */
 export async function applyProposal(p: Proposal): Promise<void> {
-  if (p.kind === "source" || p.kind === "agent") {
+  if (p.kind === "source" || p.kind === "agent" || p.kind === "project") {
     throw new Error(`a ${p.kind} proposal is completed as a form, not applied as is`);
   }
   if (p.kind === "labels") {
@@ -126,7 +128,7 @@ function NormPreview({ source, label }: { source: string; label: LabelSpec }) {
 /** What a proposal is called on its card: "View timeline", "Labels for logs", ... */
 export function proposalTitle(p: Proposal) {
   if (p.kind === "labels") return <>Labels for <span className="mono">{p.source}</span></>;
-  const noun = { view: "View", trigger: "Trigger", source: "Source", agent: "Agent" }[p.kind];
+  const noun = { view: "View", trigger: "Trigger", source: "Source", agent: "Agent", project: "Project" }[p.kind];
   return <>{noun} <span className="mono">{p.name}</span></>;
 }
 
@@ -250,6 +252,24 @@ export function ProposalBody({ proposal }: { proposal: Proposal }) {
             <> · prefilled{" "}
               {Object.entries(proposal.config ?? {}).map(([k, v]) => (
                 <span key={k} className="chip mono" title={String(v)}>{k}</span>
+              ))}
+            </>
+          )}
+          {proposal.needs.length > 0 && (
+            <span className="help" style={{ display: "block" }}>
+              you fill in: {proposal.needs.map((n) => <span key={n} className="chip mono">{n}</span>)}
+            </span>
+          )}
+        </p>
+      )}
+
+      {proposal.kind === "project" && (
+        <p style={{ margin: "0 0 8px" }}>
+          from the template <span className="chip mono">{proposal.template}</span>
+          {Object.keys(proposal.params ?? {}).length > 0 && (
+            <> · prefilled{" "}
+              {Object.entries(proposal.params ?? {}).map(([k, v]) => (
+                <span key={k} className="chip mono" title={typeof v === "string" ? v : JSON.stringify(v)}>{k}</span>
               ))}
             </>
           )}

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -28,7 +28,8 @@ import McpServers from "./pages/McpServers";
 import Sources from "./pages/Sources";
 import { TriggersPage, ViewsPage } from "./pages/ViewsTriggers";
 import Projects from "./pages/Projects";
-import ProjectNew from "./pages/ProjectNew";
+import ProjectTemplates from "./pages/ProjectNew";
+import { ProjectNewPage } from "./pages/Landing";
 import ProjectDetail from "./pages/ProjectDetail";
 import ProjectNewAssist from "./pages/ProjectNewAssist";
 import ProjectNewCustom from "./pages/ProjectNewCustom";
@@ -60,7 +61,9 @@ const router = createBrowserRouter([
       // here, so a customer arrives at the instance at a glance rather than at a table.
       { index: true, element: <Home /> },
       { path: "projects", element: <Projects /> },
-      { path: "projects/new", element: <ProjectNew /> },
+      // Create new is the landing screen; the template gallery is the step-by-step path behind it
+      { path: "projects/new", element: <ProjectNewPage /> },
+      { path: "projects/new/templates", element: <ProjectTemplates /> },
       { path: "projects/new/shared_code_context", element: <ProjectNewSharedContext /> },
       { path: "projects/new/custom", element: <ProjectNewCustom /> },
       // the AI-guided builder is not a template (it assembles a custom project), so it sits

--- a/ui/src/pages/Home.tsx
+++ b/ui/src/pages/Home.tsx
@@ -110,10 +110,19 @@ export default function Home() {
         pct={pct}
       />
 
+      {/* An empty cell's next step is a project, not a source: the builder brings the sources
+          with it. Add a source stays as the secondary link for someone who only wants data in. */}
       {sources && sources.length === 0 && !sourcesError && (
         <div className="empty">
-          Nothing is being ingested yet; <Link to="/sources/new">add a source</Link> to start
-          filling the timeline.
+          Nothing to watch yet.{" "}
+          <Link to="/projects/new">Create a project</Link>: describe what you need and Tares sets
+          up the sources, views, triggers and agent with you. Or <Link to="/sources/new">add a source</Link> on its own.
+        </div>
+      )}
+      {sources && sources.length > 0 && own.length === 0 && (
+        <div className="empty">
+          Data is coming in, but nothing watches it yet.{" "}
+          <Link to="/projects/new">Create a project</Link> to add views, triggers and an agent on top.
         </div>
       )}
     </>

--- a/ui/src/pages/Landing.tsx
+++ b/ui/src/pages/Landing.tsx
@@ -3,7 +3,6 @@ import { Link, useNavigate } from "react-router-dom";
 
 import { api } from "../api";
 import { usePolling } from "../components/bits";
-import { wizardPath } from "./ProjectNew";
 import type { ConnectorSpec, Project, Template } from "../types";
 
 // The screen a new cell lands on (TR-257): one question, answered by typing. Shown by Home while
@@ -129,8 +128,14 @@ export default function Landing({ templates, projects }: { templates: Template[]
 
   return (
     <div className="landing">
-      <h1 className="landing-title">Always-on agents for your systems.</h1>
-      <p className="landing-sub">Give it your data, tell it what to watch for, see it act.</p>
+      <div className="landing-head">
+        <div>
+          <h1 className="landing-title">Always-on agents for your systems.</h1>
+          <p className="landing-sub">Give it your data, tell it what to watch for, see it act.</p>
+        </div>
+        {/* the deterministic path: the template gallery, one button, top right */}
+        <Link className="btn" to="/projects/new/templates">Use a guided template</Link>
+      </div>
 
       <form className="landing-ask" onSubmit={(e) => { e.preventDefault(); go(); }}>
         <label className="landing-q" htmlFor="landing-goal">What do you want to build?</label>
@@ -171,14 +176,10 @@ export default function Landing({ templates, projects }: { templates: Template[]
       <div className="landing-starters">
         <div className="help">Or start from one of these</div>
         {sentences.map((s) => (
-          <div key={s.text} className="starter-row">
-            <button type="button" className="starter"
-                    onClick={() => { setGoal(s.text); setPicked(s.template); box.current?.focus(); }}>
-              {s.text}
-            </button>
-            {/* the deterministic path, one click away on every template sentence */}
-            {s.template && <Link className="help starter-wizard" to={wizardPath(s.template)} title="the template's form, no assistant">set up step by step</Link>}
-          </div>
+          <button key={s.text} type="button" className="starter"
+                  onClick={() => { setGoal(s.text); setPicked(s.template); box.current?.focus(); }}>
+            {s.text}
+          </button>
         ))}
       </div>
 
@@ -202,9 +203,8 @@ export default function Landing({ templates, projects }: { templates: Template[]
       )}
 
       <p className="help landing-foot">
-        Know exactly what you want? <Link to="/projects/new/templates">Pick a template</Link>,{" "}
-        <Link to="/projects/new/custom">assemble from existing objects</Link>, or{" "}
-        <Link to="/sources/new">add a source</Link>.
+        Or <Link to="/projects/new/custom">assemble a project from existing objects</Link>, or{" "}
+        <Link to="/sources/new">add a source</Link> on its own.
       </p>
     </div>
   );

--- a/ui/src/pages/Landing.tsx
+++ b/ui/src/pages/Landing.tsx
@@ -85,6 +85,26 @@ export default function Landing({ templates, projects }: { templates: Template[]
 
   const demo = projects.find((p) => p.template === "ai_sre_demo");
   const demoTemplate = templates.find((t) => t.key === "ai_sre_demo");
+  // The demo is an offer, never seeded: one click creates it here, in the background, from
+  // what detection finds, and lands on its page. When the demo stack is not reachable the
+  // wizard takes over with the steps to start it.
+  const [demoBusy, setDemoBusy] = useState(false);
+  const [demoErr, setDemoErr] = useState<string>();
+  const startDemo = async () => {
+    if (!demoTemplate) return;
+    setDemoBusy(true); setDemoErr(undefined);
+    try {
+      const d = await api.detectRecipe(demoTemplate.key);
+      const required = Object.entries(demoTemplate.params).filter(([, p]) => p.required).map(([k]) => k);
+      const missing = required.filter((k) => d.params[k] === undefined || d.params[k] === "");
+      if (missing.length) { navigate(`/projects/new/${demoTemplate.key}`); return; }
+      const made = await api.createProject({ template: demoTemplate.key, params: d.params });
+      navigate(`/projects/${encodeURIComponent(made.id)}`);
+    } catch (e) {
+      setDemoErr(String((e as Error).message ?? e));
+      setDemoBusy(false);
+    }
+  };
 
   const go = () => {
     if (!goal.trim()) return;
@@ -158,7 +178,12 @@ export default function Landing({ templates, projects }: { templates: Template[]
           </div>
           {demo
             ? <Link className="btn" to={`/projects/${encodeURIComponent(demo.id)}`}>Open the demo</Link>
-            : <button onClick={() => navigate("/projects/new/ai_sre_demo")}>Start the demo</button>}
+            : <button onClick={startDemo} disabled={demoBusy}>{demoBusy ? "starting…" : "Start the demo"}</button>}
+        </div>
+      )}
+      {demoErr && (
+        <div className="alert error">
+          could not start the demo: {demoErr}. <Link to="/projects/new/ai_sre_demo">Set it up step by step</Link> instead.
         </div>
       )}
 

--- a/ui/src/pages/Landing.tsx
+++ b/ui/src/pages/Landing.tsx
@@ -58,6 +58,7 @@ function overlap(typed: Set<string>, sentence: string) {
 export default function Landing({ templates, projects }: { templates: Template[]; projects: Project[] }) {
   const navigate = useNavigate();
   const [goal, setGoal] = useState("");
+  const [picked, setPicked] = useState("");   // the template behind the sentence in the box, if any
   const [paste, setPaste] = useState("");
   const [pasting, setPasting] = useState(false);
   const [specs, setSpecs] = useState<Record<string, ConnectorSpec>>({});
@@ -87,7 +88,9 @@ export default function Landing({ templates, projects }: { templates: Template[]
 
   const go = () => {
     if (!goal.trim()) return;
-    navigate("/projects/new/assist", { state: { goal: goal.trim() } });
+    // a sentence picked and left as it was names its template; an edited one is free text
+    const tpl = sentences.find((x) => x.template && x.text === goal.trim())?.template ?? picked;
+    navigate("/projects/new/assist", { state: { goal: goal.trim(), template: tpl || undefined } });
   };
   const goIncident = () => {
     if (!paste.trim()) return;
@@ -103,7 +106,7 @@ export default function Landing({ templates, projects }: { templates: Template[]
         <label className="landing-q" htmlFor="landing-goal">What do you want to build?</label>
         <textarea id="landing-goal" ref={box} rows={3} value={goal}
                   placeholder="watch my checkout service logs and wake an agent in Slack when payments fail"
-                  onChange={(e) => setGoal(e.target.value)}
+                  onChange={(e) => { setGoal(e.target.value); setPicked(""); }}
                   onKeyDown={(e) => { if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); go(); } }} />
         {/* what the screen heard, before anything is pressed */}
         <div className="landing-heard">
@@ -139,7 +142,7 @@ export default function Landing({ templates, projects }: { templates: Template[]
         <div className="help">Or start from one of these</div>
         {sentences.map((s) => (
           <button key={s.text} type="button" className="starter"
-                  onClick={() => { setGoal(s.text); box.current?.focus(); }}>
+                  onClick={() => { setGoal(s.text); setPicked(s.template); box.current?.focus(); }}>
             {s.text}
           </button>
         ))}

--- a/ui/src/pages/Landing.tsx
+++ b/ui/src/pages/Landing.tsx
@@ -2,6 +2,8 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 
 import { api } from "../api";
+import { usePolling } from "../components/bits";
+import { wizardPath } from "./ProjectNew";
 import type { ConnectorSpec, Project, Template } from "../types";
 
 // The screen a new cell lands on (TR-257): one question, answered by typing. Shown by Home while
@@ -53,6 +55,14 @@ function overlap(typed: Set<string>, sentence: string) {
   let n = 0;
   for (const w of words(sentence)) if (typed.has(w)) n++;
   return n;
+}
+
+/** Create new (/projects/new): the landing screen loading its own data. */
+export function ProjectNewPage() {
+  const { data: rec } = usePolling(() => api.templates(), 60000);
+  const { data: uc } = usePolling(() => api.projects(), 30000);
+  if (!rec || !uc) return <div className="dim">loading…</div>;
+  return <Landing templates={rec.templates} projects={uc.projects} />;
 }
 
 export default function Landing({ templates, projects }: { templates: Template[]; projects: Project[] }) {
@@ -161,10 +171,14 @@ export default function Landing({ templates, projects }: { templates: Template[]
       <div className="landing-starters">
         <div className="help">Or start from one of these</div>
         {sentences.map((s) => (
-          <button key={s.text} type="button" className="starter"
-                  onClick={() => { setGoal(s.text); setPicked(s.template); box.current?.focus(); }}>
-            {s.text}
-          </button>
+          <div key={s.text} className="starter-row">
+            <button type="button" className="starter"
+                    onClick={() => { setGoal(s.text); setPicked(s.template); box.current?.focus(); }}>
+              {s.text}
+            </button>
+            {/* the deterministic path, one click away on every template sentence */}
+            {s.template && <Link className="help starter-wizard" to={wizardPath(s.template)} title="the template's form, no assistant">set up step by step</Link>}
+          </div>
         ))}
       </div>
 
@@ -188,7 +202,8 @@ export default function Landing({ templates, projects }: { templates: Template[]
       )}
 
       <p className="help landing-foot">
-        Know exactly what you want? <Link to="/projects/new">Pick a template</Link> or{" "}
+        Know exactly what you want? <Link to="/projects/new/templates">Pick a template</Link>,{" "}
+        <Link to="/projects/new/custom">assemble from existing objects</Link>, or{" "}
         <Link to="/sources/new">add a source</Link>.
       </p>
     </div>

--- a/ui/src/pages/ProjectNew.tsx
+++ b/ui/src/pages/ProjectNew.tsx
@@ -1,15 +1,19 @@
-import { useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 
 import { api } from "../api";
 import { ErrorState, usePolling } from "../components/bits";
 import type { Template } from "../types";
 
-// The gallery behind "Create new" on /projects: one card per way to start a project. Templates
-// the console knows how to set up with a dedicated wizard; anything else the API lists still gets
-// a card, routed to the generic (params-driven) form.
-const WIZARDS: Record<string, string> = {
+// The template gallery, at /projects/new/templates: one card per template, the deterministic
+// path. Create new itself (/projects/new) is the landing screen (Landing.tsx), which links here
+// and, per template sentence, straight to the wizard. Templates the console sets up with a
+// dedicated wizard; anything else the API lists still gets a card, routed to the generic form.
+export const WIZARDS: Record<string, string> = {
   shared_code_context: "/projects/new/shared_code_context",
 };
+
+/** Where a template's step-by-step setup lives. */
+export const wizardPath = (key: string) => WIZARDS[key] ?? `/projects/new/${encodeURIComponent(key)}`;
 
 // What each template wires up, in the user's words. The daemon's describe() may carry mode-aware
 // facts (ai_sre_demo says different things against a hosted stack than against local docker);
@@ -27,7 +31,7 @@ const TEMPLATE_FACTS: Record<string, { you: string[]; tares: string[] }> = {
 
 function TemplateCard({ r }: { r: Template }) {
   const navigate = useNavigate();
-  const to = WIZARDS[r.key] ?? `/projects/new/${encodeURIComponent(r.key)}`;
+  const to = wizardPath(r.key);
   const facts = r.facts ?? TEMPLATE_FACTS[r.key];
   return (
     <div className="panel uc-card">
@@ -61,7 +65,7 @@ function TemplateCard({ r }: { r: Template }) {
   );
 }
 
-export default function ProjectNew() {
+export default function ProjectTemplates() {
   const navigate = useNavigate();
   const { data: rec, error: recError, reload: reloadRec } = usePolling(() => api.templates(), 60000);
   const templates = rec?.templates ?? [];
@@ -70,11 +74,11 @@ export default function ProjectNew() {
     <>
       <div className="pagehead">
         <div>
-          <h1>New project</h1>
+          <h1>Templates</h1>
           <p className="subtitle">
-            start from a Tares template: answer a few questions and Tares creates the objects
-            behind it, each visible and editable on its own page. Or assemble one from objects
-            you already have.
+            the step-by-step path: answer a few questions and Tares creates the objects behind it,
+            each visible and editable on its own page. Or assemble one from objects you already
+            have. To describe what you need in your own words instead, <Link to="/projects/new">create a project</Link>.
           </p>
         </div>
       </div>
@@ -85,34 +89,6 @@ export default function ProjectNew() {
         <div className="empty">No templates are registered on this instance yet.</div>
       )}
       <div className="uc-cards">
-        {/* Hand-written: the builder is not a template, it assembles a custom project one step at
-            a time with the assistant proposing each piece (ProjectNewAssist). */}
-        {rec && (
-          <div className="panel uc-card">
-            <div className="uc-card-main">
-              <div className="uc-card-title">Build with Tares</div>
-              <div className="help" style={{ marginTop: 2 }}>AI-guided</div>
-              <p className="help uc-card-desc">
-                Describe what you need in your own words. Tares proposes the sources, views, triggers
-                and agent from the connectors installed here; you confirm each one in place and fill
-                in what only you know.
-              </p>
-              <div className="uc-card-facts">
-                <div>
-                  <div className="lbl">you</div>
-                  <ul><li>say what you run and what should happen</li><li>fill in URLs, tokens and the Slack channel</li><li>apply or skip each proposal</li></ul>
-                </div>
-                <div>
-                  <div className="lbl">Tares sets up</div>
-                  <ul><li>the sources, tested before they are created</li><li>views and triggers grounded in your real data</li><li>an agent on the trigger, enabled and ready</li></ul>
-                </div>
-              </div>
-            </div>
-            <div className="uc-card-side">
-              <button className="primary" onClick={() => navigate("/projects/new/assist")}>Build</button>
-            </div>
-          </div>
-        )}
         {templates.map((r) => <TemplateCard key={r.key} r={r} />)}
         {rec && (
           <div className="panel uc-card">

--- a/ui/src/pages/ProjectNewAssist.tsx
+++ b/ui/src/pages/ProjectNewAssist.tsx
@@ -143,6 +143,7 @@ export default function ProjectNewAssist() {
 
   /** A template project is the whole build in one card: record it and finish. */
   const finishWith = (p: Project) => {
+    api.template(p.template).then(setFinishedTemplate).catch(() => {});
     projectRef.current = p;
     setProject(p);
     objectsRef.current = p.objects.map((o) => ({ kind: o.kind, name: o.name }));
@@ -192,14 +193,26 @@ export default function ProjectNewAssist() {
     await turn("sources", framing);
   };
 
+  // A template's project exists at most once (its objects have fixed names), so a picked template
+  // that already has one is answered here, without a model turn: open it.
+  const [already, setAlready] = useState<Project | null | undefined>(handoff.template ? undefined : null);
+  useEffect(() => {
+    if (!handoff.template) return;
+    api.projects().then((r) => setAlready(r.projects.find((p) => p.template === handoff.template) ?? null))
+      .catch(() => setAlready(null));
+  }, [handoff.template]);
+
   // arriving from the landing screen: start at once, once, when the key is known to be there
   const autoStarted = useRef(false);
   useEffect(() => {
-    if (ready && handoff.goal && step === "describe" && !autoStarted.current) {
+    if (ready && handoff.goal && step === "describe" && already === null && !autoStarted.current) {
       autoStarted.current = true;
       start();
     }
-  }, [ready]);   // eslint-disable-line react-hooks/exhaustive-deps
+  }, [ready, already]);   // eslint-disable-line react-hooks/exhaustive-deps
+
+  // the template behind a finished template project, for its setup steps on Done
+  const [finishedTemplate, setFinishedTemplate] = useState<Template>();
 
   /** Move on: tell the model what got created (with the decisions now known) and ask for the
    *  next step's proposals. */
@@ -225,7 +238,25 @@ export default function ProjectNewAssist() {
     await turn(step, text);
   };
 
-  if (ready === undefined) return <div className="dim">loading…</div>;
+  if (ready === undefined || already === undefined) return <div className="dim">loading…</div>;
+  if (already) {
+    return (
+      <>
+        <PageHead />
+        <div className="panel">
+          <h2 style={{ marginTop: 0 }}>You already have this</h2>
+          <p>
+            <strong>{already.name}</strong> was set up from this template. A cell holds one of these,
+            because its objects have fixed names.
+          </p>
+          <div className="btnrow">
+            <Link className="btn primary" to={`/projects/${encodeURIComponent(already.id)}`}>Open it</Link>
+            <Link className="btn" to="/">Describe something else</Link>
+          </div>
+        </div>
+      </>
+    );
+  }
   if (!ready) {
     return (
       <>
@@ -354,6 +385,26 @@ export default function ProjectNewAssist() {
                   .map((x, i, arr) => <span key={x.k}>{i > 0 ? (i === arr.length - 1 ? " and " : ", ") : ""}{x.n} {x.k}{x.n === 1 ? "" : "s"}</span>)}.
                 The project page shows its objects, firings and agent runs.
               </p>
+              {finishedTemplate?.setup && finishedTemplate.setup.length > 0 && (
+                <>
+                  <h3 style={{ margin: "14px 0 6px" }}>What happens next</h3>
+                  <ol className="uc-setup">
+                    {finishedTemplate.setup.map((st, i) => (
+                      <li key={i}>
+                        <div className="uc-setup-title">{st.title}</div>
+                        {st.text && <p className="help" style={{ margin: "2px 0 6px", whiteSpace: "normal" }}>{st.text}</p>}
+                        {st.check === "anthropic_key" && <p className="help" style={{ margin: "2px 0 6px" }}>Under <Link to="/settings">Settings</Link>, if none is set yet.</p>}
+                        {st.command && (
+                          <div className="uc-setup-cmd">
+                            <pre className="mono">{st.command}</pre>
+                            <button type="button" onClick={() => navigator.clipboard?.writeText(st.command!)}>copy</button>
+                          </div>
+                        )}
+                      </li>
+                    ))}
+                  </ol>
+                </>
+              )}
               <div className="btnrow">
                 <Link className="btn primary" to={`/projects/${encodeURIComponent(project.id)}`}>Open the project</Link>
               </div>
@@ -598,8 +649,12 @@ function ProjectCard({ proposal: p, decision, decide, finishWith }: CardCommon &
           </label>
           <TemplateParams template={template} vals={vals} setVals={setVals} needs={p.needs}
                           models={models} defaultModel={defaultModel} detected={detected} />
-          <div className="btnrow">
+          <div className="btnrow" style={{ alignItems: "center" }}>
             <button className="primary" disabled={busy} onClick={start}>{busy ? "starting…" : "Start"}</button>
+            <span className="help">
+              creates the project with everything the template sets up
+              {template.setup && template.setup.length > 0 ? `, then ${template.setup.length} steps to do on your side` : ""}
+            </span>
           </div>
         </>
       )}

--- a/ui/src/pages/ProjectNewAssist.tsx
+++ b/ui/src/pages/ProjectNewAssist.tsx
@@ -380,19 +380,17 @@ export default function ProjectNewAssist() {
         </div>
       ) : (
         <div className="panel builder-brief">
-          <div className="builder-brief-goal">
-            <span className="help">building</span>
+          <label className="field" style={{ marginBottom: 10 }}>
+            <span className="lbl">project name</span>
+            {project
+              ? <span className="mono">{project.name}</span>
+              : <input type="text" value={projectName} onChange={(e) => setProjectName(e.target.value)} style={{ maxWidth: 360 }} />}
+          </label>
+          <div className="field" style={{ marginBottom: 10 }}>
+            <span className="lbl">building</span>
             <blockquote>{goal.trim()}</blockquote>
           </div>
-          <div className="builder-brief-side">
-            <label className="field" style={{ margin: 0 }}>
-              <span className="lbl">project name</span>
-              {project
-                ? <span className="mono">{project.name}</span>
-                : <input type="text" value={projectName} onChange={(e) => setProjectName(e.target.value)} style={{ maxWidth: 260 }} />}
-            </label>
-            {step !== "done" && <button onClick={change}>Change what you need</button>}
-          </div>
+          {step !== "done" && <button onClick={change}>Change what you need</button>}
         </div>
       )}
 

--- a/ui/src/pages/ProjectNewAssist.tsx
+++ b/ui/src/pages/ProjectNewAssist.tsx
@@ -12,11 +12,13 @@ import { Picker } from "../components/bits";
 import { applyProposal, ProposalBody, ProposalShell, proposalTitle } from "../components/proposals";
 import type { DecisionMap, Proposal } from "../components/proposals";
 import SourceForm from "../components/SourceForm";
+import TemplateParams, { paramText, paramsBody } from "../components/TemplateParams";
+import type { Detected } from "../components/TemplateParams";
 import TriggerEditor from "../components/TriggerEditor";
 import { useAgentStream } from "../components/useAgentStream";
 import type { StreamEvent, WireMessage } from "../components/useAgentStream";
 import ViewEditor from "../components/ViewEditor";
-import type { AgentPreset, BuiltinAgent, ConnectorSpec, Project, ProjectObjectKind, Source, Trigger, View, ViewFilter } from "../types";
+import type { AgentPreset, BuiltinAgent, ConnectorSpec, Project, ProjectObjectKind, Source, Template, Trigger, View, ViewFilter } from "../types";
 
 // The AI-guided project builder (TR-243 to TR-246): describe what you need in your own words,
 // the assistant proposes the pieces one step at a time, and you complete each proposal in the
@@ -55,7 +57,7 @@ const wireText = (t: Turn, decisions: DecisionMap) => t.parts.map((p) => {
 }).join("").trim() || "[no answer]";
 
 const kindOf = (p: Proposal): ProjectObjectKind | null =>
-  p.kind === "labels" ? null : p.kind;
+  p.kind === "labels" || p.kind === "project" ? null : p.kind;
 
 /** A project name from the first content words of the goal, editable until the project exists. */
 const NAME_STOP = new Set(["the", "and", "when", "with", "that", "this", "from", "into", "what", "your", "my", "an", "a", "to", "of", "on", "in", "it", "its", "is", "me", "for", "watch", "tell", "wake", "agent", "want", "please", "show", "then", "also"]);
@@ -74,7 +76,7 @@ export default function ProjectNewAssist() {
   // Handed over from the landing screen (Landing.tsx): the goal already typed, so the builder
   // starts its first turn on arrival and the user never sees an empty box. `incident` means the
   // text is a pasted alert or thread, framed for the model as something to have caught.
-  const handoff = (useLocation().state ?? {}) as { goal?: string; incident?: boolean };
+  const handoff = (useLocation().state ?? {}) as { goal?: string; incident?: boolean; template?: string };
   const [goal, setGoal] = useState(handoff.goal ?? "");
   const [projectName, setProjectName] = useState(handoff.goal ? nameFromGoal(handoff.goal, !!handoff.incident) : "");
   const [step, setStep] = useState<StepKey | "describe" | "done">("describe");
@@ -139,6 +141,15 @@ export default function ProjectNewAssist() {
     return p;
   };
 
+  /** A template project is the whole build in one card: record it and finish. */
+  const finishWith = (p: Project) => {
+    projectRef.current = p;
+    setProject(p);
+    objectsRef.current = p.objects.map((o) => ({ kind: o.kind, name: o.name }));
+    setObjects(objectsRef.current);
+    setStep("done");
+  };
+
   /** One build turn: push the user framing, stream the assistant's answer into this step. */
   const turn = async (stepKey: StepKey, userText: string) => {
     const messages: WireMessage[] = [...history, { role: "user", content: userText }];
@@ -175,6 +186,8 @@ export default function ProjectNewAssist() {
     setStep("sources");
     const framing = handoff.incident
       ? `Project: ${projectName.trim()}.\nThis is an incident I had, pasted as it was written:\n\n${goal.trim()}\n\nPropose the project that would have caught it: the sources that carry the signal it shows, named the way the paste names things. Say in one sentence when it would have fired. Ask me only what the paste does not say.`
+      : handoff.template
+      ? `Project: ${projectName.trim()}.\nI picked the template "${handoff.template}": ${goal.trim()}\n\nSet it up for me: read its parameters with list_templates, run detect_template, ask me only for what neither says, then propose the project.`
       : `Project: ${projectName.trim()}.\nGoal: ${goal.trim()}`;
     await turn("sources", framing);
   };
@@ -294,6 +307,7 @@ export default function ProjectNewAssist() {
                       specs={specs ?? {}} existing={existing} refreshSources={refreshSources}
                       sourceNames={[...new Set([...created("source"), ...existing.map((x) => x.name)])]}
                       createdTriggers={created("trigger")}
+                      finishWith={finishWith}
                       active={s.key === step} />
           ))}
           {s.key === step && !streaming && states[s.key].turns.length > 0 && proposalsInStep === 0 && !asking && (
@@ -371,10 +385,11 @@ function PageHead() {
 /** One assistant turn inside a step: text, the tool rail, and each proposal as a card the user
  *  completes. Mirrors AskChat's Turn, with forms in place of Apply for sources and agents. */
 function TurnView({ turn, decisions, decide, own, thinking, specs, existing, refreshSources, sourceNames,
-                    createdTriggers, active }: {
+                    createdTriggers, finishWith, active }: {
   turn: Turn; decisions: DecisionMap; thinking: boolean; active: boolean;
   decide: (id: string, status: "applied" | "skipped" | "error", detail?: string) => void;
   own: (kind: ProjectObjectKind, name: string) => Promise<void>;
+  finishWith: (p: Project) => void;
   specs: Record<string, ConnectorSpec>; existing: Source[]; refreshSources: () => void;
   sourceNames: string[]; createdTriggers: string[];
 }) {
@@ -398,6 +413,8 @@ function TurnView({ turn, decisions, decide, own, thinking, specs, existing, ref
           return <SourceCard key={j} proposal={p} specs={specs} existing={existing} refreshSources={refreshSources} {...common} />;
         if (p.kind === "agent")
           return <AgentCard key={j} proposal={p} triggers={createdTriggers} {...common} />;
+        if (p.kind === "project")
+          return <ProjectCard key={j} proposal={p} finishWith={finishWith} {...common} />;
         return <CatalogCard key={j} proposal={p} sourceNames={sourceNames} {...common} />;
       })}
       {thinking && <div className="dim">thinking…</div>}
@@ -529,6 +546,65 @@ function CreatedSource({ made, name, specs }: {
         </>
       )}
     </div>
+  );
+}
+
+/** A whole project from a template, as the template's own form prefilled with what the assistant
+ *  knew and the `needs` params marked. Start creates it through the normal create API, so the
+ *  template's own logic runs; the build is then complete. */
+function ProjectCard({ proposal: p, decision, decide, finishWith }: CardCommon & {
+  proposal: Extract<Proposal, { kind: "project" }>; finishWith: (p: Project) => void;
+}) {
+  const [template, setTemplate] = useState<Template>();
+  const [err, setErr] = useState<string>();
+  const [name, setName] = useState(p.name);
+  const [vals, setVals] = useState<Record<string, string>>({});
+  const [models, setModels] = useState<string[]>([]);
+  const [defaultModel, setDefaultModel] = useState("");
+  const [detected, setDetected] = useState<Detected>();
+  const [busy, setBusy] = useState(false);
+  useEffect(() => {
+    api.template(p.template).then((t) => {
+      setTemplate(t);
+      setVals(Object.fromEntries(Object.entries(t.params).map(([k, spec]) =>
+        [k, p.needs.includes(k) ? "" : paramText(spec, p.params?.[k])])));
+    }).catch((e) => setErr(String((e as Error).message ?? e)));
+    api.builtinAgents().then((r) => { setModels(r.models); setDefaultModel(r.default_model); }).catch(() => {});
+    api.detectRecipe(p.template).then(setDetected).catch(() => {});
+  }, [p.id]);   // eslint-disable-line react-hooks/exhaustive-deps
+
+  const start = async () => {
+    if (!template) return;
+    setBusy(true); setErr(undefined);
+    try {
+      const made = await api.createProject({ template: template.key, name: name.trim() || undefined, params: paramsBody(template, vals) });
+      decide(p.id, "applied");
+      finishWith(made);
+    } catch (e) { setErr(String((e as Error).message ?? e)); }
+    setBusy(false);
+  };
+  const open = !decision || decision.status === "error";
+  return (
+    <ProposalShell title={proposalTitle(p)} decision={decision} reasoning={p.reasoning}
+                   actions={open ? <div className="btnrow"><button onClick={() => decide(p.id, "skipped")}>Skip</button></div> : null}>
+      <ProposalBody proposal={p} />
+      {err && <div className="alert error">{err}</div>}
+      {open && template && (
+        <>
+          <p className="help" style={{ whiteSpace: "normal" }}>{template.description}</p>
+          <label className="field">
+            <span className="lbl">name</span>
+            <input type="text" value={name} onChange={(e) => setName(e.target.value)} style={{ maxWidth: 420 }} />
+          </label>
+          <TemplateParams template={template} vals={vals} setVals={setVals} needs={p.needs}
+                          models={models} defaultModel={defaultModel} detected={detected} />
+          <div className="btnrow">
+            <button className="primary" disabled={busy} onClick={start}>{busy ? "starting…" : "Start"}</button>
+          </div>
+        </>
+      )}
+      {open && !template && !err && <div className="dim">loading the template…</div>}
+    </ProposalShell>
   );
 }
 

--- a/ui/src/pages/ProjectNewAssist.tsx
+++ b/ui/src/pages/ProjectNewAssist.tsx
@@ -200,6 +200,17 @@ export default function ProjectNewAssist() {
     collected = [];
   };
 
+  /** What this build has already made, for the framing: after a Change the assistant must build
+   *  on it, not propose it again. Sources are the ones the user took pains over. */
+  const existingLine = () => {
+    const have = (["source", "view", "trigger", "agent"] as ProjectObjectKind[])
+      .map((k) => [k, created(k)] as const).filter(([, n]) => n.length);
+    return have.length
+      ? `\n\nAlready created and part of this project, keep and build on them, do not propose them again: `
+        + have.map(([k, n]) => `${k}s ${n.join(", ")}`).join("; ") + "."
+      : "";
+  };
+
   const start = async () => {
     setStep("sources");
     const framing = handoff.incident
@@ -207,7 +218,26 @@ export default function ProjectNewAssist() {
       : handoff.template
       ? `Project: ${projectName.trim()}.\nI picked the template "${handoff.template}": ${goal.trim()}\n\nSet it up for me: read its parameters with list_templates, run detect_template, ask me only for what neither says, then propose the project.`
       : `Project: ${projectName.trim()}.\nGoal: ${goal.trim()}`;
-    await turn("sources", framing);
+    await turn("sources", framing + existingLine());
+  };
+
+  // Change: back to the goal. Stops a turn in flight and drops what was only proposed; what was
+  // created stays, stays in the project, and is named to the assistant on the next start.
+  const [changing, setChanging] = useState(false);
+  const lastStep = useRef<StepKey | "done">("sources");
+  const change = () => {
+    stop();
+    if (step !== "describe") lastStep.current = step;
+    setChanging(true);
+    setStep("describe");
+  };
+  const restart = async () => {
+    setStates({ sources: { turns: [] }, watch: { turns: [] }, agent: { turns: [] } });
+    setDecisions({});
+    setHistory([]);
+    setRefine("");
+    setChanging(false);
+    await start();
   };
 
   // A template's project exists at most once (its objects have fixed names), so a picked template
@@ -301,7 +331,7 @@ export default function ProjectNewAssist() {
       <PageHead />
       <div className="builder-steps">
         {STEPS.map((s, i) => (
-          <span key={s.key} className={"step" + (i === stepIndex ? " active" : i < stepIndex ? " done" : "")}>
+          <span key={s.key} className={"step" + (i === stepIndex ? " active" : i < stepIndex ? " done" : "") + (i === stepIndex && streaming ? " busy" : "")}>
             <span className="n">{i + 1}</span>{s.label}
             {i < stepIndex && s.kinds.some((k) => created(k).length > 0) && (
               <span className="badge ok">{s.kinds.reduce((n, k) => n + created(k).length, 0)}</span>
@@ -310,35 +340,61 @@ export default function ProjectNewAssist() {
         ))}
       </div>
 
-      {/* Describe */}
-      <div className="panel">
-        <h2 style={{ marginTop: 0 }}>Describe</h2>
-        <label className="field">
-          <span className="lbl">project name<span className="req"> *</span></span>
-          <input type="text" value={projectName} onChange={(e) => setProjectName(e.target.value)}
-                 disabled={!!project} placeholder="e.g. checkout incidents" style={{ maxWidth: 420 }} />
-          {handoff.goal && !project && <span className="help">proposed from what you typed; change it any time before the first object is created</span>}
-        </label>
-        <label className="field">
-          <span className="lbl">what you need<span className="req"> *</span></span>
-          <textarea value={goal} onChange={(e) => setGoal(e.target.value)} rows={3} disabled={step !== "describe"}
-                    placeholder="e.g. watch my payment service logs and wake an agent in Slack when checkouts fail"
-                    style={{ width: "100%", boxSizing: "border-box" }} />
-          <span className="help">
-            Name the systems you run and where they are. Tares proposes sources from the connectors
-            installed here, then views, triggers and an agent, one step at a time. Everything you
-            create is a real object you can edit on its own page.
-          </span>
-        </label>
-        {step === "describe" && (
+      {/* Describe: the form until the flow starts (and again on Change); a header afterwards */}
+      {step === "describe" ? (
+        <div className="panel">
+          <h2 style={{ marginTop: 0 }}>Describe</h2>
+          <label className="field">
+            <span className="lbl">project name<span className="req"> *</span></span>
+            <input type="text" value={projectName} onChange={(e) => setProjectName(e.target.value)}
+                   disabled={!!project} placeholder="e.g. checkout incidents" style={{ maxWidth: 420 }} />
+            {handoff.goal && !project && <span className="help">proposed from what you typed; change it any time before the first object is created</span>}
+          </label>
+          <label className="field">
+            <span className="lbl">what you need<span className="req"> *</span></span>
+            <textarea value={goal} onChange={(e) => setGoal(e.target.value)} rows={3} autoFocus={changing}
+                      placeholder="e.g. watch my payment service logs and wake an agent in Slack when checkouts fail"
+                      style={{ width: "100%", boxSizing: "border-box" }} />
+            <span className="help">
+              Name the systems you run and where they are. Tares proposes sources from the connectors
+              installed here, then views, triggers and an agent, one step at a time. Everything you
+              create is a real object you can edit on its own page.
+            </span>
+          </label>
+          {changing && objects.length > 0 && (
+            <div className="alert">
+              Starting again from the goal. What you already created stays and stays in the project:{" "}
+              {objects.map((o) => <span key={`${o.kind}:${o.name}`} className="chip mono" style={{ marginRight: 4 }}>{o.name}</span>)}
+              Proposals you had not applied are dropped.
+            </div>
+          )}
           <div className="btnrow">
-            <button className="primary" disabled={!goal.trim() || !projectName.trim() || streaming} onClick={start}>
-              Propose sources
+            <button className="primary" disabled={!goal.trim() || !projectName.trim() || streaming}
+                    onClick={changing ? restart : start}>
+              {changing ? "Propose again" : "Propose sources"}
             </button>
-            <Link className="btn" to="/projects/new">Cancel</Link>
+            {changing
+              ? <button onClick={() => { setChanging(false); setStep(lastStep.current); }}>Keep going instead</button>
+              : <Link className="btn" to="/projects/new">Cancel</Link>}
           </div>
-        )}
-      </div>
+        </div>
+      ) : (
+        <div className="panel builder-brief">
+          <div className="builder-brief-goal">
+            <span className="help">building</span>
+            <blockquote>{goal.trim()}</blockquote>
+          </div>
+          <div className="builder-brief-side">
+            <label className="field" style={{ margin: 0 }}>
+              <span className="lbl">project name</span>
+              {project
+                ? <span className="mono">{project.name}</span>
+                : <input type="text" value={projectName} onChange={(e) => setProjectName(e.target.value)} style={{ maxWidth: 260 }} />}
+            </label>
+            {step !== "done" && <button onClick={change}>Change what you need</button>}
+          </div>
+        </div>
+      )}
 
       {projectErr && <div className="alert error">{projectErr}</div>}
 
@@ -348,6 +404,12 @@ export default function ProjectNewAssist() {
           <div className="pagehead" style={{ marginBottom: 8 }}>
             <h2 style={{ margin: 0 }}>{s.label}</h2>
             {i < stepIndex && <span className="badge ok">done</span>}
+            {s.key === step && streaming && (
+              <span className="builder-running">
+                <span className="spinner" /> proposing {s.label.toLowerCase()}…
+                <button type="button" className="dim" onClick={stop}>Stop</button>
+              </span>
+            )}
           </div>
           {states[s.key].turns.map((t, j) => (
             <TurnView key={j} turn={t} decisions={decisions} decide={decide} own={own}

--- a/ui/src/pages/ProjectNewAssist.tsx
+++ b/ui/src/pages/ProjectNewAssist.tsx
@@ -59,11 +59,23 @@ const wireText = (t: Turn, decisions: DecisionMap) => t.parts.map((p) => {
 const kindOf = (p: Proposal): ProjectObjectKind | null =>
   p.kind === "labels" || p.kind === "project" ? null : p.kind;
 
-/** A project name from the first content words of the goal, editable until the project exists. */
-const NAME_STOP = new Set(["the", "and", "when", "with", "that", "this", "from", "into", "what", "your", "my", "an", "a", "to", "of", "on", "in", "it", "its", "is", "me", "for", "watch", "tell", "wake", "agent", "want", "please", "show", "then", "also"]);
+/** A project name from the goal, editable until the project exists: the nouns of the user's
+ *  world (a service, a container, a repo), never the verbs of ours. Three words at most, so
+ *  "watch the docker container checkout-api and its prometheus metrics" becomes
+ *  "checkout-api metrics". */
+const NAME_STOP = new Set([
+  "the", "and", "when", "with", "that", "this", "from", "into", "what", "your", "my", "an", "a", "to", "of",
+  "on", "in", "it", "its", "is", "me", "for", "want", "please", "then", "also", "some", "any", "all", "one",
+  "watch", "tell", "wake", "show", "build", "need", "keep", "make", "get", "let", "run", "runs", "running",
+  "agent", "agents", "service", "services", "project", "tares", "data", "something", "wrong", "happens",
+  "up", "date", "every", "each", "top", "over", "via", "using", "use", "like",
+]);
 function nameFromGoal(goal: string, incident: boolean): string {
-  const ws = goal.toLowerCase().split(/[^a-z0-9-]+/).filter((w) => w.length > 2 && !NAME_STOP.has(w)).slice(0, 4);
-  const base = ws.join(" ") || "my project";
+  const ws = goal.toLowerCase().split(/[^a-z0-9-]+/).filter((w) => w.length > 2 && !NAME_STOP.has(w));
+  // prefer words that look like names of things: hyphenated, or ending in a system-ish noun
+  const named = ws.filter((w) => w.includes("-") || /(api|logs?|metrics|db|repo|repos|server|checkout|payments?|orders?|weather|deploys?)$/.test(w));
+  const pick = [...new Set([...named, ...ws])].slice(0, 3);
+  const base = pick.join(" ") || "my project";
   return incident ? `catch ${base}` : base;
 }
 
@@ -78,7 +90,12 @@ export default function ProjectNewAssist() {
   // text is a pasted alert or thread, framed for the model as something to have caught.
   const handoff = (useLocation().state ?? {}) as { goal?: string; incident?: boolean; template?: string };
   const [goal, setGoal] = useState(handoff.goal ?? "");
-  const [projectName, setProjectName] = useState(handoff.goal ? nameFromGoal(handoff.goal, !!handoff.incident) : "");
+  const [projectName, setProjectName] = useState(handoff.goal && !handoff.template ? nameFromGoal(handoff.goal, !!handoff.incident) : "");
+  // a picked template is named after itself, not after words chopped out of its sentence
+  useEffect(() => {
+    if (!handoff.template) return;
+    api.template(handoff.template).then((t) => setProjectName((cur) => cur || t.title)).catch(() => {});
+  }, [handoff.template]);
   const [step, setStep] = useState<StepKey | "describe" | "done">("describe");
   const [states, setStates] = useState<Record<StepKey, StepState>>({
     sources: { turns: [] }, watch: { turns: [] }, agent: { turns: [] },

--- a/ui/src/pages/ProjectNewAssist.tsx
+++ b/ui/src/pages/ProjectNewAssist.tsx
@@ -434,9 +434,7 @@ export default function ProjectNewAssist() {
                           placeholder={asking ? "answer here, then Send" : "ask for a change, e.g. use the staging URL, or add the alerts too"}
                           onChange={(e) => setRefine(e.target.value)}
                           onKeyDown={(e) => { if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); sendRefine(); } }} />
-                {streaming
-                  ? <button type="button" className="danger" onClick={stop}>Stop</button>
-                  : <button type="button" disabled={!refine.trim()} onClick={sendRefine}>Send</button>}
+                <button type="button" disabled={streaming || !refine.trim()} onClick={sendRefine}>Send</button>
               </div>
               <div className="btnrow" style={{ marginTop: 12 }}>
                 <button className="primary" disabled={streaming || (s.key === "sources" && created("source").length === 0)}

--- a/ui/src/pages/ProjectNewAssist.tsx
+++ b/ui/src/pages/ProjectNewAssist.tsx
@@ -485,7 +485,7 @@ export default function ProjectNewAssist() {
               </div>
             </>
           ) : (
-            <p className="help">Nothing was created. Start again with a fuller description, or <Link to="/projects/new">pick a template</Link>.</p>
+            <p className="help">Nothing was created. Start again with a fuller description, or <Link to="/projects/new/templates">pick a template</Link>.</p>
           )}
         </div>
       )}

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -559,7 +559,8 @@ label.field .help, div.field > .help { display: block; font-size: 12px; color: v
 .fld-row.invalid input, .fld-row.invalid select, .fld-row.invalid textarea { border-color: var(--err); background: var(--err-soft); }
 .fld-row.invalid .help { color: var(--err); }
 /* a builder proposal's `needs`: the fields only the user can fill (a token, a URL) */
-.fld-row.needs input, .fld-row.needs select, .fld-row.needs textarea { border-color: var(--accent); background: var(--accent-soft); }
+.fld-row.needs input, .fld-row.needs select, .fld-row.needs textarea,
+label.field.needs input, label.field.needs textarea { border-color: var(--accent); background: var(--accent-soft); }
 
 /* The AI-guided project builder (ProjectNewAssist): one column of step panels; the strip on top
    says where you are. */

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -1361,3 +1361,13 @@ pre.payload {
 .landing-starters { display: flex; flex-direction: column; gap: 6px; margin-bottom: 18px; }
 .landing-demo { display: flex; align-items: center; justify-content: space-between; gap: 24px; margin-bottom: 14px; }
 .landing-foot { text-align: center; }
+
+/* the builder once it is running: the goal as a brief, the active step visibly busy */
+.builder-brief { display: flex; gap: 24px; align-items: flex-start; justify-content: space-between; }
+.builder-brief-goal { flex: 1; min-width: 0; }
+.builder-brief-goal blockquote { margin: 4px 0 0; padding: 0 0 0 12px; border-left: 3px solid var(--line); white-space: pre-wrap; }
+.builder-brief-side { display: flex; flex-direction: column; gap: 8px; align-items: flex-end; flex: 0 0 auto; }
+.builder-running { display: inline-flex; align-items: center; gap: 8px; color: var(--ink-soft); font-size: 13px; }
+.builder-running .spinner { width: 10px; height: 10px; border: 2px solid var(--line); border-top-color: var(--accent); border-radius: 50%; animation: builder-spin 0.8s linear infinite; }
+@keyframes builder-spin { to { transform: rotate(360deg); } }
+.builder-steps .step.busy { border-style: dashed; }

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -1359,9 +1359,8 @@ pre.payload {
 .landing-ask textarea.mono { font-family: var(--mono); font-size: 13px; }
 .landing-heard { min-height: 26px; display: flex; flex-wrap: wrap; gap: 6px; align-items: center; margin: 8px 0 10px; }
 .landing-starters { display: flex; flex-direction: column; gap: 6px; margin-bottom: 18px; }
-.starter-row { display: flex; gap: 10px; align-items: center; }
-.starter-row .starter { flex: 1; }
-.starter-wizard { flex: 0 0 auto; white-space: nowrap; }
+.landing-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; }
+.landing-head .btn { flex: 0 0 auto; margin-top: 6px; }
 .landing-demo { display: flex; align-items: center; justify-content: space-between; gap: 24px; margin-bottom: 14px; }
 .landing-foot { text-align: center; }
 

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -1363,10 +1363,7 @@ pre.payload {
 .landing-foot { text-align: center; }
 
 /* the builder once it is running: the goal as a brief, the active step visibly busy */
-.builder-brief { display: flex; gap: 24px; align-items: flex-start; justify-content: space-between; }
-.builder-brief-goal { flex: 1; min-width: 0; }
-.builder-brief-goal blockquote { margin: 4px 0 0; padding: 0 0 0 12px; border-left: 3px solid var(--line); white-space: pre-wrap; }
-.builder-brief-side { display: flex; flex-direction: column; gap: 8px; align-items: flex-end; flex: 0 0 auto; }
+.builder-brief blockquote { margin: 2px 0 0; padding: 0 0 0 12px; border-left: 3px solid var(--line); white-space: pre-wrap; }
 .builder-running { display: inline-flex; align-items: center; gap: 8px; color: var(--ink-soft); font-size: 13px; }
 .builder-running .spinner { width: 10px; height: 10px; border: 2px solid var(--line); border-top-color: var(--accent); border-radius: 50%; animation: builder-spin 0.8s linear infinite; }
 @keyframes builder-spin { to { transform: rotate(360deg); } }

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -1359,6 +1359,9 @@ pre.payload {
 .landing-ask textarea.mono { font-family: var(--mono); font-size: 13px; }
 .landing-heard { min-height: 26px; display: flex; flex-wrap: wrap; gap: 6px; align-items: center; margin: 8px 0 10px; }
 .landing-starters { display: flex; flex-direction: column; gap: 6px; margin-bottom: 18px; }
+.starter-row { display: flex; gap: 10px; align-items: center; }
+.starter-row .starter { flex: 1; }
+.starter-wizard { flex: 0 0 auto; white-space: nowrap; }
 .landing-demo { display: flex; align-items: center; justify-content: space-between; gap: 24px; margin-bottom: 14px; }
 .landing-foot { text-align: center; }
 

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -417,6 +417,7 @@ export interface GithubCredential {
 export interface RecipeParam {
   type?: string;              // string | number | bool | list | json | choice
   required?: boolean;
+  secret?: boolean;           // a token: never shown back; blank on edit means keep
   default?: unknown;
   help?: string;
   label?: string;


### PR DESCRIPTION
Stacked on #116 (landing screen), which is stacked on #112 (builder). Merge in that order.

Started as "templates as a proposal"; grew through a live test session into the rest of the onboarding front door. In this PR:

**Templates as a proposal**
- Read tools `list_templates`, `list_projects`, `detect_template`; proposal card `propose_project` (template, name, params it knows, `needs` for what only the user can fill). The build prompt puts templates first and knows a template's project exists at most once; the console shows the template's setup steps after Start, the model does not narrate them.
- The card is the template's own params form (`components/TemplateParams.tsx`, separate from the generic wizard so it does not collide with main's edit-mode change). Start creates via `POST /api/projects`, so the template's own logic runs; the page jumps to Done, which lists the setup steps with commands. A template whose project already exists short-circuits to "You already have this".
- The template-by-key endpoint from #113 is added with identical text; git merges it cleanly.

**Landing screen and Create new**
- `/projects/new` is the landing screen (one question, paste-your-incident door, sentences, the demo as an offer); the template gallery moves to `/projects/new/templates` behind a "Use a guided template" button top right. The Overview's empty states point at Create a project.
- "Start the demo" creates the demo in the background from what detection finds and lands on its page; the wizard only when the stack is not reachable. The demo is an offer, never seeded (the cloud seed is a control-plane setting, separate).
- A picked sentence hands its template key to the builder; a picked template names the project after itself; free-text names keep only the nouns.

**Builder while running**
- Once the flow starts the Describe form becomes a brief (name, goal, "Change what you need"); the active step shows "proposing …" with one Stop. Change stops the turn, reopens the goal, and Propose again restarts from the sources step: unapplied proposals are dropped, objects already created stay in the project and are named to the assistant so it builds on them.

Tests: `test_agent_build.py` (tools, card schema, prompt markers), `test_projects.py` (every template carries `sentence`). Verified live on a fresh data dir: landing, sentence to template card to Start to Done, Change, Start the demo.