### PR TITLE
Model access through a gateway, configured in Settings on the cell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@
 Notable changes to Tares (formerly NavFlow). Format follows [Keep a Changelog](https://keepachangelog.com/);
 the project follows [Semantic Versioning](https://semver.org/).
 
+## [1.28.0] - 2026-09-08
+
+### Added
+- Model access through an LLM gateway. Tares agents and Ask can talk to any server that speaks
+  the Anthropic Messages format (LiteLLM, Portkey, a proxy in front of Bedrock or Vertex).
+  From the environment with `ANTHROPIC_BASE_URL` and `ANTHROPIC_AUTH_TOKEN`, the names Claude
+  Code uses, with `TARES_ANTHROPIC_BASE` still read as the old name; or from Settings, Model
+  access, stored on the instance and winning over the environment, so a cloud customer with a
+  mandated proxy configures it on their own cell. The gateway token is sent as a bearer header
+  and never returned; a stored key is sent as the Anthropic key header. The Settings tab is now
+  called Model access and leads with where model calls go. Thanks to KurochkaR for the
+  environment half.
+
 ## [1.27.0] - 2026-09-08
 
 ### Added

--- a/tares/agent.py
+++ b/tares/agent.py
@@ -14,7 +14,6 @@ import httpx
 
 from . import tracing as _tracing
 
-from .config import API_BASE
 
 DEFAULT_MODEL = os.getenv("TARES_AGENT_MODEL", "claude-sonnet-4-6")
 _SELF = f"http://127.0.0.1:{os.getenv('TARES_PORT', '8787')}"
@@ -476,7 +475,8 @@ def _sse(obj: dict) -> str:
 
 async def run_agent(anthropic_headers: dict, messages: list,
                     model: str | None = None, self_headers: dict | None = None,
-                    on_usage=None, tracer=None, mode: str = "ask", step: str | None = None):
+                    on_usage=None, tracer=None, mode: str = "ask", step: str | None = None,
+                    base_url: str | None = None):
     """Async generator of SSE lines: the agent loop, streaming assistant text and tool activity.
 
     `on_usage(model, usage_dict)` is called once per turn (after the loop, including on an error
@@ -487,16 +487,18 @@ async def run_agent(anthropic_headers: dict, messages: list,
     one tool span per tool call. None means no tracing.
 
     `mode` is "ask" or "build"; `step` names the build step (see BUILD_STEPS) and picks which
-    proposal cards the turn may emit."""
+    proposal cards the turn may emit. `base_url` is where the model calls go (a gateway, or
+    Anthropic when None); the caller resolves it per request, like the credential."""
     with _tracing.run_span(tracer, "ask", kind="CHAIN") as obs:
         obs.set_attribute("tares.instance", _tracing.instance_name())
         async for line in _run_agent(anthropic_headers, messages, model, self_headers, on_usage, tracer,
-                                     obs, mode, step):
+                                     obs, mode, step, base_url):
             yield line
 
 
 async def _run_agent(anthropic_headers: dict, messages: list, model, self_headers, on_usage, tracer,
-                     obs: _tracing.Observation, mode: str = "ask", step: str | None = None):
+                     obs: _tracing.Observation, mode: str = "ask", step: str | None = None,
+                     base_url: str | None = None):
     try:
         import anthropic
     except ImportError:
@@ -504,7 +506,8 @@ async def _run_agent(anthropic_headers: dict, messages: list, model, self_header
                                                "(pip install tares[agent])"})
         return
 
-    client = anthropic.AsyncAnthropic(base_url=API_BASE, default_headers=anthropic_headers)
+    client = anthropic.AsyncAnthropic(base_url=base_url or "https://api.anthropic.com",
+                                      default_headers=anthropic_headers)
     convo = list(messages)
     last = convo[-1] if convo else None
     obs.set_input(last.get("content") if isinstance(last, dict) else last)

--- a/tares/builtin_agents.py
+++ b/tares/builtin_agents.py
@@ -143,17 +143,42 @@ def prompt_hash(prompt: str) -> str:
     return hashlib.sha256(prompt.encode("utf-8")).hexdigest()[:12]
 
 
+DEFAULT_API_BASE = "https://api.anthropic.com"
+
+
+def resolve_api_base(store) -> tuple[str, str]:
+    """(base URL, where-it-came-from). Where model calls go: a gateway saved in the console
+    (TR-281), else the environment (`ANTHROPIC_BASE_URL`, or the old `TARES_ANTHROPIC_BASE`),
+    else Anthropic itself. Read per request, like the key, so a cell can switch to a gateway
+    without a restart and a cloud customer can do it from Settings."""
+    stored = (store.get_setting("gateway_url") or "").strip().rstrip("/")
+    if stored:
+        return stored, "console"
+    if API_BASE != DEFAULT_API_BASE:
+        which = "ANTHROPIC_BASE_URL" if os.getenv("ANTHROPIC_BASE_URL", "").strip() else "TARES_ANTHROPIC_BASE"
+        return API_BASE, f"env:{which}"
+    return DEFAULT_API_BASE, ""
+
+
 def resolve_anthropic_headers(store) -> tuple[dict[str, str], str]:
-    """(header, where-it-came-from). The console-stored key wins over the env `ANTHROPIC_API_KEY`:
-    the user's own key takes over from whatever the deployment shipped the moment they save one.
-    That order is load-bearing for hosted trials — an operator-provided key in the env must yield
-    to the customer's key instantly, so their spend lands on their key, not the trial's. Deleting
-    the stored key falls back to the env key (if the deployment still carries one)."""
+    """(header, where-it-came-from). The console-stored values win over the environment: the
+    user's own credential takes over from whatever the deployment shipped the moment they save
+    one. That order is load-bearing for hosted trials — an operator-provided key in the env must
+    yield to the customer's key instantly, so their spend lands on their key, not the trial's.
+    Deleting the stored value falls back to the env (if the deployment still carries one).
+
+    A gateway token saved in the console (Settings, TR-281) goes first, as a bearer header: it
+    exists only because the user set a gateway up on purpose. Then the stored key, as the
+    Anthropic key header, which is what a gateway expects from a plain key too."""
+    gateway_token = (store.get_setting("gateway_token") or "").strip()
     stored = (store.get_setting("anthropic_key") or "").strip()
     auth_token = os.getenv("ANTHROPIC_AUTH_TOKEN", "").strip()
     api_key = os.getenv("ANTHROPIC_API_KEY", "").strip()
     headers = {"anthropic-version": "2023-06-01",}
-    if stored:
+    if gateway_token:
+        headers["Authorization"] = f"Bearer {gateway_token}"
+        key_origin = "console:gateway"
+    elif stored:
         headers["x-api-key"] = stored
         key_origin = "console"
     elif auth_token:
@@ -359,6 +384,7 @@ class AgentRunner:
         started_at = now_utc()
         t0 = time.monotonic()
         headers, key_origin = resolve_anthropic_headers(self.store)
+        api_base, _ = resolve_api_base(self.store)
         if not headers:
             msg = "no Anthropic key: set ANTHROPIC_API_KEY before `tares up`, or add a key under Settings"
             self.store.finish_agent_run(run_id, "failed", error=msg)
@@ -385,7 +411,7 @@ class AgentRunner:
                  "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0}
         try:
             finding, rounds, tool_calls, external_used, exhausted, partial = await self._loop(
-                agent, trigger_name, key, payload, headers, usage, tracer, obs)
+                agent, trigger_name, key, payload, headers, usage, tracer, obs, api_base=api_base)
         finally:
             if usage["calls"]:
                 cost = cost_usd(model, usage["input_tokens"], usage["output_tokens"],
@@ -445,7 +471,7 @@ class AgentRunner:
     # ── the bounded model loop ────────────────────────────────────────────────
     async def _loop(self, agent: dict, trigger_name: str, key: str, payload: str,
                     headers: dict, usage: dict, tracer=None,
-                    obs: _tracing.Observation | None = None,
+                    obs: _tracing.Observation | None = None, api_base: str = DEFAULT_API_BASE,
                     ) -> tuple[str, int, int, list[str], bool, str]:
         # External tools: the agent's selected MCP servers, connected for the duration of this
         # run. A server that fails to connect is skipped (recorded below) — losing a tool server
@@ -458,11 +484,11 @@ class AgentRunner:
             for failure in toolbox.failures:
                 print(f"[agent {agent['name']}] mcp connect failed; {failure}")
             return await self._loop_with(agent, trigger_name, key, payload, headers, toolbox,
-                                         usage, tracer, obs)
+                                         usage, tracer, obs, api_base=api_base)
 
     async def _loop_with(self, agent: dict, trigger_name: str, key: str, payload: str,
                          headers: dict, toolbox, usage: dict, tracer=None,
-                         obs: _tracing.Observation | None = None,
+                         obs: _tracing.Observation | None = None, api_base: str = DEFAULT_API_BASE,
                          ) -> tuple[str, int, int, list[str], bool, str]:
         """Returns (finding, rounds, tool_calls, external_tools_used, exhausted, partial_text)."""
         tools = TOOL_DEFS + toolbox.tool_defs
@@ -499,7 +525,7 @@ class AgentRunner:
                 with _tracing.generation(tracer, body["model"], messages,
                                          {"max_tokens": MAX_TOKENS}) as gen:
                     r = await cx.post(
-                        f"{API_BASE}/v1/messages",
+                        f"{api_base}/v1/messages",
                         headers=headers,
                         json=body)
                     if r.status_code >= 400:

--- a/tares/daemon.py
+++ b/tares/daemon.py
@@ -17,6 +17,7 @@ import secrets
 import shutil
 import traceback
 import uuid
+from urllib.parse import urlsplit
 from contextlib import asynccontextmanager
 from pathlib import Path
 from urllib.parse import parse_qs
@@ -27,7 +28,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse, PlainTextResponse, StreamingResponse
 from pydantic import BaseModel, model_validator
 
-from .config import (SLACK_URL_PREFIX, API_BASE, CatalogError, agent_url, export_db_to_yaml,
+from .config import (SLACK_URL_PREFIX, CatalogError, agent_url, export_db_to_yaml,
                      validate_mcp_server_dict,
                      import_yaml_to_db, slack_channel_from_url, slack_url,
                      validate_agent_dict, validate_slack_channel, validate_source_dict,
@@ -41,7 +42,7 @@ from .builtin_agents import (AGENT_MODELS, MODEL as AGENT_DEFAULT_MODEL,
                              MAX_ROUNDS_LIMIT as AGENT_MAX_ROUNDS_LIMIT,
                              MAX_ROUNDS_WITH_MCP as AGENT_MAX_ROUNDS_WITH_MCP,
                              PRESETS as AGENT_PRESETS, AgentRunner, effective_max_rounds,
-                             resolve_anthropic_headers)
+                             resolve_anthropic_headers, resolve_api_base, DEFAULT_API_BASE)
 from .runtime import Runtime
 from . import slack as slack_mod
 from . import slack_verify
@@ -369,6 +370,11 @@ class TracingIn(BaseModel):
 
 class AnthropicKeyIn(BaseModel):
     key: str    # blank-to-keep is not offered here: the only edits are "set a new one" or DELETE
+
+
+class GatewayIn(BaseModel):
+    url: str
+    token: str = ""    # blank keeps the stored token; the URL alone can change
 
 
 class SlackTokenIn(BaseModel):
@@ -977,7 +983,7 @@ def make_app() -> FastAPI:
             ver = _pkg_version("tares")   # the installed release (release.sh bumps pyproject.toml)
         except Exception:
             ver = None
-        url_configured = API_BASE != "https://api.anthropic.com"
+        url_configured = resolve_api_base(store)[1] != ""
         return {
             "version": ver,
             "discover_docker": shutil.which("docker") is not None or os.path.exists("/var/run/docker.sock"),
@@ -1331,7 +1337,8 @@ def make_app() -> FastAPI:
             run_agent(headers, body.get("messages") or [],
                       model=body.get("model"), self_headers=self_headers,
                       on_usage=lambda m, u: _record_ask_usage(m, u, key_source=key_origin),
-                      tracer=tracing.tracer_for("ask"), mode=mode, step=step),
+                      tracer=tracing.tracer_for("ask"), mode=mode, step=step,
+                      base_url=resolve_api_base(store)[0]),
             media_type="text/event-stream")
 
     # ── MCP connections — external tool servers a Tares agent can opt into ─────
@@ -1874,6 +1881,40 @@ def make_app() -> FastAPI:
         key, origin = resolve_anthropic_headers(store)
         return {"ok": True, "configured": bool(key), "source": origin}
 
+    # ── model access through a gateway (TR-281): stored on the cell like the key ──────────
+    # Where model calls go, and the credential for it. Saved here they win over the environment,
+    # so a cloud customer with a mandated proxy configures it on their own cell and the platform
+    # key stops being used, the same as when they store their own key. The token is write-only.
+    def _gateway_status() -> dict:
+        url, origin = resolve_api_base(store)
+        return {"configured": origin != "", "url": url if origin else "", "source": origin,
+                "stored": bool(store.get_setting("gateway_url")),
+                "token_stored": bool(store.get_setting("gateway_token")),
+                "default_url": DEFAULT_API_BASE}
+
+    @app.get("/api/settings/gateway")
+    async def get_gateway():
+        return _gateway_status()
+
+    @app.put("/api/settings/gateway")
+    async def set_gateway(body: GatewayIn):
+        url = body.url.strip().rstrip("/")
+        parts = urlsplit(url)
+        if parts.scheme not in ("http", "https") or not parts.hostname:
+            _err(ValueError("gateway url must be an http(s) URL with a host, e.g. "
+                            "https://llm-gateway.internal"))
+        store.set_setting("gateway_url", url)
+        if body.token.strip():
+            store.set_setting("gateway_token", body.token.strip())
+        return {"ok": True, **_gateway_status()}
+
+    @app.delete("/api/settings/gateway")
+    async def clear_gateway():
+        """Back to the environment's gateway if the deployment set one, else Anthropic."""
+        store.set_setting("gateway_url", None)
+        store.set_setting("gateway_token", None)
+        return {"ok": True, **_gateway_status()}
+
     # ── agent tracing: where runs are exported, and whether ──────────────────
     # A console-stored value wins over the environment, like the Anthropic key. Secrets (the
     # key, the headers) are write-only: the API says whether one resolves and where from.
@@ -2026,6 +2067,7 @@ def make_app() -> FastAPI:
                 nonlocal text, error
                 async for chunk in run_agent(headers, [{"role": "user", "content": question}],
                                              self_headers=self_headers,
+                                             base_url=resolve_api_base(store)[0],
                                              on_usage=lambda m, u: _record_ask_usage(
                                                  m, u, key_source=key_origin),
                                              tracer=tracing.tracer_for("ask")):

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -38,12 +38,14 @@ FINDING = "checkout is returning 500s since the 14:02 deploy; roll it back."
 
 # ── stub Anthropic: one tool_use round, then the conclusion ──────────────────
 _calls = []
+_headers = []   # the request headers per call: which credential reached the wire
 
 
 class Stub(BaseHTTPRequestHandler):
     def do_POST(self):
         body = json.loads(self.rfile.read(int(self.headers["content-length"])))
         _calls.append(body)
+        _headers.append({k.lower(): v for k, v in self.headers.items()})
         # First call: ask for a wider read (exercises the tool path). Second: conclude.
         if len(_calls) == 1:
             content = [{"type": "tool_use", "id": "tu_1", "name": "read",
@@ -228,6 +230,20 @@ async def main():
             ck("finding is on the entity's timeline", FINDING in rd["payload"], rd["payload"][:200])
             ck("findings source contributes to the read", "findings" in rd["sources"], str(rd["sources"]))
 
+            # ── a gateway saved in Settings (TR-281): URL and token, per request, over the env ──
+            g = (await cx.get(f"{B}/api/settings/gateway")).json()
+            ck("gateway status: the env base URL shows as such", g["configured"] and g["source"] == "env:TARES_ANTHROPIC_BASE"
+               and not g["stored"], str(g))
+            r = await cx.put(f"{B}/api/settings/gateway", json={"url": "not a url", "token": ""})
+            ck("gateway url is checked", r.status_code == 400, r.text[:120])
+            r = await cx.put(f"{B}/api/settings/gateway", json={"url": f"http://127.0.0.1:{STUB_PORT}/", "token": "gw-tok"})
+            ck("gateway saved", r.status_code == 200 and r.json()["source"] == "console" and r.json()["token_stored"], r.text[:200])
+            g = (await cx.get(f"{B}/api/settings/gateway")).json()
+            ck("gateway token never returned", "gw-tok" not in json.dumps(g), str(g))
+            k = (await cx.get(f"{B}/api/settings/anthropic-key")).json()
+            ck("the stored gateway token is the credential in use", k["source"] == "console:gateway", str(k))
+            headers_before = len(_headers)
+
             # ── the next run opens with the previous finding (a head start) ──
             await asyncio.sleep(1.2)   # past the trigger cooldown
             for i in range(3):
@@ -236,6 +252,13 @@ async def main():
                 rs = (await cx.get(f"{B}/api/agents/builtin/first-look/runs")).json()
                 return len(rs) >= 2 and rs[0]["status"] != "running"
             ck("a second run completed", await _until(_ran_again), "no second run")
+            ck("the run reached the gateway with the bearer token",
+               len(_headers) > headers_before and _headers[-1].get("authorization") == "Bearer gw-tok"
+               and "x-api-key" not in _headers[-1], str(_headers[-1:]))
+            r = await cx.delete(f"{B}/api/settings/gateway")
+            ck("clearing the gateway falls back to the env", r.status_code == 200 and r.json()["source"] == "env:TARES_ANTHROPIC_BASE", r.text[:200])
+            k = (await cx.get(f"{B}/api/settings/anthropic-key")).json()
+            ck("credential falls back to the env key", k["source"] == "env:ANTHROPIC_API_KEY", str(k))
             opening = str(_calls[-1]["messages"][0]["content"])
             ck("the second run opens with the first run's finding",
                "earlier run" in opening and FINDING in opening, opening[:300])

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -182,6 +182,16 @@ export const api = {
   modelUsage: (days = 30) => request<ModelUsage>(`/api/usage/model?days=${days}`),
 
   // The Anthropic key Tares agents run on. Never returned — only whether one resolves and where.
+  gatewayStatus: () =>
+    request<{ configured: boolean; url: string; source: string; stored: boolean; token_stored: boolean;
+              default_url: string }>("/api/settings/gateway"),
+  setGateway: (url: string, token: string) =>
+    request<{ ok: boolean; configured: boolean; url: string; source: string; stored: boolean;
+              token_stored: boolean }>("/api/settings/gateway",
+      { method: "PUT", body: JSON.stringify({ url, token }) }),
+  clearGateway: () =>
+    request<{ ok: boolean; configured: boolean; source: string }>("/api/settings/gateway",
+      { method: "DELETE" }),
   anthropicKeyStatus: () =>
     request<{ configured: boolean; source: string; stored: boolean; env_overrides: boolean }>(
       "/api/settings/anthropic-key"),

--- a/ui/src/pages/Security.tsx
+++ b/ui/src/pages/Security.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 import { api, type TracingStatus } from "../api";
 import ConfirmDialog from "../components/ConfirmDialog";
 import { Close } from "../components/icons";
-import { TimeAgo } from "../components/bits";
+import { Picker, TimeAgo } from "../components/bits";
 import type { ApiKey, GithubCredential } from "../types";
 
 // Four distinct credential concepts, one box each:
@@ -16,7 +16,7 @@ import type { ApiKey, GithubCredential } from "../types";
 type SettingsTab = "access" | "anthropic" | "github" | "slack" | "observability";
 const TABS: { key: SettingsTab; label: string }[] = [
   { key: "access", label: "Access and API keys" },
-  { key: "anthropic", label: "Anthropic" },
+  { key: "anthropic", label: "Model access" },
   { key: "github", label: "GitHub" },
   { key: "slack", label: "Slack" },
   { key: "observability", label: "Observability" },
@@ -41,7 +41,7 @@ export default function Security() {
   return (
     <>
       <h1>Settings</h1>
-      <p className="subtitle">access mode, API keys, the instance credentials (Anthropic, GitHub, Slack) and agent tracing</p>
+      <p className="subtitle">access mode, API keys, model access, the instance credentials (GitHub, Slack) and agent tracing</p>
       {workspaceUrl && (
         <div className="alert" style={{ marginBottom: 14 }}>
           <strong>Users, the Slack app, plan and storage</strong> are managed in your workspace, not
@@ -289,6 +289,7 @@ function AccessPanel() {
 // so a deployment's config is never silently overridden by something typed in here months earlier.
 function AnthropicKeyPanel() {
   const [st, setSt] = useState<{ configured: boolean; source: string; stored: boolean; env_overrides: boolean }>();
+  const [mode, setMode] = useState<"direct" | "gateway">();
   const [key, setKey] = useState("");
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string>();
@@ -313,17 +314,23 @@ function AnthropicKeyPanel() {
     <div className="panel">
       <h2 style={{ marginTop: 0 }}>Model access</h2>
       <p className="help" style={{ marginTop: 0 }}>
-        What <strong>Tares agents</strong> run on; their first look at an entity when a trigger
-        fires. Store one here (it takes precedence),
-        or set <code>ANTHROPIC_API_KEY</code> or <code>ANTHROPIC_AUTH_TOKEN</code> in the daemon's environment.
-        It is never returned by the API and never included in a catalog export.
+        What <strong>Tares agents</strong> and Ask run on. Anthropic directly with your API key, or
+        through a gateway your organisation runs. Values stored here win over the daemon's
+        environment (<code>ANTHROPIC_API_KEY</code>, <code>ANTHROPIC_AUTH_TOKEN</code>,{" "}
+        <code>ANTHROPIC_BASE_URL</code>); credentials are never returned by the API and never
+        included in a catalog export.
       </p>
+
+      <GatewaySection onChanged={load} mode={mode} setMode={setMode} />
 
       {err && <div className="alert error">{err}</div>}
       {msg && <p className="help">{msg}</p>}
 
       {!st ? <div className="muted">loading…</div> : (
         <>
+          <span className="lbl" style={{ display: "block", marginBottom: 4 }}>
+            {mode === "gateway" ? "Anthropic API key (optional: only if the gateway takes your key instead of a token)" : "Anthropic API key"}
+          </span>
           <p style={{ margin: "0 0 10px" }}>
             {st.configured
               ? <><span className="badge ok">configured</span>{" "}
@@ -349,6 +356,99 @@ function AnthropicKeyPanel() {
                 setBusy(false);
               }}>Clear stored</button>
             )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+// Where the model calls go (TR-281). Direct to Anthropic, or through a gateway that speaks the
+// Anthropic Messages format (LiteLLM, Portkey, a proxy in front of Bedrock or Vertex). Stored on
+// this instance like the key and winning over the environment, so a cloud customer with a
+// mandated proxy sets it here, on their own cell. The token is write-only.
+function GatewaySection({ onChanged, mode, setMode }: {
+  onChanged: () => void; mode: "direct" | "gateway" | undefined;
+  setMode: (m: "direct" | "gateway") => void;
+}) {
+  const [st, setSt] = useState<{ configured: boolean; url: string; source: string; stored: boolean;
+    token_stored: boolean; default_url: string }>();
+  const [url, setUrl] = useState("");
+  const [token, setToken] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string>();
+  const [msg, setMsg] = useState<string>();
+
+  const load = () => api.gatewayStatus().then((s) => {
+    setSt(s);
+    if (mode === undefined) setMode(s.configured ? "gateway" : "direct");
+    setUrl((u) => u || (s.stored ? s.url : ""));
+  }).catch((e) => setErr(String((e as Error).message ?? e)));
+  useEffect(() => { load(); }, []);
+
+  const save = async () => {
+    setBusy(true); setErr(undefined); setMsg(undefined);
+    try {
+      await api.setGateway(url.trim(), token.trim());
+      setToken("");
+      setMsg("✓ saved; model calls go through the gateway from the next call");
+      await load(); onChanged();
+    } catch (e) { setErr(String((e as Error).message ?? e)); }
+    setBusy(false);
+  };
+  const clear = async () => {
+    setBusy(true); setErr(undefined); setMsg(undefined);
+    try { await api.clearGateway(); setUrl(""); setMode("direct"); await load(); onChanged(); }
+    catch (e) { setErr(String((e as Error).message ?? e)); }
+    setBusy(false);
+  };
+
+  if (!st) return null;
+  const fromEnv = st.source.startsWith("env:");
+  return (
+    <div style={{ margin: "0 0 18px", maxWidth: 720 }}>
+      <div className="field" style={{ marginBottom: 8 }}>
+        <span className="lbl">where model calls go</span>
+        <Picker value={mode ?? "direct"} options={["direct", "gateway"]} style={{ width: 260 }}
+                labels={{ direct: "Anthropic directly", gateway: "through a gateway" }}
+                ariaLabel="where model calls go"
+                onChange={(v) => setMode(v as "direct" | "gateway")} />
+      </div>
+      {err && <div className="alert error">{err}</div>}
+      {msg && <p className="help">{msg}</p>}
+      {mode === "direct" && st.configured && (
+        <p className="help" style={{ margin: "0 0 8px" }}>
+          A gateway is in use{fromEnv ? <> from the environment (<span className="mono">{st.source}</span>)</> : ""}: <span className="mono">{st.url}</span>.
+          {st.stored
+            ? <> <button type="button" className="linklike" disabled={busy} onClick={clear}>Stop using it</button> and calls go {fromEnv ? "to the environment's gateway" : "to Anthropic directly"}.</>
+            : " It was set by the deployment; only its operator can change it."}
+        </p>
+      )}
+      {mode === "gateway" && (
+        <>
+          <p className="help" style={{ margin: "0 0 8px" }}>
+            A gateway serves the Anthropic Messages format and forwards to what you run behind it:
+            LiteLLM, Portkey, a proxy in front of Bedrock or Vertex. Tares sends a Claude model id;
+            what answers is the gateway's choice, and the spend meter prices runs at Claude rates.
+            {fromEnv && <> The deployment set <span className="mono">{st.url}</span>; a gateway saved here takes over.</>}
+          </p>
+          <label className="field">
+            <span className="lbl">gateway URL</span>
+            <input type="text" className="mono" placeholder="https://llm-gateway.internal"
+                   value={url} onChange={(e) => setUrl(e.target.value)} />
+          </label>
+          <label className="field">
+            <span className="lbl">gateway token</span>
+            <input type="password" className="mono" autoComplete="off"
+                   placeholder={st.token_stored ? "leave blank to keep the stored token" : "sent as Authorization: Bearer; leave empty if the gateway takes your key"}
+                   value={token} onChange={(e) => setToken(e.target.value)} />
+            <span className="help">
+              {st.token_stored ? "a token is stored and sent as a bearer header; it is never shown again" : "without a token, the key above is sent to the gateway as the Anthropic key header"}
+            </span>
+          </label>
+          <div className="btnrow">
+            <button className="primary" disabled={busy || !url.trim()} onClick={save}>Save gateway</button>
+            {st.stored && <button className="danger" disabled={busy} onClick={clear}>Stop using the gateway</button>}
           </div>
         </>
       )}


### PR DESCRIPTION
Linear TR-281. Follows #110, which added the environment half (`ANTHROPIC_BASE_URL`, `ANTHROPIC_AUTH_TOKEN`).

**Why.** A cloud customer has no access to a cell's environment, so on the cloud a gateway could not be used at all, and a self-hoster had to restart the daemon to change it. The model key already shows the right pattern: stored on the cell through Settings, resolved at request time, winning over the environment. A gateway now follows the same path, so a customer with a mandated proxy configures it on their own cell and the platform key stops being used, as when they store their own key.

**Daemon.** Two settings, gateway URL and gateway token, on `/api/settings/gateway` (GET, PUT, DELETE); the token is write-only, blank keeps it, DELETE clears both, the URL is checked on save. `resolve_api_base` and `resolve_anthropic_headers` resolve per request: stored values, then the environment, then Anthropic. The module constant is gone from both call sites, the trigger-woken agent loop and Ask. A stored gateway token goes as `Authorization: Bearer`; a stored key goes as the Anthropic key header, which gateways accept too.

**Console.** The tab is now Model access. The panel leads with "where model calls go", Anthropic directly or through a gateway; gateway shows the URL and token fields, Save and Stop using the gateway, and the key marked optional. A gateway set by the deployment's environment shows as such and can be overridden but not cleared from the console.

**Verified against LiteLLM** (official image, Postgres, real Anthropic key behind a master key): Ask streamed through it, a trigger-woken agent run finished through it, usage attributed to `console:gateway`, one spend-log row per model call in LiteLLM, a wrong token refused. Ops follow-up for a prod LiteLLM is TR-282.

**Tests.** Eight new checks in `tests/test_agents.py`: the saved gateway reaches the stub with the bearer header and no key header, the token is never returned, a bad URL is refused, clearing falls back to the environment's gateway and key. 83 pass; builder, Slack and CLI tests pass; console typechecks.

Docs: the "planned" line in glassflow-docs#101 needs replacing with the Settings path once this ships.