### PR TITLE
Builder: split layout, no invented triggers, keep-alive 502 fix, landing starters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,33 @@
 Notable changes to Tares (formerly NavFlow). Format follows [Keep a Changelog](https://keepachangelog.com/);
 the project follows [Semantic Versioning](https://semver.org/).
 
+## [1.26.0] - 2026-09-07
+
+### Added
+- The running builder is two columns that fill the window: the conversation on the left with
+  the answer box pinned under it, and a "To do" column on the right holding every card the
+  assistant proposed, in order. A decided card folds to one line; the pointer the chat leaves
+  for each card opens it. A one-line head carries the steps, the project name and the goal.
+- Overview shows the Projects panel with a Create new button also on an instance with no
+  project yet.
+
+### Changed
+- The builder no longer invents a trigger for the agent. The daemon refuses an agent proposal
+  whose trigger does not exist and hands the model the real list; Continue on the views and
+  triggers step waits until a trigger exists; the step names sources that have no events yet,
+  since views and triggers are grounded in real events; the agent card never prefills an
+  unknown trigger.
+- Landing: the starter sentences keep a fixed order instead of reordering while you type, the
+  picked one is marked, and the call to action reads "Build it".
+- The assistant shows a readable line for a non-JSON error reply (a proxy's 502 page) instead of
+  its HTML.
+
+### Fixed
+- Behind an nginx ingress, a builder step sent about five seconds after the previous one could
+  fail with 502 "upstream prematurely closed connection": the proxy reused a pooled connection
+  uvicorn was closing at that moment, and does not retry a POST. The daemon now keeps idle
+  connections for 75 seconds, longer than the proxy's pool.
+
 ## [1.25.0] - 2026-09-04
 
 ### Added

--- a/tares/agent.py
+++ b/tares/agent.py
@@ -273,6 +273,18 @@ async def _current_labels(source: str, headers: dict):
         return None
 
 
+async def _trigger_names(headers: dict) -> list | None:
+    """Names of the triggers that exist right now, or None if they can't be read."""
+    try:
+        async with httpx.AsyncClient(timeout=10, headers=headers, base_url=_SELF) as cx:
+            r = await cx.get("/api/triggers")
+        if r.status_code != 200:
+            return None
+        return [t["name"] for t in r.json()]
+    except Exception:
+        return None
+
+
 async def _execute_tool(name: str, args: dict, headers: dict) -> tuple[bool, str]:
     """Run a tool by calling the daemon's own read endpoint. Returns (ok, response text).
 
@@ -419,8 +431,10 @@ every key, filter and field in `source_fields` from real data, exactly as in the
 If no events have arrived yet, say so and ask the user to send some first, or propose from the \
 source's configured fields and say the thresholds are theirs to confirm. Ask about thresholds, \
 windows and which conditions matter before proposing them unless the user already said.
-· AGENT: one propose_agent card. The prompt is the substance, and it is the user's: before you \
-write it, ask what the agent should do when the trigger fires (what to look at, what a useful \
+· AGENT: one propose_agent card. Its `trigger` is one of the triggers the console lists as \
+created; never invent a name. If it lists none, say the agent needs a trigger to wake it and \
+that the Views and triggers step is where to make one; propose nothing. The prompt is the \
+substance, and it is the user's: before you write it, ask what the agent should do when the trigger fires (what to look at, what a useful \
 finding says, what it should recommend or decide, any thresholds or vocabulary they use), unless \
 the goal already says. Write the prompt from their answer, in their terms. For delivery, pick \
 "slack" when the user mentioned Slack, "webhook" when they named a system or URL to post into, \
@@ -536,6 +550,25 @@ async def _run_agent(api_key: str, messages: list, model, self_headers, on_usage
                                                        "set; no card was shown. Tell the user its "
                                                        "labels already look right; propose only "
                                                        "changes."})
+                            continue
+                    # An agent card names the trigger that wakes it, and the form submits that
+                    # name as is: a made-up one is a 400 the user cannot get past (the weather
+                    # build on 2026-09-07, no trigger existed and the model invented one). Refuse
+                    # here, with the real list, so the model corrects itself or says so.
+                    if tu.name == "propose_agent":
+                        have = await _trigger_names(headers)
+                        want = str(tu.input.get("trigger", ""))
+                        if have is not None and want not in have:
+                            results.append({"type": "tool_result", "tool_use_id": tu.id,
+                                            "content": (f"no trigger named {want!r} exists, so no card "
+                                                        f"was shown. Triggers that exist: "
+                                                        f"{', '.join(have)}. Propose again with one of "
+                                                        "them.") if have else
+                                                       (f"no trigger named {want!r} exists; this cell "
+                                                        "has no triggers at all, so no card was shown. "
+                                                        "Tell the user the agent needs a trigger to "
+                                                        "wake it, made on the Views and triggers step, "
+                                                        "and propose nothing.")})
                             continue
                     # a proposal is a card for the user, not a server-side action
                     kind = _PROPOSAL_KIND[tu.name]

--- a/tares/cli.py
+++ b/tares/cli.py
@@ -44,7 +44,11 @@ def run_daemon():
     host = os.getenv("TARES_HOST", "127.0.0.1")
     port = int(os.getenv("TARES_PORT", "8787"))
     _warn_if_exposed(host)
-    uvicorn.run(make_app(), host=host, port=port)
+    # Idle keep-alive must outlast whatever proxy sits in front (nginx ingress pools upstream
+    # connections for 60s). uvicorn's 5s default let nginx reuse a connection the daemon was
+    # closing at that very moment: "upstream prematurely closed connection", a 502 on any POST
+    # that landed ~5s after the previous response, which the step-by-step project builder did.
+    uvicorn.run(make_app(), host=host, port=port, timeout_keep_alive=75)
 
 
 def run_mcp():

--- a/tests/test_agent_build.py
+++ b/tests/test_agent_build.py
@@ -93,7 +93,8 @@ ck("build prompt is the ask prompt plus the build section",
    build.startswith(base) and "BUILD MODE" in build)
 for marker in ("ASK BEFORE YOU GUESS", "INSTALLED connectors", "`needs`", "source_fields",
                "One card per object", "propose NOTHING in that turn",
-               "ask what the agent should do", "delivery.url", "TEMPLATES FIRST"):
+               "ask what the agent should do", "delivery.url", "TEMPLATES FIRST",
+               "never invent a name"):
     ck(f"build prompt says: {marker}", marker in build)
 
 
@@ -109,6 +110,16 @@ async def main():
         ck("build turn without a key -> 400 (same gate as Ask)", r.status_code == 400, r.text)
         r = await cx.post("/api/agent/chat", json={"messages": [{"role": "user", "content": "hi"}]})
         ck("ask turn without a key -> 400", r.status_code == 400, r.text)
+        print("== agent proposal names a real trigger ==")
+        # the guard reads the daemon's trigger list; with none, every name is unknown
+        agent._SELF = "http://t"
+        real_client = httpx.AsyncClient
+        httpx.AsyncClient = lambda **kw: real_client(transport=httpx.ASGITransport(app=app), **{k: v for k, v in kw.items() if k != "base_url"}, base_url=kw.get("base_url", "http://t"))
+        try:
+            have = await agent._trigger_names({})
+        finally:
+            httpx.AsyncClient = real_client
+        ck("no triggers on a fresh cell -> empty list, not None", have == [], repr(have))
         await cx.aclose()
     print(f"\n{P} passed, {F} failed")
     raise SystemExit(1 if F else 0)

--- a/ui/src/components/useAgentStream.ts
+++ b/ui/src/components/useAgentStream.ts
@@ -24,6 +24,22 @@ export type SendOptions = {
   step?: "sources" | "watch" | "agent";
 };
 
+/** A non-200 reply as one readable line. The daemon answers with JSON `{detail}`; anything
+ *  else (an nginx 502 page, an empty body) is a proxy or network failure, and its HTML is
+ *  not something to show the user. */
+async function httpErrorDetail(res: Response): Promise<string> {
+  const body = await res.text().catch(() => "");
+  try {
+    const parsed = JSON.parse(body);
+    if (parsed && typeof parsed.detail === "string") return parsed.detail;
+  } catch { /* not JSON */ }
+  const status = `${res.status} ${res.statusText}`.trim();
+  if (res.status >= 500 || !body.trim() || /<html/i.test(body)) {
+    return `the server returned ${status}; try sending again`;
+  }
+  return body.slice(0, 300);
+}
+
 export function useAgentStream() {
   const [streaming, setStreaming] = useState(false);
   const abortRef = useRef<AbortController | null>(null);
@@ -48,7 +64,7 @@ export function useAgentStream() {
         body: JSON.stringify(body),
       });
       if (!res.ok || !res.body) {
-        onEvent({ type: "error", detail: await res.text().catch(() => res.statusText) });
+        onEvent({ type: "error", detail: await httpErrorDetail(res) });
         return;
       }
       const reader = res.body.getReader();

--- a/ui/src/pages/Home.tsx
+++ b/ui/src/pages/Home.tsx
@@ -98,7 +98,7 @@ export default function Home() {
           reason is said out loud here. See the rule in components/bits.tsx. */}
       {sourcesError && <ErrorState error={sourcesError} what="the source list" />}
 
-      {uc && uc.projects.length > 0 && <ProjectsPanel projects={uc.projects} />}
+      {uc && <ProjectsPanel projects={uc.projects} />}
 
       <ModelSpendPanel usage={mu} error={muError} reload={reloadMu} />
 
@@ -261,7 +261,10 @@ function ProjectsPanel({ projects }: { projects: Project[] }) {
           <Link className="btn" to="/projects">All projects</Link>
         </div>
       </div>
-      <table>
+      {projects.length === 0 && (
+        <div className="empty">no projects yet</div>
+      )}
+      {projects.length > 0 && <table>
         <tbody>
           {projects.map((u) => {
             const missing = u.objects.filter((o) => o.missing).length;
@@ -278,7 +281,7 @@ function ProjectsPanel({ projects }: { projects: Project[] }) {
             );
           })}
         </tbody>
-      </table>
+      </table>}
     </div>
   );
 }

--- a/ui/src/pages/Home.tsx
+++ b/ui/src/pages/Home.tsx
@@ -256,7 +256,10 @@ function ProjectsPanel({ projects }: { projects: Project[] }) {
     <div className="panel">
       <div className="pagehead" style={{ marginBottom: 8 }}>
         <h2 style={{ margin: 0 }}>Projects</h2>
-        <Link className="btn" to="/projects">All projects</Link>
+        <div className="btnrow">
+          <Link className="btn primary" to="/projects/new">Create new</Link>
+          <Link className="btn" to="/projects">All projects</Link>
+        </div>
       </div>
       <table>
         <tbody>

--- a/ui/src/pages/Landing.tsx
+++ b/ui/src/pages/Landing.tsx
@@ -9,8 +9,7 @@ import type { ConnectorSpec, Project, Template } from "../types";
 // the cell has no project of the user's own; the seeded demo does not count.
 //
 // It is a conversation that has not started yet, not a form. As the user types, the screen
-// answers: the connectors they name light up under the box, and the starter sentences reorder to the
-// closest ones. Nothing here asks the user to know
+// answers: the connectors they name light up under the box. Nothing here asks the user to know
 // a source from a view. Three doors, one builder: describe it, paste your last incident, or
 // start the demo. Templates live behind the sentences; the gallery stays one click away under
 // Projects for people who already know what they want.
@@ -44,17 +43,7 @@ const COMMON: string[] = [
   "tell me when a city in Germany gets storm winds, from a public weather API",
 ];
 
-// Words every goal shares are not a match: only the nouns of their world count.
-const STOP = new Set(["the", "and", "when", "with", "that", "this", "from", "into", "what", "your", "my", "an", "a", "to", "of", "on", "in", "it", "is", "me", "for", "one", "watch", "agent", "tell", "wake", "show", "its", "something", "every", "each"]);
-const words = (t: string) => new Set(t.toLowerCase().split(/[^a-z0-9]+/).filter((w) => w.length > 2 && !STOP.has(w)));
 
-/** How many of the typed words a sentence shares; the sentences reorder by it while typing. */
-function overlap(typed: Set<string>, sentence: string) {
-  if (!typed.size) return 0;
-  let n = 0;
-  for (const w of words(sentence)) if (typed.has(w)) n++;
-  return n;
-}
 
 /** Create new (/projects/new): the landing screen loading its own data. */
 export function ProjectNewPage() {
@@ -75,7 +64,6 @@ export default function Landing({ templates, projects }: { templates: Template[]
   useEffect(() => { api.connectors().then(setSpecs).catch(() => {}); }, []);
   useEffect(() => { box.current?.focus(); }, []);
 
-  const typed = useMemo(() => words(goal), [goal]);
   // what the screen heard: installed connectors the words point at, and where the finding goes
   const heard = useMemo(() => {
     const out: string[] = [];
@@ -84,13 +72,14 @@ export default function Landing({ templates, projects }: { templates: Template[]
   }, [goal, specs]);
   const delivery = useMemo(() => DELIVERY.filter(([re]) => re.test(goal)).map(([, d]) => d), [goal]);
 
+  // A fixed list, in a fixed order. It used to reorder by overlap with the typed words, which
+  // moved the row the user had just clicked; the sentence is already in the box, that is enough.
   const sentences = useMemo(() => {
     const fromTemplates = templates.filter((t) => t.sentence).map((t) => ({ text: t.sentence!, template: t.key }));
-    const all = [...fromTemplates, ...COMMON.map((text) => ({ text, template: "" }))];
-    // one shared word is noise ("service" matches almost anything); two is a real neighbour
-    return all.map((s, i) => { const n = overlap(typed, s.text); return { ...s, i, score: n >= 2 ? n : 0 }; })
-      .sort((a, b) => b.score - a.score || a.i - b.i);
-  }, [templates, typed]);
+    return [...fromTemplates, ...COMMON.map((text) => ({ text, template: "" }))];
+  }, [templates]);
+  // the starter whose sentence is in the box, unedited: shown as the one picked
+  const selected = sentences.find((x) => x.text === goal.trim())?.text ?? "";
 
   const demo = projects.find((p) => p.template === "ai_sre_demo");
   const demoTemplate = templates.find((t) => t.key === "ai_sre_demo");
@@ -147,12 +136,14 @@ export default function Landing({ templates, projects }: { templates: Template[]
         <div className="landing-heard">
           {heard.map((k) => <span key={k} className="chip">{specs[k]?.label ?? k}</span>)}
           {delivery.map((d) => <span key={d} className="chip lbl">finding to {d}</span>)}
-          {goal.trim() && heard.length === 0 && (
+          {/* the nudge is for typed text; a picked starter is our sentence, and the row must
+              not grow a second line under it and shift the list the user is clicking in */}
+          {goal.trim() && heard.length === 0 && !selected && (
             <span className="help">say where it runs: a container, a Prometheus URL, a repo, a table, or an API you can post from</span>
           )}
         </div>
         <div className="btnrow">
-          <button className="primary" disabled={!goal.trim()}>Show me</button>
+          <button className="primary cta" disabled={!goal.trim()}>Build it</button>
           {!pasting && (
             <button type="button" className="dim" onClick={() => setPasting(true)}>or paste your last alert or incident thread</button>
           )}
@@ -167,7 +158,7 @@ export default function Landing({ templates, projects }: { templates: Template[]
                     onChange={(e) => setPaste(e.target.value)} />
           <span className="help">It goes to the assistant like any message and is not stored beyond the project's goal.</span>
           <div className="btnrow">
-            <button className="primary" disabled={!paste.trim()}>Show me what would have caught it</button>
+            <button className="primary cta" disabled={!paste.trim()}>Build what would have caught it</button>
             <button type="button" onClick={() => setPasting(false)}>Cancel</button>
           </div>
         </form>
@@ -175,8 +166,12 @@ export default function Landing({ templates, projects }: { templates: Template[]
 
       <div className="landing-starters">
         <div className="help">Or start from one of these</div>
+        {/* A click picks: the sentence lands in the box above, editable, and the row shows as
+            the one picked. Show me (or Enter in the box) is the one way to start; nothing starts
+            on the click alone. */}
         {sentences.map((s) => (
-          <button key={s.text} type="button" className="starter"
+          <button key={s.text} type="button"
+                  className={"starter" + (selected === s.text ? " on" : selected ? " off" : "")}
                   onClick={() => { setGoal(s.text); setPicked(s.template); box.current?.focus(); }}>
             {s.text}
           </button>

--- a/ui/src/pages/ProjectNewAssist.tsx
+++ b/ui/src/pages/ProjectNewAssist.tsx
@@ -258,6 +258,18 @@ export default function ProjectNewAssist() {
     }
   }, [ready, already]);   // eslint-disable-line react-hooks/exhaustive-deps
 
+  // Sources of this build with no events yet: on the watch step the model has nothing to ground
+  // a view or trigger in, and the page says so instead of leaving the user with a silent step.
+  const [quiet, setQuiet] = useState<string[]>([]);
+  useEffect(() => {
+    if (step !== "watch" || streaming) return;
+    let live = true;
+    Promise.all(created("source").map((n) =>
+      api.sourceFields(n).then((f) => (f.sampled === 0 ? n : null)).catch(() => null)))
+      .then((r) => { if (live) setQuiet(r.filter((n): n is string => n !== null)); });
+    return () => { live = false; };
+  }, [step, streaming]);   // eslint-disable-line react-hooks/exhaustive-deps
+
   // the template behind a finished template project, for its setup steps on Done
   const [finishedTemplate, setFinishedTemplate] = useState<Template>();
 
@@ -318,6 +330,13 @@ export default function ProjectNewAssist() {
     ? states[step].turns.flatMap((t) => t.parts).filter((p): p is { type: "proposal"; proposal: Proposal } =>
         p.type === "proposal" && !decisions[p.proposal.id]).length
     : 0;
+  /** Why Continue is held on this step, or undefined when it may go on. Each step needs the
+   *  object the next one builds on: a source to watch, a trigger to wake the agent. */
+  const held = (k: StepKey): string | undefined => {
+    if (k === "sources" && created("source").length === 0) return "connect at least one source first";
+    if (k === "watch" && created("trigger").length === 0) return "create a trigger first; the agent needs one to wake it";
+    return undefined;
+  };
   const proposalsInStep = step !== "describe" && step !== "done"
     ? states[step].turns.flatMap((t) => t.parts).filter((p) => p.type === "proposal").length
     : 0;
@@ -425,6 +444,16 @@ export default function ProjectNewAssist() {
                 : <>Nothing was proposed for this step. Ask for what you have in mind below, or continue.</>}
             </div>
           )}
+          {s.key === step && s.key === "watch" && quiet.length > 0 && !streaming && (
+            <div className="alert">
+              {quiet.length === 1 ? <>Source <span className="mono">{quiet[0]}</span> has</> : <>Sources <span className="mono">{quiet.join(", ")}</span> have</>}{" "}
+              no events yet. Views and triggers are proposed from real events, so send one first
+              (the ingest URL is on the source page), then ask again below.
+            </div>
+          )}
+          {s.key === step && s.key === "watch" && created("trigger").length === 0 && !streaming && (
+            <p className="help" style={{ marginTop: 8 }}>The agent step needs a trigger to wake the agent. Create one here first.</p>
+          )}
           {s.key === step && (
             <>
               <div className="builder-refine">
@@ -435,9 +464,8 @@ export default function ProjectNewAssist() {
                 <button type="button" disabled={streaming || !refine.trim()} onClick={sendRefine}>Send</button>
               </div>
               <div className="btnrow" style={{ marginTop: 12 }}>
-                <button className="primary" disabled={streaming || (s.key === "sources" && created("source").length === 0)}
-                        onClick={advance}
-                        title={s.key === "sources" && created("source").length === 0 ? "connect at least one source first" : undefined}>
+                <button className="primary" disabled={streaming || held(s.key) !== undefined}
+                        onClick={advance} title={held(s.key)}>
                   {NEXT[s.key] === "done" ? "Finish" : `Continue to ${STEPS[i + 1].label.toLowerCase()}`}
                   {pending > 0 ? ` (${pending} undecided)` : ""}
                 </button>
@@ -801,28 +829,33 @@ function AgentCard({ proposal: p, triggers, decision, decide, own }: CardCommon 
     api.triggers().then((ts) => setAllTriggers(ts.map((t) => t.name))).catch(() => setAllTriggers(triggers));
   }, []);   // eslint-disable-line react-hooks/exhaustive-deps
 
+  const open = !decision || decision.status === "error";
+  const triggerNames = [...new Set([...(allTriggers ?? []), ...triggers])];
+  // a trigger the model named but that does not exist is not prefilled: the form would submit
+  // it as is and the daemon would refuse it every time
+  const known = triggerNames.includes(p.trigger);
   const initial: BuiltinAgent = {
-    name: p.name, trigger: p.trigger, prompt: p.prompt, enabled: false, slack_configured: false,
+    name: p.name, trigger: known ? p.trigger : "", prompt: p.prompt, enabled: false, slack_configured: false,
     model: p.model ?? "", slack_channel: "",
     webhook_url: p.delivery.kind === "webhook" ? (p.delivery.url ?? "") : "", webhook_token_configured: false,
     mcp_servers: [], max_rounds: p.max_rounds ?? null, budget_usd: p.budget_usd ?? null,
     effective_max_rounds: p.max_rounds ?? 6,
   };
-  const open = !decision || decision.status === "error";
-  const triggerNames = [...new Set([...(allTriggers ?? []), ...triggers])];
   return (
     <ProposalShell title={proposalTitle(p)} decision={decision} reasoning={p.reasoning}
                    actions={open ? <div className="btnrow"><button onClick={() => decide(p.id, "skipped")}>Skip</button></div> : null}>
       <ProposalBody proposal={p} />
       {note && <div className="alert">{note}</div>}
-      {open && !triggerNames.includes(p.trigger) && (
+      {open && allTriggers && !known && (
         <div className="alert">
-          The proposed trigger <span className="mono">{p.trigger}</span> does not exist; pick one of yours in the form.
+          {triggerNames.length > 0
+            ? <>The proposed trigger <span className="mono">{p.trigger}</span> does not exist; pick one of yours in the form.</>
+            : <>This project has no trigger yet, and an agent needs one to wake it. Go back to Views and triggers and create one first.</>}
         </div>
       )}
       {open && bundle && allTriggers && (
         <AgentForm prefill deliveryKind={p.delivery.kind} initial={initial}
-                   presetTrigger={triggerNames.includes(p.trigger) ? p.trigger : undefined}
+                   presetTrigger={known ? p.trigger : undefined}
                    triggers={triggerNames} presets={bundle.presets} models={bundle.models}
                    defaultModel={bundle.default_model} slackWorkspace={bundle.slack_workspace}
                    defaultMaxRounds={bundle.default_max_rounds} defaultMaxRoundsWithMcp={bundle.default_max_rounds_with_mcp}

--- a/ui/src/pages/ProjectNewAssist.tsx
+++ b/ui/src/pages/ProjectNewAssist.tsx
@@ -104,6 +104,9 @@ export default function ProjectNewAssist() {
   const [history, setHistory] = useState<WireMessage[]>([]);
   const [refine, setRefine] = useState("");
   const { send, stop, streaming } = useAgentStream();
+  const chatEnd = useRef<HTMLDivElement>(null);
+  // a decided card folds to one line; "show" opens it again, and revealing from the chat too
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
 
   // what this build has made so far; the project is created around the first source
   const [project, setProject] = useState<Project>();
@@ -175,6 +178,7 @@ export default function ProjectNewAssist() {
     setStates((s) => ({ ...s, [stepKey]: { turns: [...s[stepKey].turns, { parts: [] }] } }));
     const mut = (fn: (parts: Part[]) => Part[]) =>
       setStates((s) => ({ ...s, [stepKey]: { turns: s[stepKey].turns.map((t, i) => i === idx ? { parts: fn(t.parts) } : t) } }));
+    chatEnd.current?.scrollIntoView({ block: "nearest" });
     const appendText = (text: string) => mut((parts) => {
       const last = parts[parts.length - 1];
       if (last && last.type === "text") return [...parts.slice(0, -1), { type: "text", text: last.text + text }];
@@ -337,6 +341,15 @@ export default function ProjectNewAssist() {
     if (k === "watch" && created("trigger").length === 0) return "create a trigger first; the agent needs one to wake it";
     return undefined;
   };
+  // every proposal of every step reached, in the order the assistant made them
+  const allProposals = STEPS.filter((_, i) => i <= stepIndex && i < STEPS.length)
+    .flatMap((s) => states[s.key].turns.flatMap((t) => t.parts)
+      .filter((p): p is { type: "proposal"; proposal: Proposal } => p.type === "proposal")
+      .map((p) => ({ p: p.proposal, stepKey: s.key })));
+  const reveal = (id: string) => {
+    setExpanded((x) => ({ ...x, [id]: true }));
+    requestAnimationFrame(() => document.getElementById(`card-${id}`)?.scrollIntoView({ behavior: "smooth", block: "nearest" }));
+  };
   const proposalsInStep = step !== "describe" && step !== "done"
     ? states[step].turns.flatMap((t) => t.parts).filter((p) => p.type === "proposal").length
     : 0;
@@ -345,19 +358,23 @@ export default function ProjectNewAssist() {
   const asking = !!lastTurn && !streaming && lastTurn.parts.some((p) => p.type === "text")
     && !lastTurn.parts.some((p) => p.type === "proposal");
 
+  const running = stepIndex >= 0 && step !== "done";
+  const stepsStrip = (
+    <div className="builder-steps">
+      {STEPS.map((s, i) => (
+        <span key={s.key} className={"step" + (i === stepIndex ? " active" : i < stepIndex ? " done" : "") + (i === stepIndex && streaming ? " busy" : "")}>
+          <span className="n">{i + 1}</span>{s.label}
+          {i < stepIndex && s.kinds.some((k) => created(k).length > 0) && (
+            <span className="badge ok">{s.kinds.reduce((n, k) => n + created(k).length, 0)}</span>
+          )}
+        </span>
+      ))}
+    </div>
+  );
   return (
     <>
-      <PageHead />
-      <div className="builder-steps">
-        {STEPS.map((s, i) => (
-          <span key={s.key} className={"step" + (i === stepIndex ? " active" : i < stepIndex ? " done" : "") + (i === stepIndex && streaming ? " busy" : "")}>
-            <span className="n">{i + 1}</span>{s.label}
-            {i < stepIndex && s.kinds.some((k) => created(k).length > 0) && (
-              <span className="badge ok">{s.kinds.reduce((n, k) => n + created(k).length, 0)}</span>
-            )}
-          </span>
-        ))}
-      </div>
+      {!running && <PageHead />}
+      {!running && stepsStrip}
 
       {/* Describe: the form until the flow starts (and again on Change); a header afterwards */}
       {step === "describe" ? (
@@ -397,7 +414,7 @@ export default function ProjectNewAssist() {
               : <Link className="btn" to="/projects/new">Cancel</Link>}
           </div>
         </div>
-      ) : (
+      ) : running ? null : (
         <div className="panel builder-brief">
           <label className="field" style={{ marginBottom: 10 }}>
             <span className="lbl">project name</span>
@@ -413,13 +430,33 @@ export default function ProjectNewAssist() {
         </div>
       )}
 
-      {projectErr && <div className="alert error">{projectErr}</div>}
+      {!running && projectErr && <div className="alert error">{projectErr}</div>}
 
-      {/* One panel per step reached so far */}
+      {/* The running builder fills the viewport: a one-line head (steps, the brief), then the
+          conversation on the left and everything it proposes on the right as cards to complete
+          or skip, each column scrolling on its own with the answer box pinned under the chat.
+          A decided card folds to one line so the right side is always the work still to do. */}
+      {running && (
+      <div className="builder-run">
+        <div className="builder-head">
+          <h1>Build with Tares</h1>
+          {stepsStrip}
+          <div className="brief" title={goal.trim()}>
+            {project
+              ? <span className="mono">{project.name}</span>
+              : <input type="text" value={projectName} onChange={(e) => setProjectName(e.target.value)} />}
+            <span className="goal">{goal.trim()}</span>
+          </div>
+          <button type="button" onClick={change}>Change what you need</button>
+        </div>
+        {projectErr && <div className="alert error" style={{ margin: "8px 36px 0" }}>{projectErr}</div>}
+      <div className="builder-split">
+      <div className="builder-chat">
+      <div className="builder-log">
       {STEPS.filter((_, i) => i <= stepIndex && i < STEPS.length).map((s, i) => (
-        <div className="panel" key={s.key}>
-          <div className="pagehead" style={{ marginBottom: 8 }}>
-            <h2 style={{ margin: 0 }}>{s.label}</h2>
+        <div className="builder-step" key={s.key}>
+          <div className="pagehead" style={{ marginBottom: 4 }}>
+            <h3 style={{ margin: 0 }}>{s.label}</h3>
             {i < stepIndex && <span className="badge ok">done</span>}
             {s.key === step && streaming && (
               <span className="builder-running">
@@ -429,13 +466,8 @@ export default function ProjectNewAssist() {
             )}
           </div>
           {states[s.key].turns.map((t, j) => (
-            <TurnView key={j} turn={t} decisions={decisions} decide={decide} own={own}
-                      thinking={streaming && s.key === step && j === states[s.key].turns.length - 1 && t.parts.length === 0}
-                      specs={specs ?? {}} existing={existing} refreshSources={refreshSources}
-                      sourceNames={[...new Set([...created("source"), ...existing.map((x) => x.name)])]}
-                      createdTriggers={created("trigger")}
-                      finishWith={finishWith}
-                      active={s.key === step} />
+            <TurnText key={j} turn={t} decisions={decisions} reveal={reveal}
+                      thinking={streaming && s.key === step && j === states[s.key].turns.length - 1 && t.parts.length === 0} />
           ))}
           {s.key === step && !streaming && states[s.key].turns.length > 0 && proposalsInStep === 0 && !asking && (
             <div className="empty">
@@ -454,27 +486,69 @@ export default function ProjectNewAssist() {
           {s.key === step && s.key === "watch" && created("trigger").length === 0 && !streaming && (
             <p className="help" style={{ marginTop: 8 }}>The agent step needs a trigger to wake the agent. Create one here first.</p>
           )}
-          {s.key === step && (
-            <>
-              <div className="builder-refine">
-                <textarea value={refine} rows={asking ? 2 : 1} autoFocus={asking}
-                          placeholder={asking ? "answer here, then Send" : "ask for a change, e.g. use the staging URL, or add the alerts too"}
-                          onChange={(e) => setRefine(e.target.value)}
-                          onKeyDown={(e) => { if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); sendRefine(); } }} />
-                <button type="button" disabled={streaming || !refine.trim()} onClick={sendRefine}>Send</button>
-              </div>
-              <div className="btnrow" style={{ marginTop: 12 }}>
-                <button className="primary" disabled={streaming || held(s.key) !== undefined}
-                        onClick={advance} title={held(s.key)}>
-                  {NEXT[s.key] === "done" ? "Finish" : `Continue to ${STEPS[i + 1].label.toLowerCase()}`}
-                  {pending > 0 ? ` (${pending} undecided)` : ""}
-                </button>
-                {project && <Link className="btn" to={`/projects/${encodeURIComponent(project.id)}`}>Open the project so far</Link>}
-              </div>
-            </>
-          )}
         </div>
       ))}
+      <div ref={chatEnd} />
+      </div>
+      {((active: StepKey) => (
+        <div className="builder-compose">
+          <div className="builder-refine">
+            <textarea value={refine} rows={asking ? 2 : 1} autoFocus={asking}
+                      placeholder={asking ? "answer here, then Send" : pending > 0 ? "decide the cards on the right, or ask for a change" : "ask for a change, e.g. use the staging URL, or add the alerts too"}
+                      onChange={(e) => setRefine(e.target.value)}
+                      onKeyDown={(e) => { if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); sendRefine(); } }} />
+            <button type="button" disabled={streaming || !refine.trim()} onClick={sendRefine}>Send</button>
+          </div>
+          <div className="btnrow" style={{ marginTop: 10 }}>
+            <button className="primary" disabled={streaming || held(active) !== undefined}
+                    onClick={advance} title={held(active)}>
+              {NEXT[active] === "done" ? "Finish" : `Continue to ${STEPS[stepIndex + 1].label.toLowerCase()}`}
+              {pending > 0 ? ` (${pending} undecided)` : ""}
+            </button>
+            {project && <Link className="btn" to={`/projects/${encodeURIComponent(project.id)}`}>Open the project so far</Link>}
+          </div>
+        </div>
+      ))(step as StepKey)}
+      </div>
+
+      <div className="builder-actions">
+        <div className="pagehead" style={{ marginBottom: 8 }}>
+          <h2 style={{ margin: 0 }}>To do</h2>
+          {pending > 0 && <span className="badge paused">{pending} to decide</span>}
+        </div>
+        {allProposals.length === 0 && (
+          <div className="empty">Each source, view, trigger and agent the assistant proposes appears here for you to complete or skip.</div>
+        )}
+        {allProposals.map(({ p, stepKey }) => {
+          const d = decisions[p.id];
+          const folded = !!d && d.status !== "error" && !expanded[p.id];
+          if (folded) {
+            return (
+              <div key={p.id} className="action-folded" id={`card-${p.id}`}>
+                <span className="title">{proposalTitle(p)}</span>
+                {d.status === "applied" ? <span className="badge ok">applied</span> : <span className="badge starting">skipped</span>}
+                <button type="button" className="dim" onClick={() => setExpanded((x) => ({ ...x, [p.id]: true }))}>show</button>
+              </div>
+            );
+          }
+          return (
+            <div key={p.id} id={`card-${p.id}`}>
+              {d && d.status !== "error" && (
+                <div className="btnrow" style={{ justifyContent: "flex-end", marginTop: 10 }}>
+                  <button type="button" className="dim" onClick={() => setExpanded((x) => ({ ...x, [p.id]: false }))}>fold</button>
+                </div>
+              )}
+              <CardFor proposal={p} decision={d} decide={decide} own={own} active={stepKey === step}
+                       specs={specs ?? {}} existing={existing} refreshSources={refreshSources}
+                       sourceNames={[...new Set([...created("source"), ...existing.map((x) => x.name)])]}
+                       createdTriggers={created("trigger")} finishWith={finishWith} />
+            </div>
+          );
+        })}
+      </div>
+      </div>
+      </div>
+      )}
 
       {step === "done" && (
         <div className="panel">
@@ -538,14 +612,10 @@ function PageHead() {
 
 /** One assistant turn inside a step: text, the tool rail, and each proposal as a card the user
  *  completes. Mirrors AskChat's Turn, with forms in place of Apply for sources and agents. */
-function TurnView({ turn, decisions, decide, own, thinking, specs, existing, refreshSources, sourceNames,
-                    createdTriggers, finishWith, active }: {
-  turn: Turn; decisions: DecisionMap; thinking: boolean; active: boolean;
-  decide: (id: string, status: "applied" | "skipped" | "error", detail?: string) => void;
-  own: (kind: ProjectObjectKind, name: string) => Promise<void>;
-  finishWith: (p: Project) => void;
-  specs: Record<string, ConnectorSpec>; existing: Source[]; refreshSources: () => void;
-  sourceNames: string[]; createdTriggers: string[];
+/** One assistant turn as conversation: its text and tool rail, and for each proposal a line
+ *  that points at its card on the right, with where that card stands. */
+function TurnText({ turn, decisions, reveal, thinking }: {
+  turn: Turn; decisions: DecisionMap; thinking: boolean; reveal: (id: string) => void;
 }) {
   const blocks: ({ kind: "tools"; tools: ToolPart[] } | { kind: "part"; part: Part })[] = [];
   for (const p of turn.parts) {
@@ -562,20 +632,34 @@ function TurnView({ turn, decisions, decide, own, thinking, specs, existing, ref
           return <div key={j} className="md"><ReactMarkdown remarkPlugins={[remarkGfm]}>{b.part.text}</ReactMarkdown></div>;
         if (b.part.type !== "proposal") return null;
         const p = b.part.proposal;
-        const common = { decision: decisions[p.id], decide, own, active };
-        if (p.kind === "source")
-          return <SourceCard key={j} proposal={p} specs={specs} existing={existing} refreshSources={refreshSources} {...common} />;
-        if (p.kind === "agent")
-          return <AgentCard key={j} proposal={p} triggers={createdTriggers} {...common} />;
-        if (p.kind === "project")
-          return <ProjectCard key={j} proposal={p} finishWith={finishWith} {...common} />;
-        return <CatalogCard key={j} proposal={p} sourceNames={sourceNames} {...common} />;
+        const d = decisions[p.id];
+        return (
+          <button key={j} type="button" className={"proposal-ref" + (d ? " " + d.status : "")} onClick={() => reveal(p.id)}>
+            <span>{proposalTitle(p)}</span>
+            <span className="state">{d?.status === "applied" ? "applied" : d?.status === "skipped" ? "skipped" : d?.status === "error" ? "failed" : "to decide"}</span>
+          </button>
+        );
       })}
       {thinking && <div className="dim">thinking…</div>}
     </div>
   );
 }
 
+/** The card for one proposal: the form or the apply card its kind needs. */
+function CardFor({ proposal: p, decision, decide, own, active, specs, existing, refreshSources, sourceNames,
+                   createdTriggers, finishWith }: CardCommon & {
+  proposal: Proposal; specs: Record<string, ConnectorSpec>; existing: Source[]; refreshSources: () => void;
+  sourceNames: string[]; createdTriggers: string[]; finishWith: (p: Project) => void;
+}) {
+  const common = { decision, decide, own, active };
+  if (p.kind === "source")
+    return <SourceCard proposal={p} specs={specs} existing={existing} refreshSources={refreshSources} {...common} />;
+  if (p.kind === "agent")
+    return <AgentCard proposal={p} triggers={createdTriggers} {...common} />;
+  if (p.kind === "project")
+    return <ProjectCard proposal={p} finishWith={finishWith} {...common} />;
+  return <CatalogCard proposal={p} sourceNames={sourceNames} {...common} />;
+}
 type CardCommon = {
   decision?: DecisionMap[string]; active: boolean;
   decide: (id: string, status: "applied" | "skipped" | "error", detail?: string) => void;

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -569,6 +569,41 @@ label.field.needs input, label.field.needs textarea { border-color: var(--accent
 .builder-steps .step.active { border-color: var(--accent); color: var(--ink); }
 .builder-steps .step.done { color: var(--ok); border-color: var(--ok-border); }
 .builder-steps .step .n { font-family: var(--mono); font-size: 11px; }
+/* The running builder fills the viewport under the top bar: a one-line head, then two columns
+   that scroll on their own. The page container drops its padding for it, like Ask does. */
+.main:has(> .builder-run) { padding: 0; max-width: none; display: flex; }
+.builder-run { flex: 1; display: flex; flex-direction: column; min-width: 0; height: calc(100vh - 46px); }
+.builder-head { display: flex; align-items: center; gap: 16px; padding: 10px 36px; border-bottom: 1px solid var(--line); min-width: 0; }
+.builder-head h1 { margin: 0; font-size: 16px; white-space: nowrap; }
+.builder-head .builder-steps { margin: 0; flex-wrap: nowrap; }
+.builder-head .brief { flex: 1; min-width: 0; display: flex; align-items: baseline; gap: 10px; font-size: 13px; }
+.builder-head .brief input { max-width: 220px; }
+.builder-head .brief .goal { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--ink-soft); }
+.builder-split { flex: 1; min-height: 0; display: grid; grid-template-columns: minmax(0, 1fr) minmax(420px, 44%); }
+.builder-chat { min-width: 0; min-height: 0; display: flex; flex-direction: column; }
+.builder-log { flex: 1; min-height: 0; overflow: auto; padding: 14px 24px 14px 36px; }
+.builder-compose { padding: 10px 24px 14px 36px; border-top: 1px solid var(--line); background: var(--bg); }
+.builder-compose .builder-refine { margin-top: 0; }
+.builder-step { padding: 12px 0 6px; border-top: 1px solid var(--line); }
+.builder-step:first-child { border-top: 0; padding-top: 0; }
+.builder-actions { min-height: 0; overflow: auto; padding: 14px 36px 24px 20px; border-left: 1px solid var(--line); background: var(--panel); }
+.builder-actions .card { margin: 10px 0 0; }
+.action-folded { display: flex; align-items: center; gap: 10px; padding: 8px 12px; margin-top: 6px; border: 1px solid var(--line); font-size: 13px; }
+.action-folded .title { flex: 1; }
+.proposal-ref { display: flex; align-items: center; gap: 10px; width: 100%; max-width: 78ch; margin: 6px 0; padding: 6px 10px; border: 1px dashed var(--accent); background: transparent; color: var(--ink); font: inherit; font-size: 13px; text-align: left; cursor: pointer; }
+.proposal-ref .state { margin-left: auto; font-family: var(--mono); font-size: 11px; color: var(--accent-deep); }
+.proposal-ref.applied { border-style: solid; border-color: var(--ok-border); }
+.proposal-ref.applied .state { color: var(--ok); }
+.proposal-ref.skipped { border-color: var(--line); color: var(--ink-soft); }
+.proposal-ref.skipped .state { color: var(--ink-soft); }
+.proposal-ref.error .state { color: var(--err); }
+@media (max-width: 1000px) {
+  .builder-run { height: auto; }
+  .builder-head { flex-wrap: wrap; }
+  .builder-split { grid-template-columns: 1fr; }
+  .builder-log, .builder-actions { overflow: visible; }
+  .builder-actions { border-left: 0; border-top: 1px solid var(--line); }
+}
 .builder-refine { display: flex; gap: 8px; align-items: flex-start; margin-top: 10px; }
 .builder-refine textarea { flex: 1; min-height: 38px; }
 /* field grouping (postgres) */
@@ -1357,8 +1392,11 @@ pre.payload {
 .landing-q { display: block; font-weight: 600; margin-bottom: 10px; }
 .landing-ask textarea { width: 100%; box-sizing: border-box; font: inherit; font-size: 15px; padding: 10px 12px; }
 .landing-ask textarea.mono { font-family: var(--mono); font-size: 13px; }
+.landing-ask .cta { padding: 10px 22px; font-size: 14px; font-weight: 600; }
 .landing-heard { min-height: 26px; display: flex; flex-wrap: wrap; gap: 6px; align-items: center; margin: 8px 0 10px; }
 .landing-starters { display: flex; flex-direction: column; gap: 6px; margin-bottom: 18px; }
+.starter.on { border-color: var(--accent); color: var(--ink); }
+.starter.off { color: var(--ink-soft); }
 .landing-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; }
 .landing-head .btn { flex: 0 0 auto; margin-top: 6px; }
 .landing-demo { display: flex; align-items: center; justify-content: space-between; gap: 24px; margin-bottom: 14px; }


### PR DESCRIPTION
Found while testing the AI-guided builder on the rapid-willow cell (2026-09-07).

**502 on the builder's next step.** nginx ingress pools upstream connections for 60s; uvicorn closed idle ones after 5s. A POST landing ~5s after the previous response hit a connection the daemon was closing: "upstream prematurely closed connection", a 502 nginx does not retry for POST. The daemon now keeps idle connections for 75s, longer than the proxy. The assistant shows a readable line for a non-JSON error body instead of the nginx HTML.

**No view, trigger or agent when the source has no events.** The watch step grounds views and triggers in real events; with none it proposed nothing, and the agent step then invented a trigger name the daemon rejected with a 400 on every click. Now: the daemon refuses an agent proposal whose trigger does not exist and hands the model the real list; Continue on the watch step is held until a trigger exists; the watch step names sources with no events yet; the agent card never prefills an unknown trigger. Trigger-less agents are TR-271.

**Builder layout.** Once the flow runs the page fills the viewport: a one-line head (steps, project name, goal), the conversation on the left with the answer box pinned at the bottom, and a "To do" column on the right with every proposed card. Decided cards fold to one line; a pointer in the chat opens its card.

**Landing.** Starters no longer reorder while typing; the picked row is marked; one call to action, "Build it". The Overview shows the Projects panel with Create new also on an empty instance (TR-273).

Tests: test_agent_build (32 checks) and test_cli pass; console typechecks and builds. Verified in a local run end to end.