### PR TITLE
Sidebar: scroll and tighten on short screens

### DIFF
--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -266,6 +266,19 @@ b, strong { font-weight: 600; }
   position: sticky;
   top: 0;
   height: 100vh;
+  /* Taller than the viewport on a laptop screen: scroll the sidebar itself rather than clip
+     Settings, Sign out and the version at the bottom (TR-291). */
+  overflow-y: auto;
+  min-height: 0;
+  box-sizing: border-box;
+}
+/* A short screen: tighter rows so the whole sidebar fits without scrolling in most cases. */
+@media (max-height: 820px) {
+  .sidebar { padding: 12px 14px; }
+  .sidebar .brand { margin-bottom: 18px; }
+  .navlink { padding: 5px 10px; }
+  .nav-group { margin-bottom: 4px; }
+  .sidebar .sep { margin: 4px 6px; }
 }
 .brand {
   font-size: 19px;


### PR DESCRIPTION
Linear TR-291. The sidebar is a sticky 100vh box with no overflow, so on a laptop screen its entries plus the footer are taller than the viewport and Settings, Workspace, Sign out and the version are clipped with no way to reach them. Now the sidebar scrolls on its own when it is taller than the viewport, and under 820px of height its padding, row height and group gaps tighten so it fits without scrolling in the common case. Checked at a 1440x760 window on a local instance: every row and the version visible.