### PR TITLE
rius_rca: service as the entity, rule label, 5 minute cooldown; write-back key from a label and delivery status

### DIFF
--- a/tares/builtin_agents.py
+++ b/tares/builtin_agents.py
@@ -22,6 +22,8 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import json
+from datetime import timedelta
 import os
 import time
 import uuid
@@ -29,7 +31,7 @@ import uuid
 import httpx
 
 from . import tracing as _tracing
-from .config import FINDINGS_SOURCE, API_BASE, agent_url
+from .config import FINDINGS_SOURCE, API_BASE, agent_url, parse_duration
 from .envelope import now_utc
 from .pricing import cost_usd
 from .slack import deep_link as _slack_deep_link
@@ -451,9 +453,12 @@ class AgentRunner:
         self.store.finish_agent_run(run_id, "ok", rounds=rounds, tool_calls=tool_calls,
                                     finding=finding, external_tools=external_used)
         if (agent.get("webhook_url") or "").strip():
-            await self._webhook(agent, {
+            delivery, derr = await self._webhook(agent, {
                 "event": "finding",
-                "agent": agent["name"], "trigger": trigger_name, "key": key,
+                "agent": agent["name"], "trigger": trigger_name,
+                # `key` is the entity, unless the agent names a label to report instead: Rius
+                # attributes reports by delivery id while the entity is the service (TR-285)
+                "key": self._callback_key(agent, trigger_name, key),
                 "finding": finding,
                 "run_id": run_id, "dispatch_id": dispatch_id,
                 "model": model,
@@ -466,7 +471,43 @@ class AgentRunner:
                 "duration_s": round(time.monotonic() - t0, 2),
                 "prompt_hash": prompt_hash(agent["prompt"]),
             })
+            self.store.set_run_delivery(run_id, delivery, derr)
         return "ok", None
+
+    def _callback_key(self, agent: dict, trigger_name: str, key: str) -> str:
+        """The `key` the write-back carries: the entity, or the value of `webhook_key_label` on
+        the most recent event that woke this run, when the agent names one. Falls back to the
+        entity when the label is not on the event, so a wrong name never drops the field."""
+        label = (agent.get("webhook_key_label") or "").strip()
+        if not label:
+            return key
+        try:
+            catalog = self.runtime.catalog
+            triggers = catalog.triggers
+            trig = (triggers.get(trigger_name) if isinstance(triggers, dict)
+                    else next((t for t in triggers if t.name == trigger_name), None))
+            views = catalog.views
+            view = None
+            if trig is not None:
+                view = (views.get(trig.view) if isinstance(views, dict)
+                        else next((v for v in views if v.name == trig.view), None))
+            if view is None:
+                return key
+            window = max(parse_duration(trig.condition.window or "15m"), 900.0)
+            since = now_utc() - timedelta(seconds=window)
+            rows = self.store.read_view_window(view.sources, key, since, cap=1,
+                                               filters=view.filters)
+            latest = max(rows, key=lambda r: r[0]) if rows else None
+            if latest is None:
+                return key
+            labels = latest[3]
+            if isinstance(labels, str):
+                labels = json.loads(labels or "{}")
+            value = (labels or {}).get(label)
+            return str(value) if value not in (None, "") else key
+        except Exception as e:  # noqa: BLE001 — never lose the write-back over the key lookup
+            print(f"[agent {agent['name']}] callback key from {label!r}: {type(e).__name__}: {e}")
+            return key
 
     # ── the bounded model loop ────────────────────────────────────────────────
     async def _loop(self, agent: dict, trigger_name: str, key: str, payload: str,
@@ -661,14 +702,17 @@ class AgentRunner:
         elif hook:
             await self._slack(agent["name"], hook, trigger_name, key, finding)
 
-    async def _webhook(self, agent: dict, body: dict, attempts: int = 3) -> None:
+    async def _webhook(self, agent: dict, body: dict, attempts: int = 3) -> tuple[str, str | None]:
         """POST the finding plus its run metadata to the agent's write-back webhook — the machine
         counterpart of the Slack post, for feeding findings into the customer's own automation.
 
         The body carries only what the customer may already read via the API: the finding, the
         run's shape (rounds, tool calls, duration), the model name and a hash of the prompt —
         never a key or token. Auth is an optional bearer token sent as a header; it is never
-        logged, and a delivery failing must never lose the finding (already stored)."""
+        logged, and a delivery failing must never lose the finding (already stored).
+
+        Returns (delivery, error) for the run: "ok"; "http <status>" for a client error, which
+        is not retried; "failed" with the last error after the retries."""
         url = agent["webhook_url"].strip()
         headers = {"content-type": "application/json"}
         token = (agent.get("webhook_token") or "").strip()
@@ -680,10 +724,10 @@ class AgentRunner:
                 try:
                     r = await cx.post(url, json=body, headers=headers)
                     if 200 <= r.status_code < 300:
-                        return
+                        return "ok", None
                     if r.status_code < 500:   # client error — won't self-heal, don't retry
                         print(f"[agent {agent['name']}] webhook: HTTP {r.status_code}")
-                        return
+                        return f"http {r.status_code}", r.text[:200]
                     err = f"HTTP {r.status_code}"
                 except Exception as e:        # transport failure — unreachable / timeout / DNS
                     err = f"{type(e).__name__}: {str(e)[:120]}"
@@ -691,6 +735,7 @@ class AgentRunner:
                     await asyncio.sleep(delay)
                     delay = min(delay * 2, 10)
         print(f"[agent {agent['name']}] webhook: giving up after {attempts} attempts ({err})")
+        return "failed", f"after {attempts} attempts: {err}"
 
     async def _slack_channel(self, agent_name: str, channel: str, trigger_name: str,
                              key: str, finding: str) -> None:

--- a/tares/config.py
+++ b/tares/config.py
@@ -131,6 +131,7 @@ class AgentCfg:
     slack_channel: str = ""   # workspace-bot channel id; wins over slack_webhook when both set
     webhook_url: str = ""     # write-back: findings + run metadata POSTed here
     webhook_token: str = ""   # optional bearer token for the write-back (a secret)
+    webhook_key_label: str = ""   # the write-back reports this label's value as `key`, else the entity
     mcp_servers: list = dc_field(default_factory=list)   # registry names this agent may use
     max_rounds: int | None = None   # model rounds per run; None = default for the agent's shape
     budget_usd: float | None = None  # lifetime spend cap in USD; None = no budget
@@ -238,6 +239,7 @@ def _agent_from_dict(a: dict, enabled: bool = False) -> AgentCfg:
         slack_channel=a.get("slack_channel") or "",
         webhook_url=a.get("webhook_url") or "",
         webhook_token=a.get("webhook_token") or "",
+        webhook_key_label=a.get("webhook_key_label") or "",
         mcp_servers=list(a.get("mcp_servers") or []),
         max_rounds=(int(a["max_rounds"]) if a.get("max_rounds") not in (None, "") else None),
         budget_usd=(float(a["budget_usd"]) if a.get("budget_usd") not in (None, "") else None),
@@ -368,7 +370,8 @@ def import_catalog_dict(store, raw: dict, engine=None) -> dict:
                                    (int(a["max_rounds"]) if a.get("max_rounds") not in (None, "")
                                     else None),
                                    (float(a["budget_usd"]) if a.get("budget_usd") not in (None, "")
-                                    else None))
+                                    else None),
+                                   webhook_key_label=a.get("webhook_key_label"))
         # enabled ⟺ a subscription to the trigger. Reflect the document's state so an enabled agent
         # round-trips: add the internal subscription if enabled, remove it if not.
         url = agent_url(a["name"])
@@ -493,6 +496,7 @@ def export_db_to_yaml(store, sources: list | None = None, include_secrets: bool 
          **({"model": a["model"]} if a.get("model") else {}),
          **({"slack_channel": a["slack_channel"]} if a.get("slack_channel") else {}),
          **({"webhook_url": a["webhook_url"]} if a.get("webhook_url") else {}),
+         **({"webhook_key_label": a["webhook_key_label"]} if a.get("webhook_key_label") else {}),
          **({"mcp_servers": a["mcp_servers"]} if a.get("mcp_servers") else {}),
          **({"max_rounds": a["max_rounds"]} if a.get("max_rounds") else {}),
          **({"budget_usd": a["budget_usd"]} if a.get("budget_usd") else {}),
@@ -789,6 +793,9 @@ def validate_agent_dict(a: dict, trigger_names: set, triggers: dict | None = Non
     wurl = str(a.get("webhook_url") or "").strip()
     if wurl and not wurl.startswith("https://") and not wurl.startswith("http://"):
         raise CatalogError(f"agent {a['name']!r}: webhook_url must be an http(s) URL")
+    wkl = str(a.get("webhook_key_label") or "").strip()
+    if wkl and not re.fullmatch(r"[A-Za-z0-9_.-]+", wkl):
+        raise CatalogError(f"agent {a['name']!r}: webhook_key_label must be a label name")
     servers = a.get("mcp_servers") or []
     if not isinstance(servers, list) or not all(isinstance(x, str) for x in servers):
         raise CatalogError(f"agent {a['name']!r}: mcp_servers must be a list of server names")

--- a/tares/daemon.py
+++ b/tares/daemon.py
@@ -303,6 +303,7 @@ class AgentIn(BaseModel):
     slack_channel: str = ""      # workspace-bot channel; the primary notification path
     webhook_url: str = ""        # write-back: findings + run metadata POSTed here
     webhook_token: str = ""      # optional bearer for the write-back (secret; blank-to-keep)
+    webhook_key_label: str = ""  # the write-back reports this label's value as `key`; "" = the entity
     slack_webhook_clear: bool = False   # blank means keep (it is a secret), so clearing is explicit
     mcp_servers: list[str] = []  # registry names this agent may use
     max_rounds: int | None = None   # model rounds per run; None = default (6, or 12 with MCP servers)
@@ -1724,6 +1725,7 @@ def make_app() -> FastAPI:
                          "slack_channel": a.get("slack_channel") or "",
                          "webhook_url": a.get("webhook_url") or "",
                          "webhook_token_configured": bool(a.get("webhook_token")),
+                         "webhook_key_label": a.get("webhook_key_label") or "",
                          "mcp_servers": a.get("mcp_servers") or [],
                          "max_rounds": a.get("max_rounds"),
                          "budget_usd": a.get("budget_usd"),
@@ -1749,7 +1751,8 @@ def make_app() -> FastAPI:
         store.upsert_catalog_agent(body.name, body.trigger, body.prompt, body.slack_webhook,
                                    body.model, body.slack_channel,
                                    body.webhook_url, body.webhook_token, body.mcp_servers,
-                                   body.max_rounds, body.budget_usd)
+                                   body.max_rounds, body.budget_usd,
+                                   webhook_key_label=body.webhook_key_label)
         runtime.reload_catalog()
         return {"ok": True, "enabled": False,
                 "note": "agents start disabled; enable it to run on the next firing"}
@@ -1774,7 +1777,7 @@ def make_app() -> FastAPI:
         store.upsert_catalog_agent(name, body.trigger, body.prompt, hook,
                                    body.model, body.slack_channel,
                                    body.webhook_url, wtoken, body.mcp_servers, body.max_rounds,
-                                   body.budget_usd)
+                                   body.budget_usd, webhook_key_label=body.webhook_key_label)
         store.mark_customized("agent", name)
         # if the trigger changed while enabled, re-point the subscription so the agent fires on the
         # new trigger (the subscription, not the definition, is what the dispatcher reads).

--- a/tares/projects/rius_rca.py
+++ b/tares/projects/rius_rca.py
@@ -140,6 +140,9 @@ class RiusRca(Template):
                  "prompt": p.get("prompt") or PROMPT,
                  "mcp_servers": [MCP],
                  "webhook_url": p["callback_url"], "webhook_token": p["callback_token"],
+                 # the entity is the service; the report is attributed by delivery id, so the
+                 # callback's `key` reports that label from the firing that woke the run
+                 "webhook_key_label": "delivery_id",
                  "max_rounds": p["max_rounds"], "enabled": True}
         if p.get("budget_usd") is not None:
             agent["budget_usd"] = p["budget_usd"]

--- a/tares/projects/rius_rca.py
+++ b/tares/projects/rius_rca.py
@@ -8,8 +8,11 @@ server and the write-back webhook POSTs the finding to Rius's callback, keyed by
 Every knob here is the hand-built configuration proven on a live cell on 2026-09-01 (TR-223
 comment: run_7a954505c5c7 and friends — 4/4 green against staging Rius), with the five traps from
 that session baked in:
-  1. the KEY is stamped at ingest by the source's PRIMARY LABEL (delivery_id) — never rely on
-     view.key_field for it (TR-226/TR-228);
+  1. the KEY is stamped at ingest by the source's PRIMARY LABEL, never by view.key_field
+     (TR-226/TR-228). The entity is the SERVICE (TR-285): a delivery id is new on every firing,
+     so a cooldown keyed by it never held and one noisy service woke the agent on every alert;
+     keyed by service, one investigation per service per 5 minutes, and the timeline the agent
+     reads is that service's history. The delivery id stays a label on every event;
   2. the prompt names the Rius tool chain and demands tool-grounded claims — it must not carry
      the demo agents' "no live access" language, which makes an MCP-equipped agent refuse to
      query;
@@ -111,21 +114,24 @@ class RiusRca(Template):
                 "config": {
                     "event_type": "alert_firing",
                     "text_template": TEXT_TEMPLATE,
-                    # The primary label stamps the stored key at ingest — the axis the trigger
-                    # cools down per, and the `key` the callback carries back to Rius.
+                    # The primary label stamps the stored key at ingest, the axis the trigger
+                    # cools down per and the `key` the callback carries back to Rius.
                     "labels": [
-                        {"name": "delivery_id", "field": "delivery_id", "primary": True},
-                        {"name": "service", "field": "service"},
+                        {"name": "service", "field": "service", "primary": True},
+                        {"name": "delivery_id", "field": "delivery_id"},
                         {"name": "workspace_id", "field": "workspace_id"},
                         {"name": "alert_id", "field": "alert_id"},
+                        {"name": "rule", "field": "rule"},
                     ],
                 }}),
             PlannedObject("view", "view", {
-                "name": VIEW, "key_field": "delivery_id", "sources": [SOURCE]}),
+                "name": VIEW, "key_field": "service", "sources": [SOURCE]}),
+            # one investigation per service per 5 minutes: a service that keeps alerting does
+            # not wake the agent again until the cooldown is over (TR-285)
             PlannedObject("trigger", "trigger", {
                 "name": TRIGGER, "view": VIEW,
                 "condition": {"aggregate": "count", "predicate": "> 0", "window": "5m"},
-                "cooldown": "30s"}),
+                "cooldown": "5m"}),
             PlannedObject("mcp_server", "mcp", {
                 "name": MCP, "url": p["mcp_url"], "auth_header": "Authorization",
                 "auth_value": f"Bearer {p['mcp_token']}"}),

--- a/tares/store.py
+++ b/tares/store.py
@@ -295,6 +295,13 @@ _MIGRATIONS = [
     "ALTER TABLE agent_runs ADD COLUMN IF NOT EXISTS cache_creation_input_tokens BIGINT",
     "ALTER TABLE agent_runs ADD COLUMN IF NOT EXISTS cache_read_input_tokens BIGINT",
     "ALTER TABLE agent_runs ADD COLUMN IF NOT EXISTS cost_usd DOUBLE",
+    # the write-back's outcome, so a run can say whether its finding reached the customer's
+    # endpoint: "ok", "http 4xx", "failed after 3 attempts: ...", NULL when no webhook
+    "ALTER TABLE agent_runs ADD COLUMN IF NOT EXISTS delivery TEXT",
+    "ALTER TABLE agent_runs ADD COLUMN IF NOT EXISTS delivery_error TEXT",
+    # the label whose value the write-back reports as `key` (TR-285: Rius attributes reports by
+    # delivery id while the entity, the cooldown axis, is the service)
+    "ALTER TABLE catalog_agents ADD COLUMN IF NOT EXISTS webhook_key_label TEXT",
     # Which key paid for a ledger row ("env:ANTHROPIC_API_KEY" | "console") — the boundary a
     # hosted trial's enforcement counts against. Rows from before attribution stay NULL (unknown).
     "ALTER TABLE model_usage ADD COLUMN IF NOT EXISTS key_source TEXT",
@@ -945,31 +952,36 @@ class Store:
                              webhook_token: str | None = None,
                              mcp_servers: list[str] | None = None,
                              max_rounds: int | None = None,
-                             budget_usd: float | None = None) -> None:
+                             budget_usd: float | None = None,
+                             webhook_key_label: str | None = None) -> None:
         ts = now_utc()
         with self._lock:
             self.con.execute(
                 "INSERT INTO catalog_agents "
                 "(name, trigger, prompt, slack_webhook, model, slack_channel, "
-                "webhook_url, webhook_token, mcp_servers, max_rounds, budget_usd, created_at, updated_at) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
+                "webhook_url, webhook_token, mcp_servers, max_rounds, budget_usd, "
+                "webhook_key_label, created_at, updated_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
                 "ON CONFLICT (name) DO UPDATE SET trigger = excluded.trigger, "
                 "prompt = excluded.prompt, slack_webhook = excluded.slack_webhook, "
                 "model = excluded.model, slack_channel = excluded.slack_channel, "
                 "webhook_url = excluded.webhook_url, webhook_token = excluded.webhook_token, "
                 "mcp_servers = excluded.mcp_servers, max_rounds = excluded.max_rounds, "
                 "budget_usd = excluded.budget_usd, "
+                "webhook_key_label = excluded.webhook_key_label, "
                 "updated_at = excluded.updated_at",
                 [name, trigger, prompt, slack_webhook or "", model or "",
                  slack_channel or "", webhook_url or "", webhook_token or "",
-                 json.dumps(mcp_servers or []), max_rounds, budget_usd, ts, ts],
+                 json.dumps(mcp_servers or []), max_rounds, budget_usd,
+                 webhook_key_label or "", ts, ts],
             )
 
     def list_catalog_agents(self) -> list[dict]:
         with self._lock:
             rows = self.con.execute(
                 "SELECT name, trigger, prompt, slack_webhook, model, slack_channel, "
-                "webhook_url, webhook_token, mcp_servers, updated_at, max_rounds, budget_usd, owned_by, customized "
+                "webhook_url, webhook_token, mcp_servers, updated_at, max_rounds, budget_usd, owned_by, customized, "
+                "webhook_key_label "
                 "FROM catalog_agents ORDER BY name"
             ).fetchall()
         return [
@@ -977,7 +989,8 @@ class Store:
              "model": r[4] or "", "slack_channel": r[5] or "",
              "webhook_url": r[6] or "", "webhook_token": r[7] or "",
              "mcp_servers": json.loads(r[8]) if r[8] else [], "updated_at": r[9],
-             "max_rounds": r[10], "budget_usd": r[11], "owned_by": r[12], "customized": bool(r[13])}
+             "max_rounds": r[10], "budget_usd": r[11], "owned_by": r[12], "customized": bool(r[13]),
+             "webhook_key_label": r[14] or ""}
             for r in rows
         ]
 
@@ -1045,7 +1058,7 @@ class Store:
         sql = ("SELECT id, agent, trigger, dispatch_id, key_value, status, rounds, tool_calls, "
                "started_at, duration_ms, finding, error, external_tools, max_rounds, "
                "model, input_tokens, output_tokens, cache_creation_input_tokens, "
-               "cache_read_input_tokens, cost_usd "
+               "cache_read_input_tokens, cost_usd, delivery, delivery_error "
                "FROM agent_runs ")
         where, params = [], []
         if agent:
@@ -1067,9 +1080,16 @@ class Store:
              "external_tools": json.loads(r[12]) if r[12] else [], "max_rounds": r[13],
              "model": r[14], "input_tokens": r[15], "output_tokens": r[16],
              "cache_creation_input_tokens": r[17], "cache_read_input_tokens": r[18],
-             "cost_usd": r[19]}
+             "cost_usd": r[19], "delivery": r[20], "delivery_error": r[21]}
             for r in rows
         ]
+
+    def set_run_delivery(self, run_id: str, delivery: str, error: str | None = None) -> None:
+        """The write-back's outcome for a run, recorded after the finding is stored: a failed
+        delivery never loses the finding, it only marks the run."""
+        with self._lock:
+            self.con.execute("UPDATE agent_runs SET delivery = ?, delivery_error = ? WHERE id = ?",
+                             [delivery, error, run_id])
 
     def agent_stats(self) -> dict[str, dict]:
         """Per-agent lifetime aggregates for the console, one grouped query. `finished` excludes

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -39,6 +39,19 @@ FINDING = "checkout is returning 500s since the 14:02 deploy; roll it back."
 # ── stub Anthropic: one tool_use round, then the conclusion ──────────────────
 _calls = []
 _headers = []   # the request headers per call: which credential reached the wire
+_hooks = []     # write-back bodies received by the fake customer endpoint
+
+
+class Hook(BaseHTTPRequestHandler):
+    """The customer's write-back endpoint: records the body; a path of /reject answers 401."""
+    def do_POST(self):
+        body = json.loads(self.rfile.read(int(self.headers["content-length"])))
+        _hooks.append((self.path, body))
+        status = 401 if self.path == "/reject" else 200
+        self.send_response(status); self.send_header("content-length", "0"); self.end_headers()
+
+    def log_message(self, *a):
+        pass
 
 
 class Stub(BaseHTTPRequestHandler):
@@ -92,6 +105,9 @@ async def main():
 
     stub = HTTPServer(("127.0.0.1", int(STUB_PORT)), Stub)
     threading.Thread(target=stub.serve_forever, daemon=True).start()
+    hook = HTTPServer(("127.0.0.1", 0), Hook)
+    threading.Thread(target=hook.serve_forever, daemon=True).start()
+    HOOK = f"http://127.0.0.1:{hook.server_port}"
 
     env = {**os.environ, "TARES_DB": DB, "TARES_CATALOG": SEED, "TARES_PORT": PORT,
            "TARES_OTLP_GRPC_PORT": "off", "ANTHROPIC_API_KEY": "sk-test","ANTHROPIC_AUTH_TOKEN": "test_token",
@@ -230,6 +246,24 @@ async def main():
             ck("finding is on the entity's timeline", FINDING in rd["payload"], rd["payload"][:200])
             ck("findings source contributes to the read", "findings" in rd["sources"], str(rd["sources"]))
 
+            # ── the write-back reports a label as `key` and records its delivery (TR-285) ──
+            r = await cx.put(f"{B}/api/sources/evt", json={"name": "evt", "connector": "webhook", "poll": "5s", "config": {
+                "labels": [{"name": "service", "field": "service", "primary": True},
+                           {"name": "msg", "field": "msg"}]}})
+            ck("source gains a msg label", r.status_code == 200, r.text[:200])
+            r = await cx.put(f"{B}/api/agents/builtin/first-look", json={
+                "name": "first-look", "trigger": "incident", "prompt": "Take a first look.",
+                "webhook_url": f"{HOOK}/findings", "webhook_key_label": "msg"})
+            ck("write-back with a key label saved", r.status_code == 200, r.text[:200])
+            ag = next(a for a in (await cx.get(f"{B}/api/agents/builtin")).json()["agents"] if a["name"] == "first-look")
+            ck("key label reported by the API", ag.get("webhook_key_label") == "msg", str(ag.get("webhook_key_label")))
+            r = await cx.put(f"{B}/api/agents/builtin/first-look", json={
+                "name": "first-look", "trigger": "incident", "prompt": "x", "webhook_url": f"{HOOK}/findings", "webhook_key_label": "not a label!"})
+            ck("key label must be a label name", r.status_code == 400, r.text[:120])
+            r = await cx.put(f"{B}/api/agents/builtin/first-look", json={
+                "name": "first-look", "trigger": "incident", "prompt": "Take a first look.",
+                "webhook_url": f"{HOOK}/findings", "webhook_key_label": "msg"})
+
             # ── a gateway saved in Settings (TR-281): URL and token, per request, over the env ──
             g = (await cx.get(f"{B}/api/settings/gateway")).json()
             ck("gateway status: the env base URL shows as such", g["configured"] and g["source"] == "env:TARES_ANTHROPIC_BASE"
@@ -252,6 +286,19 @@ async def main():
                 rs = (await cx.get(f"{B}/api/agents/builtin/first-look/runs")).json()
                 return len(rs) >= 2 and rs[0]["status"] != "running"
             ck("a second run completed", await _until(_ran_again), "no second run")
+            # the write-back is posted after the run is marked ok; wait for its record
+            async def _delivered_run():
+                rs = (await cx.get(f"{B}/api/agents/builtin/first-look/runs")).json()
+                return bool(rs) and rs[0].get("delivery") is not None
+            ck("write-back delivered", await _until(_delivered_run), "no delivery recorded")
+            hooks_now = [h for h in _hooks if h[0] == "/findings"]
+            hb = hooks_now[-1][1] if hooks_now else {}
+            ck("write-back key is the label's value on the latest firing event",
+               hb.get("key", "").startswith("500 again"), str(hb.get("key")))
+            ck("write-back still carries the finding and the entity's trigger",
+               hb.get("finding") == FINDING and hb.get("trigger") == "incident", str(hb)[:200])
+            rs = (await cx.get(f"{B}/api/agents/builtin/first-look/runs")).json()
+            ck("run records the delivery", rs and rs[0].get("delivery") == "ok", str(rs[:1])[:200])
             ck("the run reached the gateway with the bearer token",
                len(_headers) > headers_before and _headers[-1].get("authorization") == "Bearer gw-tok"
                and "x-api-key" not in _headers[-1], str(_headers[-1:]))

--- a/tests/test_rius_rca.py
+++ b/tests/test_rius_rca.py
@@ -110,6 +110,7 @@ async def main():
             check("callback wired", ag["webhook_url"] == PARAMS["callback_url"]
                   and ag["webhook_token_configured"] is True, str(ag.get("webhook_url")))
             check("mcp server attached", ag["mcp_servers"] == ["rius"], str(ag.get("mcp_servers")))
+            check("callback reports the delivery id as key", ag.get("webhook_key_label") == "delivery_id", str(ag.get("webhook_key_label")))
             check("prompt allows live access", "live access" in ag["prompt"]
                   and "no live access" not in ag["prompt"])
             mcp = {m["name"]: m for m in

--- a/tests/test_rius_rca.py
+++ b/tests/test_rius_rca.py
@@ -3,11 +3,12 @@
 Run: .venv/bin/python tests/test_rius_rca.py   (no external services needed)
 
 Asserts the five traps from the live hand-build (TR-223 comment) stay fixed: the ingest key is
-stamped by the source's primary label, the agent is born enabled with max_rounds 10 and the
+stamped by the source's primary label (the service), the agent is born enabled with max_rounds 10 and the
 callback configured, the text template carries the query identifiers, and the prompt permits
 live MCP access.
 """
 import asyncio
+import json
 import os
 import sys
 
@@ -88,8 +89,15 @@ async def main():
             srcs = {s["name"]: s for s in (await cx.get("/api/sources")).json()}
             src = srcs.get("rius_alerts") or {}
             labels = {l["name"]: l for l in (src.get("config") or {}).get("labels", [])}
-            check("primary label stamps the key",
-                  labels.get("delivery_id", {}).get("primary") is True, str(labels))
+            check("the service is the entity (primary label)",
+                  labels.get("service", {}).get("primary") is True
+                  and labels.get("delivery_id", {}).get("primary") is not True, str(labels))
+            check("rule and delivery id are labels", "rule" in labels and "delivery_id" in labels, str(labels))
+            views = {v["name"]: v for v in (await cx.get("/api/views")).json()}
+            check("view keyed by service", views.get("rius_alerts_view", {}).get("key_field") == "service",
+                  str(views.get("rius_alerts_view")))
+            trig = {t["name"]: t for t in (await cx.get("/api/triggers")).json()}.get("rius_alert_fired", {})
+            check("one investigation per service per 5 minutes", trig.get("cooldown") == "5m", str(trig))
             tmpl = (src.get("config") or {}).get("text_template", "")
             check("text template carries the query identifiers",
                   all(k in tmpl for k in ("{delivery_id}", "{workspace_id}", "{service}",
@@ -110,7 +118,7 @@ async def main():
                   mcp["auth_value_configured"] is True and not mcp.get("auth_value"),
                   str(mcp)[:200])
 
-            print("== ingest stamps the delivery id as the key ==")
+            print("== ingest stamps the service as the key ==")
             body = {"delivery_id": "dlv-test-001", "alert_id": "al-1", "workspace_id": "ws-1",
                     "service": "canary-raw", "rule": "error rate > 25%",
                     "summary": "error rate 48% over 24h",
@@ -118,8 +126,11 @@ async def main():
             r = await cx.post(f"/ingest/{src['ingest_key']}", json=body)
             check("alert ingests -> 202", r.status_code == 202, r.text)
             ev = (await cx.get("/api/sources/rius_alerts/events", params={"limit": 1})).json()
-            check("stored key is the delivery id", ev and ev[0]["key"] == "dlv-test-001",
-                  str(ev)[:200])
+            check("stored key is the service", ev and ev[0]["key"] == "canary-raw", str(ev)[:200])
+            ents = (await cx.get("/api/entities", params={"label": "rule"})).json()
+            check("rule is a label on the event", "error rate > 25%" in json.dumps(ents), str(ents)[:200])
+            ents = (await cx.get("/api/entities", params={"label": "delivery_id"})).json()
+            check("delivery id is a label on the event", "dlv-test-001" in json.dumps(ents), str(ents)[:200])
             check("rendered line carries identifiers", ev and "dlv-test-001" in ev[0]["text"]
                   and "canary-raw" in ev[0]["text"], str(ev and ev[0]["text"]))
 

--- a/ui/src/components/AgentForm.tsx
+++ b/ui/src/components/AgentForm.tsx
@@ -85,6 +85,7 @@ export default function AgentForm({ initial, prefill, deliveryKind, presetTrigge
   const [slack, setSlack] = useState("");
   const [writebackOn, setWritebackOn] = useState(!!initial?.webhook_url || deliveryKind === "webhook");
   const [webhookUrl, setWebhookUrl] = useState(initial?.webhook_url ?? "");
+  const [webhookKeyLabel, setWebhookKeyLabel] = useState(initial?.webhook_key_label ?? "");
   const [webhookToken, setWebhookToken] = useState("");
   const [mcpSel, setMcpSel] = useState<string[]>(initial?.mcp_servers ?? []);
   // "" = default (6 rounds, or 12 once the agent uses external MCP servers).
@@ -136,6 +137,7 @@ export default function AgentForm({ initial, prefill, deliveryKind, presetTrigge
       slack_webhook_clear: !hookOn,
       webhook_url: writebackOn ? webhookUrl.trim() : "",
       webhook_token: writebackOn ? webhookToken.trim() : "",
+      webhook_key_label: writebackOn ? webhookKeyLabel.trim() : "",
       mcp_servers: mcpSel,
       max_rounds: maxRounds.trim() ? Number(maxRounds) : null,
       budget_usd: budget.trim() ? Number(budget) : null,
@@ -274,6 +276,16 @@ export default function AgentForm({ initial, prefill, deliveryKind, presetTrigge
           <span className="help">
             finding + run metadata as JSON; the token is sent as a bearer header
           </span>
+          <label className="field" style={{ marginTop: 8 }}>
+            <span className="lbl">report as key</span>
+            <input type="text" className="mono" placeholder="the entity (default)"
+                   value={webhookKeyLabel} onChange={(e) => setWebhookKeyLabel(e.target.value)} />
+            <span className="help">
+              a label name; the POST's <span className="mono">key</span> becomes that label's value on
+              the firing that woke the run, for a system that files reports by its own id. Empty
+              reports the entity.
+            </span>
+          </label>
         </OptionRow>
       </div>
 

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -26,6 +26,13 @@ function statusBadge(r: AgentRun) {
   return <span className={`badge ${cls}`}>{r.status}</span>;
 }
 
+/** Whether the finding reached the write-back webhook; nothing when the agent has none. */
+function deliveryBadge(r: AgentRun) {
+  if (!r.delivery) return null;
+  if (r.delivery === "ok") return <span className="badge ok" title="the finding was delivered to the write-back webhook">delivered</span>;
+  return <span className="badge error" title={r.delivery_error ?? r.delivery}>not delivered: {r.delivery}</span>;
+}
+
 export default function AgentDetail() {
   // A dispatch page links here as ?dispatch=<id> (and a project as ?run=<id>): the Runs tab
   // opens with that run expanded, highlighted, and scrolled into view.
@@ -409,7 +416,7 @@ function RunRow({ r, open, focused, onToggle }: {
       <tr className="clickable" onClick={onToggle}
           style={focused ? { outline: "2px solid var(--accent)", outlineOffset: -2 } : undefined}
           ref={rowRef}>
-        <td>{statusBadge(r)}</td>
+        <td>{statusBadge(r)} {deliveryBadge(r)}</td>
         <td style={{ whiteSpace: "nowrap" }}><TimeAgo ts={r.started_at} /></td>
         <td className="mono">{r.key}</td>
         <td className="mono">{r.model ?? <span className="dim">—</span>}</td>
@@ -435,6 +442,7 @@ function RunRow({ r, open, focused, onToggle }: {
                   ? <><Link to={`/dispatches/${encodeURIComponent(r.dispatch_id)}`}>the firing</Link> that woke it</>
                   : "run without a firing (manual or bootstrap)"}
                 {r.tool_calls ? <> · {r.tool_calls} tool call{r.tool_calls === 1 ? "" : "s"}</> : null}
+                {r.delivery && r.delivery !== "ok" && <> · write-back {r.delivery}{r.delivery_error ? <>: <span className="mono">{r.delivery_error}</span></> : null}</>}
                 {cache > 0 && <> · cache: {fmtTokens(r.cache_creation_input_tokens)} written, {fmtTokens(r.cache_read_input_tokens)} read</>}
               </p>
               {(r.external_tools ?? []).length > 0 && (

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -245,6 +245,7 @@ export interface BuiltinAgent {
   model: string;               // "" = the instance default
   slack_channel: string;       // workspace-bot channel id, "" = none
   webhook_url: string;         // write-back target, "" = none
+  webhook_key_label?: string;  // the write-back reports this label's value as `key`; "" = the entity
   webhook_token_configured: boolean;   // the token itself is never sent to the client
   mcp_servers: string[];       // registry names this agent may use
   max_rounds: number | null;   // model rounds per run; null = the default for its shape
@@ -292,6 +293,9 @@ export interface AgentRun {
   cache_creation_input_tokens?: number | null;
   cache_read_input_tokens?: number | null;
   cost_usd?: number | null;
+  // the write-back's outcome: "ok", "http 4xx", "failed"; null when the agent has no webhook
+  delivery?: string | null;
+  delivery_error?: string | null;
 }
 
 // The cell's Anthropic spend meter (/api/usage/model): all-time totals plus a per-day tail,


### PR DESCRIPTION
Linear TR-285.

**Template.** `rius_rca` now plans what the Rius test cell carried by hand: `service` is the primary label, so the entity and the cooldown axis; `delivery_id` stays a label on every event; `rule` is a new label; the trigger's cooldown is 5 minutes, one investigation per service per five minutes instead of one per alert. (The view's key_field is set to service too, which changes nothing; that field is the subject of the views and triggers project.)

**Write-back key.** With the entity now the service, the callback's `key` would have been the service name and Rius could not attribute the report. Agents gain an optional `webhook_key_label`: when set, the POST's `key` is that label's value on the latest firing that woke the run; empty keeps the entity; a label missing on the event falls back to the entity. The template sets it to `delivery_id`, so Rius receives the same body as before. On the form: "report as key" under the write-back option. Round-trips through YAML.

**Delivery status.** The write-back's outcome used to go only to the daemon log. Each run now records it (`ok`, `http 4xx`, or `failed` with the last error after the retries), the run API returns it, and the agent page shows "delivered" or "not delivered: ..." beside the run status, with the reason on hover and in the expanded row.

**Tests.** `tests/test_rius_rca.py` asserts the new template shape (29 checks). `tests/test_agents.py` gains a fake customer endpoint: the saved key label reaches the POST as `key`, a bad label name is refused, the run records its delivery (91 checks). Catalog sync, projects, Slack, CLI and cascade tests pass; console typechecks.

**After merge, on the Rius test cell:** the hand-edited project's agent has no `webhook_key_label`; set it to `delivery_id` on the agent's form, or recreate the project from the template.