### PR TITLE
Storage: measure against the volume when no limit is set; pause ingest at 95% instead of filling the disk

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,8 @@ Every knob is a `TARES_*` variable read at start. The ones you will meet most:
 | `ANTHROPIC_AUTH_TOKEN` | a bearer token instead of the key, for a gateway that wants `Authorization: Bearer`; beats the key when both are set |
 | `ANTHROPIC_BASE_URL` | an Anthropic-compatible gateway (LiteLLM, Portkey, a Bedrock or Vertex proxy) instead of api.anthropic.com; `TARES_ANTHROPIC_BASE` is the old name, still read |
 | `TARES_AGENT_MODEL` | model for Tares agents |
-| `TARES_MAX_DB_SIZE` | cap on the DuckDB file; `/api/usage` reports against it |
+| `TARES_MAX_DB_SIZE` | storage limit `/api/usage` and `/health` measure against; unset = the volume the database sits on |
+| `TARES_INGEST_PAUSE_PCT` | share of the limit at which ingest is refused (507) and polls pause; default 95 |
 | `TARES_SLACK_BOT_TOKEN`, `TARES_SLACK_SIGNING_SECRET` | the Slack surface |
 | `TARES_SEED_PROJECT` | template of the project to seed on first boot (`TARES_SEED_USECASE` still read) |
 | `TARES_TRACING_ENABLED` | agent tracing on/off (a console setting wins over it) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,27 @@
 Notable changes to Tares (formerly NavFlow). Format follows [Keep a Changelog](https://keepachangelog.com/);
 the project follows [Semantic Versioning](https://semver.org/).
 
+## [1.29.0] - 2026-09-08
+
+### Added
+- Storage is measured against the volume the database sits on when no `TARES_MAX_DB_SIZE` is
+  set, so a grown volume shows on the next mount with nothing to refresh; `/api/usage` says
+  which (`max_bytes_source`). At 95% of the limit (`TARES_INGEST_PAUSE_PCT`) ingest is refused
+  with 507 and poll connectors wait, with the reason on the source's health, `/health` and the
+  Overview, instead of the database filling its disk and dying. Reads, agents and the console
+  keep working; ingest resumes on its own once there is room.
+- A run records whether its finding reached the write-back webhook: delivered, an HTTP status,
+  or failed with the last error after the retries. The agent page shows it beside the run.
+- Agents can report a label's value as the write-back's `key` (`webhook_key_label`, "report as
+  key" on the form) instead of the entity, for a system that files reports by its own id.
+- Project page: the Firings tab filters by outcome, trigger and entity.
+
+### Changed
+- The `rius_rca` template keys by service: `service` is the primary label, `delivery_id` and
+  the new `rule` are labels, the trigger cools down for 5 minutes per service, and the callback
+  reports the delivery id as `key` through `webhook_key_label`.
+- Project page: an agent's configuration is one folded row, so its runs are in view.
+
 ## [1.28.0] - 2026-09-08
 
 ### Added

--- a/tares/daemon.py
+++ b/tares/daemon.py
@@ -149,7 +149,12 @@ def _parse_size(v: str | None) -> int | None:
     return n if n > 0 else None
 
 
+# The operator's explicit limit; None means "the volume the data directory sits on", which is
+# what a cell wants: a grown volume is reflected on the next mount, no chart value to refresh.
 MAX_DB_SIZE = _parse_size(os.getenv("TARES_MAX_DB_SIZE"))
+# Above this share of the limit ingest is refused (507) and polls pause, so the database never
+# fills its disk and dies (glassflow-web, 2026-09-08). Reads, findings and the console keep working.
+INGEST_PAUSE_PCT = float(os.getenv("TARES_INGEST_PAUSE_PCT", "95"))
 
 
 def _ui_dist() -> Path:
@@ -167,9 +172,38 @@ def _ui_dist() -> Path:
 
 UI_DIST = _ui_dist()
 
-# /health reports `degraded` at or above this share of TARES_MAX_DB_SIZE. On the 0-100 scale of
-# /api/usage's pct_used, so 90 means 90% — not 0.9. Unknown (no limit configured) is never degraded.
+# /health reports `degraded` at or above this share of the storage limit. On the 0-100 scale of
+# /api/usage's pct_used, so 90 means 90% — not 0.9. Unknown (no limit and no volume) is never degraded.
 DEGRADED_PCT = float(os.getenv("TARES_DEGRADED_PCT", "90"))
+
+
+def storage_limit(db_path: str) -> tuple[int | None, str]:
+    """(max_bytes, where it comes from): TARES_MAX_DB_SIZE when set ("env"), else the total size
+    of the volume the database sits on ("volume"). None only when neither is known."""
+    if MAX_DB_SIZE:
+        return MAX_DB_SIZE, "env"
+    try:
+        return shutil.disk_usage(os.path.dirname(os.path.abspath(db_path)) or ".").total, "volume"
+    except OSError:
+        return None, ""
+
+
+def storage_state(store, db_path: str) -> dict:
+    """How full this instance is against its limit, and whether ingest is paused because of it.
+    stat() calls only, so every probe and every ingest can afford it."""
+    limit, origin = storage_limit(db_path)
+    if not limit:
+        return {"max_bytes": None, "max_bytes_source": "", "pct_used": None, "paused": False, "detail": None}
+    pct = round(100 * store.disk_bytes() / limit, 2)
+    paused = pct >= INGEST_PAUSE_PCT
+    detail = None
+    if paused:
+        detail = (f"ingest paused: storage {pct}% full of the {limit} byte "
+                  f"{'limit' if origin == 'env' else 'volume'}; grow the volume or delete data")
+    elif pct >= DEGRADED_PCT:
+        detail = f"storage {pct}% full ({limit} byte {'limit' if origin == 'env' else 'volume'})"
+    return {"max_bytes": limit, "max_bytes_source": origin, "pct_used": pct, "paused": paused,
+            "detail": detail}
 
 # How long a `/tares ask` may think before Slack gets an apology instead of an answer. The user
 # is staring at a "…" in a channel, so this is deliberately much shorter than the agent's own
@@ -432,6 +466,8 @@ def make_app() -> FastAPI:
 
     dispatcher = Dispatcher(store)
     runtime = Runtime(store, dispatcher)
+    # poll connectors hold off while ingest is paused for storage (see storage_state)
+    runtime.storage_full = lambda: storage_state(store, DB_PATH)["detail"] if storage_state(store, DB_PATH)["paused"] else None
     # Projects: templates instantiated with params; they create and own ordinary catalog objects.
     projects = ProjectEngine(store, reload=runtime.reload_catalog, runtime=runtime)
     # Tares agents are the second kind of subscriber to a firing (the first is an external agent's
@@ -575,11 +611,11 @@ def make_app() -> FastAPI:
             store.ping()
         except Exception as e:
             status, detail = "down", f"database unavailable: {e}"
-        if status == "ok" and MAX_DB_SIZE:
-            pct = round(100 * store.disk_bytes() / MAX_DB_SIZE, 2)
-            if pct >= DEGRADED_PCT:
-                status = "degraded"
-                detail = f"storage {pct}% full ({MAX_DB_SIZE} byte limit)"
+        if status == "ok":
+            st = storage_state(store, DB_PATH)
+            pct = st["pct_used"]
+            if st["detail"]:
+                status, detail = "degraded", st["detail"]
         body = {"status": status, "auth_required": bool(AUTH_TOKEN),
                 "sources": [] if AUTH_TOKEN else list(runtime.catalog.sources),
                 "pct_used": pct, "version": _installed_version(),
@@ -858,8 +894,16 @@ def make_app() -> FastAPI:
         # Vercel (and similar) probe the endpoint before saving a drain — answer with the verify header.
         return JSONResponse({"ok": True}, headers=_verify_headers(request))
 
+    def _refuse_if_full() -> None:
+        """507 Insufficient Storage when the store is at the pause mark: the producer gets a plain
+        reason and can retry later; the database keeps working for everything else."""
+        st = storage_state(store, DB_PATH)
+        if st["paused"]:
+            raise HTTPException(status_code=507, detail=st["detail"])
+
     @app.post("/ingest/{token}", status_code=202)
     async def ingest(token: str, request: Request):
+        _refuse_if_full()
         body = await _parse_ingest_body(request)
         try:
             n = await runtime.ingest(token, body)
@@ -901,6 +945,7 @@ def make_app() -> FastAPI:
             _err(e)
 
     async def _otlp(signal: str, request: Request):
+        _refuse_if_full()
         try:
             body = await request.json()
         except Exception:
@@ -2454,8 +2499,9 @@ def make_app() -> FastAPI:
     @app.get("/api/usage")
     async def usage():
         """What this instance is using: db + WAL bytes, the volume they sit on, and event counts.
-        `max_bytes` is what the operator says this instance may grow to (TARES_MAX_DB_SIZE — a
-        hosted cell gets its PVC size); unset -> null, and nothing is enforced here either way.
+        `max_bytes` is the operator's TARES_MAX_DB_SIZE, else the volume the database sits on
+        (`max_bytes_source` says which); null only when neither is known. At INGEST_PAUSE_PCT of it
+        ingest is refused and polls pause (`ingest_paused`), so the disk never fills.
         `pct_used` is (db + wal) over max_bytes on a 0-100 scale, NOT a 0-1 fraction — so a
         "warn at 80%" consumer compares against 80, not 0.8. Null whenever max_bytes is null.
         Cheap by construction: file stats plus the maintained per-source counters, no table scan,
@@ -2466,10 +2512,10 @@ def make_app() -> FastAPI:
             disk_total, disk_free = du.total, du.free
         except OSError:
             disk_total = disk_free = None
-        used = u["db_bytes"] + u["wal_bytes"]
+        st = storage_state(store, DB_PATH)
         return {**u, "disk_total": disk_total, "disk_free": disk_free,
-                "max_bytes": MAX_DB_SIZE,
-                "pct_used": round(100 * used / MAX_DB_SIZE, 2) if MAX_DB_SIZE else None}
+                "max_bytes": st["max_bytes"], "max_bytes_source": st["max_bytes_source"],
+                "pct_used": st["pct_used"], "ingest_paused": st["paused"]}
 
     @app.get("/api/usage/model")
     async def usage_model(days: int = 30):

--- a/tares/runtime.py
+++ b/tares/runtime.py
@@ -36,6 +36,10 @@ class SourceRuntime:
 class Runtime:
     def __init__(self, store, dispatcher):
         self.store = store
+        # Set by the daemon: returns a reason while ingest is paused for storage, else None.
+        # Poll connectors skip their fetch while it is set, so a full disk stops growth from
+        # every direction, not only the push endpoints.
+        self.storage_full = None
         self.dispatcher = dispatcher
         self.catalog: Catalog = catalog_from_db(store)
         self.sources: dict[str, SourceRuntime] = {}
@@ -95,6 +99,11 @@ class Runtime:
             h = rt.health
             h.last_poll_at = now_utc()
             h.polls += 1
+            reason = self.storage_full() if self.storage_full else None
+            if reason:
+                h.last_error, h.status = reason, "paused"
+                await asyncio.sleep(rt.cfg.poll_seconds)
+                continue
             try:
                 envelopes = await conn.poll()
                 self.store.append(envelopes)

--- a/tests/test_degraded.py
+++ b/tests/test_degraded.py
@@ -64,8 +64,9 @@ async def main():
         ck("status is ok", h and h["status"] == "ok", h)
         # the keys AuthGate + the cloud login handoff + the control plane's uptime check depend on
         ck("keeps auth_required/sources", h and "auth_required" in h and "sources" in h, h)
-        ck("pct_used is null with no limit configured (unknown, NOT 0)",
-           h and h.get("pct_used") is None, h)
+        # no limit configured: the volume the database sits on is the denominator (TR-290)
+        ck("pct_used is measured against the volume with no limit configured",
+           h and h.get("pct_used") is not None and h["pct_used"] < 100, h)
     finally:
         proc.terminate(); proc.wait(timeout=10)
 

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -89,8 +89,11 @@ async def main():
             ck("db_bytes > 0", u["db_bytes"] > 0, str(u["db_bytes"]))
             ck("disk_total/disk_free are real",
                u["disk_total"] > 0 and 0 < u["disk_free"] <= u["disk_total"], str(u))
-            ck("no TARES_MAX_DB_SIZE -> max_bytes null", u["max_bytes"] is None, str(u["max_bytes"]))
-            ck("no TARES_MAX_DB_SIZE -> pct_used null", u["pct_used"] is None, str(u["pct_used"]))
+            ck("no TARES_MAX_DB_SIZE -> the volume is the limit",
+               u["max_bytes"] == u["disk_total"] and u["max_bytes_source"] == "volume", str(u))
+            ck("no TARES_MAX_DB_SIZE -> pct_used against the volume",
+               u["pct_used"] is not None and 0 <= u["pct_used"] < 100, str(u["pct_used"]))
+            ck("ingest not paused on a roomy volume", u["ingest_paused"] is False, str(u))
             ck("events total", u["events"] == 25, str(u["events"]))
             ck("per-source counts", {s["name"]: s["events"] for s in u["sources"]} == {"evt": 20, "evt2": 5},
                str(u["sources"]))
@@ -115,7 +118,28 @@ async def main():
     finally:
         proc.terminate(); proc.wait(timeout=10)
 
-    # ── limit configured + auth on ──
+    # ── a limit the data already exceeds: ingest refused, polls paused, health says why ──
+    proc = _boot(TARES_MAX_DB_SIZE="1Mi")
+    try:
+        if not await _wait(f"{B}/health"):
+            ck("daemon up (tiny limit)", False); return
+        async with httpx.AsyncClient() as cx:
+            h = (await cx.get(f"{B}/health")).json()
+            ck("health degraded with the pause reason", h["status"] == "degraded"
+               and "ingest paused" in (h.get("detail") or ""), str(h))
+            u = (await cx.get(f"{B}/api/usage")).json()
+            ck("usage reports ingest paused", u["ingest_paused"] is True and u["max_bytes_source"] == "env", str(u))
+            r = await cx.post(f"{B}/ingest/evt", json=[{"m": "one more"}])
+            ck("push ingest refused with 507", r.status_code == 507 and "ingest paused" in r.text, f"{r.status_code} {r.text[:120]}")
+            r = await cx.post(f"{B}/v1/logs", json={"resourceLogs": []}, headers={"x-tares-source": "evt"})
+            ck("OTLP ingest refused with 507 too", r.status_code == 507, str(r.status_code))
+            ck("reads still work", (await cx.get(f"{B}/api/sources")).status_code == 200)
+            u2 = (await cx.get(f"{B}/api/usage")).json()
+            ck("nothing was stored while paused", u2["events"] == 10025, str(u2["events"]))
+    finally:
+        proc.terminate(); proc.wait(timeout=10)
+
+    # ── limit configured + auth on; a limit with room lets ingest resume ──
     proc = _boot(TARES_AUTH_TOKEN=AUTH, TARES_MAX_DB_SIZE="1Gi")
     try:
         if not await _wait(f"{B}/health"):
@@ -135,6 +159,8 @@ async def main():
             ck("pct_used = (db+wal)/max as a percentage", u["pct_used"] == expect and u["pct_used"] > 0,
                f"{u['pct_used']} vs {expect}")
             ck("counts survived the restart", u["events"] == 10025, str(u["events"]))
+            ck("ingest resumes under a roomier limit", u["ingest_paused"] is False
+               and (await cx.post(f"{B}/ingest/evt", json=[{"m": "after"}], headers=H(ing_key))).status_code == 202)
     finally:
         proc.terminate(); proc.wait(timeout=10)
 

--- a/ui/src/pages/Home.tsx
+++ b/ui/src/pages/Home.tsx
@@ -212,11 +212,18 @@ function StoragePanel({ usage, error, reload, onDisk, pct }: {
 
       {u && (
         <>
-          {pct !== null && pct >= 80 && (
+          {u.ingest_paused ? (
+            <div className="alert error">
+              <strong>Ingest is paused: storage {pct}% full.</strong> Producers get 507 and poll
+              connectors wait, so the database never fills its disk. Reads, agents and the console
+              keep working. Grow the volume or delete a source's events; ingest resumes on its own
+              once there is room.
+            </div>
+          ) : pct !== null && pct >= 80 && (
             <div className="alert warn">
               <strong>Storage {pct}% full</strong> · {formatBytes(onDisk)} of the{" "}
-              {formatBytes(u.max_bytes)} limit for this instance. Ingest keeps working until it
-              runs out; free space or raise <code>TARES_MAX_DB_SIZE</code> before it does.
+              {formatBytes(u.max_bytes)} {u.max_bytes_source === "volume" ? "volume" : "limit"} for this
+              instance. At 95% ingest pauses; grow the volume or free space before it does.
             </div>
           )}
 
@@ -227,8 +234,9 @@ function StoragePanel({ usage, error, reload, onDisk, pct }: {
                       style={{ width: `${Math.min(100, Math.max(0, pct))}%` }} />
               </div>
               <p className="help" style={{ marginBottom: 0 }}>
-                <strong>{formatBytes(onDisk)}</strong> of {formatBytes(u.max_bytes)} used ({pct}%)
-                {u.disk_free != null && <> · {formatBytes(u.disk_free)} free on the volume</>}
+                <strong>{formatBytes(onDisk)}</strong> of {formatBytes(u.max_bytes)}
+                {u.max_bytes_source === "volume" ? " on the volume" : " limit"} used ({pct}%)
+                {u.max_bytes_source === "env" && u.disk_free != null && <> · {formatBytes(u.disk_free)} free on the volume</>}
               </p>
             </>
           ) : (

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -375,7 +375,9 @@ export interface SourceEvent {
 // GET /api/usage — what this instance is using on disk.
 // Three things the renderer must respect:
 //  · `pct_used` is 0-100, NOT a 0-1 fraction — "warn at 80%" compares against 80.
-//  · `pct_used` and `max_bytes` are null unless the operator set TARES_MAX_DB_SIZE (the Helm
+//  · `max_bytes` is TARES_MAX_DB_SIZE when set, else the volume the database sits on
+//    (`max_bytes_source` says which); null only when neither is known. At the pause mark ingest
+//    is refused and polls stop (`ingest_paused`). Older comment, still true for the null case: (the Helm
 //    chart does it for hosted cells), so a self-hosted install has no denominator at all: show
 //    absolute bytes and fall back to `disk_free` for headroom. Null is unknown, never 0.
 //  · `sources[].bytes` is always null — DuckDB keeps every source in one events table and cannot
@@ -386,7 +388,9 @@ export interface Usage {
   disk_total: number | null;
   disk_free: number | null;
   max_bytes: number | null;
+  max_bytes_source?: "env" | "volume" | "";
   pct_used: number | null;
+  ingest_paused?: boolean;
   events: number;
   sources: { name: string; events: number; bytes: number | null }[];
   agent_runs: number;


### PR DESCRIPTION
Linear TR-290. From the glassflow-web cell on 2026-09-08: the DuckDB file filled its volume, the database invalidated itself and every request answered 500 until a restart with more space; after the volume was grown, the cell kept reporting 93% full against a stale chart value.

**Measure against the volume.** With no `TARES_MAX_DB_SIZE`, the limit is the volume the database sits on. `/api/usage` reports `max_bytes_source` (`env` or `volume`) and `pct_used` is no longer null on a plain install. A grown volume shows on the next mount, nothing to refresh. An explicit `TARES_MAX_DB_SIZE` still wins.

**Pause instead of dying.** At 95% of the limit (`TARES_INGEST_PAUSE_PCT`), push ingest and OTLP answer 507 with "ingest paused: storage N% full of the ... volume; grow the volume or delete data", poll connectors wait with that reason in their health, and `/health` says degraded with the same sentence. Reads, agents and the console keep working; `ingest_paused` on `/api/usage`. Ingest resumes on its own once there is room.

**Console.** The Overview storage panel shows the usage bar against the volume ("19 GiB of 59 GiB on the volume used") and a red notice while ingest is paused.

**Tests.** `tests/test_usage.py`: volume fallback, 507 on both ingest paths, the health detail, resumption under a roomier limit (33 checks); `test_degraded` updated for the fallback. AGENTS.md lists both variables.

Cloud side: glassflow-cloud branch `storage-limit-volume` drops the derived `maxDbSize` from the chart and the control plane. Roll this release to cells before that chart change reaches them, or older cells report a blank percentage in between.