### PR TITLE
Project page: fold the agent configuration, filter the firings

### DIFF
--- a/ui/src/pages/ProjectShell.tsx
+++ b/ui/src/pages/ProjectShell.tsx
@@ -829,6 +829,9 @@ function AgentSection({ name, focusDispatch, triggerInProject, onShowTrigger }: 
 }) {
   const [openRun, setOpenRun] = useState<string>();
   const [editing, setEditing] = useState(false);
+  // The configuration is folded by default: on a project page the runs are what changes and
+  // what a person came to see; the prompt alone pushed them below the fold (TR-286).
+  const [configOpen, setConfigOpen] = useState(false);
   const { data, error, reload } = usePolling(() => api.builtinAgents(), 10000);
   const { data: runs } = usePolling(() => api.builtinAgentRuns(name, 1), 10000);   // the latest, for the overview row
   const [err, setErr] = useState<string>();
@@ -868,7 +871,20 @@ function AgentSection({ name, focusDispatch, triggerInProject, onShowTrigger }: 
                    onSaved={() => { setEditing(false); reload(); }}
                    onCancel={() => setEditing(false)} />
       ) : (
-        <div className="panel" style={{ marginBottom: 12 }}>
+        <div className="opt-row" style={{ marginBottom: 12 }}>
+          <button type="button" className="opt-head" onClick={() => setConfigOpen((o) => !o)}>
+            <span className="opt-caret">{configOpen ? "▾" : "▸"}</span>
+            <span>
+              <span className="opt-title">Configuration</span>
+              <span className="opt-desc help">
+                wakes on <span className="mono">{agent.trigger}</span>
+                {" · "}{agent.model ? <span className="mono">{agent.model}</span> : "instance default model"}
+                {lastRun ? <> · last woken <TimeAgo ts={lastRun.started_at} /> for <span className="mono">{lastRun.key}</span></> : " · never woken"}
+              </span>
+            </span>
+            {agent.enabled ? <span className="badge ok">enabled</span> : <span className="badge">disabled</span>}
+          </button>
+          {configOpen && <div className="opt-body" style={{ paddingLeft: 12 }}>
           <table>
             <tbody>
               <tr><td className="help" style={{ width: 150 }}>status</td>
@@ -905,6 +921,7 @@ function AgentSection({ name, focusDispatch, triggerInProject, onShowTrigger }: 
                   <td><pre className="mono" style={{ whiteSpace: "pre-wrap", margin: 0, maxHeight: 180, overflow: "auto" }}>{agent.prompt}</pre></td></tr>
             </tbody>
           </table>
+          </div>}
         </div>
       )}
       <h3 style={{ margin: "12px 0 6px" }}>Runs</h3>

--- a/ui/src/pages/ProjectShell.tsx
+++ b/ui/src/pages/ProjectShell.tsx
@@ -96,7 +96,21 @@ export default function ProjectShell({ s, id, reload, template }: {
   const myViews = (views ?? []).filter((x) => names("view").includes(x.name));
   const myTriggers = (triggers ?? []).filter((x) => names("trigger").includes(x.name));
   const triggerNames = new Set(myTriggers.map((t) => t.name));
-  const firings = (dispatches ?? []).filter((d) => triggerNames.has(d.trigger));
+  const allFirings = (dispatches ?? []).filter((d) => triggerNames.has(d.trigger));
+  // Filters on the Firings tab (TR-284): outcome, trigger, entity. Client-side over the loaded
+  // page; the pickers offer what is actually in the list, so an empty result means "none of
+  // these", never a typo.
+  const [firingStatus, setFiringStatus] = useState<"" | "delivered" | "failed" | "nobody">("");
+  const [firingTrigger, setFiringTrigger] = useState("");
+  const [firingEntity, setFiringEntity] = useState("");
+  const outcome = (d: typeof allFirings[number]) =>
+    d.subscribers === 0 ? "nobody" : d.delivered < d.subscribers ? "failed" : "delivered";
+  const firingEntities = [...new Set(allFirings.map((d) => d.key))].sort();
+  const firings = allFirings.filter((d) =>
+    (!firingStatus || outcome(d) === firingStatus)
+    && (!firingTrigger || d.trigger === firingTrigger)
+    && (!firingEntity || d.key === firingEntity));
+  const firingsFiltered = !!(firingStatus || firingTrigger || firingEntity);
   // Consecutive firings of the same trigger that reached nobody collapse into one row: dozens of
   // identical "0 of 0" lines say one thing — nobody is subscribed — so say it once, with a count.
   const firingRows: (typeof firings[number] & { repeats?: number })[] = [];
@@ -527,6 +541,27 @@ export default function ProjectShell({ s, id, reload, template }: {
       {tab === "firings" && (
         <>
           {dispatchesError && <ErrorState error={dispatchesError} what="the firings" />}
+          {allFirings.length > 0 && (
+            <div className="btnrow" style={{ marginBottom: 10 }}>
+              <Picker value={firingStatus} ariaLabel="outcome" style={{ width: 190 }}
+                      options={["", "delivered", "failed", "nobody"]}
+                      labels={{ "": "all outcomes", delivered: "delivered", failed: "not fully delivered", nobody: "nobody subscribed" }}
+                      onChange={(v) => setFiringStatus(v as typeof firingStatus)} />
+              <Picker value={firingTrigger} ariaLabel="trigger" style={{ width: 220 }}
+                      options={["", ...myTriggers.map((t) => t.name)]}
+                      labels={{ "": "all triggers", ...Object.fromEntries(myTriggers.map((t) => [t.name, t.name])) }}
+                      onChange={setFiringTrigger} />
+              <Picker value={firingEntity} ariaLabel="entity" style={{ width: 220 }}
+                      options={["", ...firingEntities]}
+                      labels={{ "": "all entities", ...Object.fromEntries(firingEntities.map((k) => [k, k])) }}
+                      onChange={setFiringEntity} />
+              {firingsFiltered && (
+                <span className="help">{firings.length} of {allFirings.length}{" "}
+                  <button type="button" className="linklike" onClick={() => { setFiringStatus(""); setFiringTrigger(""); setFiringEntity(""); }}>clear</button>
+                </span>
+              )}
+            </div>
+          )}
           {firings.length ? (
             <table>
               <thead><tr><th>when</th><th>trigger</th><th>entity</th><th>delivered to</th></tr></thead>
@@ -563,7 +598,9 @@ export default function ProjectShell({ s, id, reload, template }: {
                 })}
               </tbody>
             </table>
-          ) : !dispatchesError && <div className="empty">no firings yet across this project's triggers</div>}
+          ) : !dispatchesError && (
+            <div className="empty">{firingsFiltered ? "no firings match these filters" : "no firings yet across this project's triggers"}</div>
+          )}
         </>
       )}
 


### PR DESCRIPTION
Linear TR-286 and TR-284, both on the project page.

**Agents tab (TR-286).** An agent's configuration is one folded row: "Configuration", the trigger it wakes on, the model, when it was last woken and for which entity, the enabled badge on the right. Click to open the full table with the prompt. The Runs list sits directly under it, so it is the first thing on screen; the prompt alone used to push it below the fold. The agent's own page is unchanged, its tabs already separate runs from configuration.

**Firings tab (TR-284).** Three pickers above the table: outcome (delivered, not fully delivered, nobody subscribed), trigger (the project's), entity (those seen in the loaded firings). They combine; a count with a clear link shows when any is set; an empty result says "no firings match these filters". Client-side over the loaded page, the latest hundred, as the tab showed before.

Console typechecks and builds; checked on a local instance.