### PR TITLE
Write-back: report every firing the investigation covers, not one of them (TR-285)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Backend — install + tests
         run: |
           pip install -e .
-          for t in test_labels test_normalize test_auth test_api_keys test_pricing test_agents test_catalog_sync test_cli test_status test_usage test_slack test_slack_verify test_slack_ask test_degraded test_loki test_projects test_rius_rca test_ai_sre_demo test_seed test_session_flow test_challenger_workflow test_plugin_challenger test_tracing test_agent_runs_filter test_delete_cascade test_agent_build test_builder_flow test_http_poll; do
+          for t in test_labels test_normalize test_auth test_api_keys test_pricing test_agents test_catalog_sync test_cli test_status test_usage test_slack test_slack_verify test_slack_ask test_degraded test_loki test_projects test_rius_rca test_rca_fanout test_ai_sre_demo test_seed test_session_flow test_challenger_workflow test_plugin_challenger test_tracing test_agent_runs_filter test_delete_cascade test_agent_build test_builder_flow test_http_poll; do
             echo "== $t =="
             python "tests/$t.py"
           done

--- a/tares/builtin_agents.py
+++ b/tares/builtin_agents.py
@@ -56,6 +56,10 @@ TOOL_TIMEOUT = 120        # per Anthropic request
 # the first surprise is the bill. Per-agent and per-day, counted from the run log.
 DAILY_RUN_CAP = int(os.getenv("TARES_AGENT_DAILY_CAP", "50"))
 MAX_BOOTSTRAP_KEYS = 50    # a project bootstraps at most this many entities in one go
+# How many events one write-back may fan out over. A burst of firings inside one cooldown is one
+# investigation reported to each of them, and this bounds that: read_view_window's default cap of
+# 12 would silently drop the rest of a larger burst.
+CALLBACK_KEY_CAP = 200
 
 def effective_max_rounds(agent: dict) -> int:
     """The round cap a run is held to: the agent's own setting when set, else the default for its
@@ -453,12 +457,9 @@ class AgentRunner:
         self.store.finish_agent_run(run_id, "ok", rounds=rounds, tool_calls=tool_calls,
                                     finding=finding, external_tools=external_used)
         if (agent.get("webhook_url") or "").strip():
-            delivery, derr = await self._webhook(agent, {
+            body = {
                 "event": "finding",
                 "agent": agent["name"], "trigger": trigger_name,
-                # `key` is the entity, unless the agent names a label to report instead: Rius
-                # attributes reports by delivery id while the entity is the service (TR-285)
-                "key": self._callback_key(agent, trigger_name, key),
                 "finding": finding,
                 "run_id": run_id, "dispatch_id": dispatch_id,
                 "model": model,
@@ -470,17 +471,52 @@ class AgentRunner:
                 "started_at": started_at.isoformat(), "finished_at": now_utc().isoformat(),
                 "duration_s": round(time.monotonic() - t0, 2),
                 "prompt_hash": prompt_hash(agent["prompt"]),
-            })
+            }
+            delivery, derr = await self._deliver_finding(agent, trigger_name, key, body)
             self.store.set_run_delivery(run_id, delivery, derr)
         return "ok", None
 
-    def _callback_key(self, agent: dict, trigger_name: str, key: str) -> str:
-        """The `key` the write-back carries: the entity, or the value of `webhook_key_label` on
-        the most recent event that woke this run, when the agent names one. Falls back to the
-        entity when the label is not on the event, so a wrong name never drops the field."""
+    async def _deliver_finding(self, agent: dict, trigger_name: str, key: str,
+                               body: dict) -> tuple[str, str | None]:
+        """POST one finding to the write-back, once per `key` the investigation covers.
+
+        `key` is the entity, unless the agent names a label to report instead: Rius attributes
+        reports by delivery id while the entity is the service (TR-285). One investigation covers
+        every firing in the window, so the finding is posted once per value — the shared run_id
+        is what marks those posts as one investigation rather than several.
+
+        A run has ONE delivery column, so the outcome reported is the first failure across the
+        fan-out, in the existing vocabulary; a later key failing must not overwrite it, and one
+        key failing must not stop the rest from being told.
+        """
+        delivery, derr = "ok", None
+        for cb_key in self._callback_keys(agent, trigger_name, key):
+            one, one_err = await self._webhook(agent, {**body, "key": cb_key})
+            if derr is None and (one_err is not None or one != "ok"):
+                delivery, derr = one, one_err
+        return delivery, derr
+
+    def _callback_keys(self, agent: dict, trigger_name: str, key: str) -> list[str]:
+        """The `key`s the write-back carries — one report per value, all sharing this run's id.
+
+        The entity, unless the agent names a `webhook_key_label`: then every distinct value that
+        label takes over the events this run answers for. A trigger fires on an aggregate over a
+        window, never on one event, so there is no single firing to attribute a finding to. One
+        value was reported before, which meant a burst inside one cooldown got a report keyed to
+        an arbitrary member of the burst — the newest, while the agent had usually written up the
+        oldest — leaving every other firing with no report at all.
+
+        The lookback is min(window, cooldown), the span no earlier firing of this trigger can
+        have covered, so a fan-out can never overwrite a previous run's report for the same
+        value. This is why there is no floor on the lookback: widening it past the cooldown would
+        reach back into events an earlier run already answered.
+
+        Falls back to the entity when the label is on no event, so a wrong name never drops the
+        field.
+        """
         label = (agent.get("webhook_key_label") or "").strip()
         if not label:
-            return key
+            return [key]
         try:
             catalog = self.runtime.catalog
             triggers = catalog.triggers
@@ -492,22 +528,25 @@ class AgentRunner:
                 view = (views.get(trig.view) if isinstance(views, dict)
                         else next((v for v in views if v.name == trig.view), None))
             if view is None:
-                return key
-            window = max(parse_duration(trig.condition.window or "15m"), 900.0)
-            since = now_utc() - timedelta(seconds=window)
-            rows = self.store.read_view_window(view.sources, key, since, cap=1,
+                return [key]
+            window = parse_duration(trig.condition.window or "15m")
+            cooldown = float(getattr(trig, "cooldown_seconds", 0) or 0)
+            since = now_utc() - timedelta(seconds=min(window, cooldown) if cooldown else window)
+            rows = self.store.read_view_window(view.sources, key, since, cap=CALLBACK_KEY_CAP,
                                                filters=view.filters)
-            latest = max(rows, key=lambda r: r[0]) if rows else None
-            if latest is None:
-                return key
-            labels = latest[3]
-            if isinstance(labels, str):
-                labels = json.loads(labels or "{}")
-            value = (labels or {}).get(label)
-            return str(value) if value not in (None, "") else key
+            values: list[str] = []
+            for row in sorted(rows, key=lambda r: r[0]):
+                labels = row[3]
+                if isinstance(labels, str):
+                    labels = json.loads(labels or "{}")
+                value = (labels or {}).get(label)
+                if value in (None, "") or str(value) in values:
+                    continue
+                values.append(str(value))
+            return values or [key]
         except Exception as e:  # noqa: BLE001 — never lose the write-back over the key lookup
-            print(f"[agent {agent['name']}] callback key from {label!r}: {type(e).__name__}: {e}")
-            return key
+            print(f"[agent {agent['name']}] callback keys from {label!r}: {type(e).__name__}: {e}")
+            return [key]
 
     # ── the bounded model loop ────────────────────────────────────────────────
     async def _loop(self, agent: dict, trigger_name: str, key: str, payload: str,

--- a/tares/projects/rius_rca.py
+++ b/tares/projects/rius_rca.py
@@ -3,7 +3,8 @@
 One project per Rius workspace, created remotely by rius-cp via POST /api/projects against the
 workspace's dedicated cell. When an alert fires in Rius, its region POSTs the alert context to
 this project's source; the trigger wakes the agent; the agent investigates over the Rius MCP
-server and the write-back webhook POSTs the finding to Rius's callback, keyed by the delivery id.
+server and the write-back webhook POSTs the finding to Rius's callback, once per delivery id the
+investigation covers.
 
 Every knob here is the hand-built configuration proven on a live cell on 2026-09-01 (TR-223
 comment: run_7a954505c5c7 and friends — 4/4 green against staging Rius), with the five traps from
@@ -12,7 +13,10 @@ that session baked in:
      (TR-226/TR-228). The entity is the SERVICE (TR-285): a delivery id is new on every firing,
      so a cooldown keyed by it never held and one noisy service woke the agent on every alert;
      keyed by service, one investigation per service per 5 minutes, and the timeline the agent
-     reads is that service's history. The delivery id stays a label on every event;
+     reads is that service's history. The delivery id stays a label on every event, and the
+     write-back reports EVERY delivery id in the window it covers, not one of them: Rius stores a
+     report per delivery, so reporting a single id left the rest of a burst with no report and
+     could key the finding to a firing the agent never wrote about;
   2. the prompt names the Rius tool chain and demands tool-grounded claims — it must not carry
      the demo agents' "no live access" language, which makes an MCP-equipped agent refuse to
      query;
@@ -44,15 +48,23 @@ TEXT_TEMPLATE = ("{rule} on {service}: {summary} "
 # their tool names without waiting on a Tares release.
 PROMPT = """You are an SRE performing root-cause analysis for the Rius agent-observability platform.
 
-You are handed ONE alert firing from Rius. The firing payload carries identifiers, not bulk
+You are handed the recent alert firings for ONE service, newest last. There may be several: the
+entity is the service, so a burst of alerts is one investigation covering all of them, and your
+note is delivered back to every firing you were handed. Each line carries identifiers, not bulk
 evidence: the delivery id, the alert, the affected workspace and service, and the window.
+
+Write ONE note for the service and window. Do not present it as the analysis of a single alert
+or delivery id — several of the firings shown may be symptoms of the same cause, and the reader
+of any one of them sees this same note. Where the firings have different causes, say so and
+cover each.
 
 You DO have live access to Rius through the `rius` MCP server. Use it. Start from
 `agent_traces_summary` and `workspace_metrics_overview` for the window, narrow with
 `list_agent_traces` (status "Error"), then pull the specific failures with `get_agent_trace`,
 passing include_content=true when you need to see what a span actually said or returned.
 
-Produce a short incident note in markdown:
+Produce a short incident note in markdown, headed by the service and the window it covers, and
+listing the alerts it covers when there is more than one:
 1. **What is failing** and since when.
 2. **Most likely root cause**, tied to specific evidence you fetched (name the trace, the span,
    the error, the numbers).

--- a/tests/test_rca_fanout.py
+++ b/tests/test_rca_fanout.py
@@ -1,0 +1,215 @@
+"""The write-back's fan-out: one investigation, one report per firing it covers.
+
+Run: .venv/bin/python tests/test_rca_fanout.py   (no external services needed)
+
+A trigger fires on an aggregate over a window, not on one event, so a burst of firings inside one
+cooldown is a single investigation. Reporting one `webhook_key_label` value meant the rest of the
+burst got no report at all, and the one report was keyed to an arbitrary member of it — the newest
+event, while the agent had usually written up the oldest. These assert the whole set is reported,
+that the lookback cannot reach into an earlier run's firings, and that the fallbacks still hold.
+"""
+import asyncio
+import json
+import os
+import sys
+from datetime import timedelta
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from tares.builtin_agents import CALLBACK_KEY_CAP, AgentRunner
+from tares.envelope import now_utc
+
+PASS = FAIL = 0
+
+
+def check(label, cond, detail=""):
+    global PASS, FAIL
+    if cond:
+        PASS += 1; print(f"  ok   {label}")
+    else:
+        FAIL += 1; print(f"  FAIL {label}  {detail}")
+
+
+class Condition:
+    def __init__(self, window):
+        self.window = window
+
+
+class Trigger:
+    def __init__(self, window="5m", cooldown=300.0):
+        self.name = "rius_alert_fired"
+        self.view = "rius_alerts_view"
+        self.condition = Condition(window)
+        self.cooldown_seconds = cooldown
+
+
+class View:
+    name = "rius_alerts_view"
+    sources = ["rius_alerts"]
+    filters = None
+
+
+class Catalog:
+    def __init__(self, trig):
+        self.triggers = [trig]
+        self.views = [View()]
+
+
+class Runtime:
+    def __init__(self, catalog):
+        self.catalog = catalog
+
+
+class Store:
+    """Only what _callback_keys touches. `events` are (age_seconds, labels), newest age smallest."""
+
+    def __init__(self, events, labels_as_json=False):
+        self.events = events
+        self.labels_as_json = labels_as_json
+        self.since_asked = None
+        self.cap_asked = None
+
+    def read_view_window(self, sources, key, since, cap=12, filters=None, where=None,
+                         include_payload=False):
+        self.since_asked, self.cap_asked = since, cap
+        rows = []
+        for age, labels in self.events:
+            at = now_utc() - timedelta(seconds=age)
+            if at < since:
+                continue
+            rows.append((at, sources[0], "text",
+                         json.dumps(labels) if self.labels_as_json else labels))
+        # The real store returns each source's most-recent `cap` events.
+        return sorted(rows, key=lambda r: r[0])[-cap:]
+
+
+def runner(store, trig=None):
+    """An AgentRunner without its __init__: that reaps stale runs and needs a real store, and
+    neither of the two methods under test touches anything else on the object."""
+    r = object.__new__(AgentRunner)
+    r.store = store
+    r.runtime = Runtime(Catalog(trig or Trigger()))
+    return r
+
+
+AGENT = {"name": "rius_rca_agent", "webhook_key_label": "delivery_id",
+         "webhook_url": "https://ingest.rius.invalid/v1/rca/reports"}
+
+
+def keys_for(store, agent=AGENT, trig=None):
+    return runner(store, trig)._callback_keys(agent, "rius_alert_fired", "billing-svc")
+
+
+async def main():
+    print("== every firing in the window is reported, oldest first ==")
+    # The burst that produced the bug: 6 firings 2s apart, one run woken by the oldest.
+    burst = [(12 - i, {"service": "billing-svc", "delivery_id": f"d{i}"}) for i in range(6)]
+    got = keys_for(Store(burst))
+    check("all six delivery ids reported", got == [f"d{i}" for i in range(6)], str(got))
+    check("not just the newest (the old bug)", got != ["d5"], str(got))
+    check("anchored on the oldest, which the agent writes up", got[0] == "d0", str(got))
+
+    print("== duplicates and blanks ==")
+    dupes = [(9, {"delivery_id": "a"}), (6, {"delivery_id": "a"}), (3, {"delivery_id": "b"}),
+             (2, {"delivery_id": ""}), (1, {"service": "billing-svc"})]
+    got = keys_for(Store(dupes))
+    check("each value once, blank and missing skipped", got == ["a", "b"], str(got))
+
+    print("== labels arriving as a JSON string ==")
+    got = keys_for(Store([(5, {"delivery_id": "j1"}), (4, {"delivery_id": "j2"})],
+                         labels_as_json=True))
+    check("json labels parsed", got == ["j1", "j2"], str(got))
+
+    print("== the lookback cannot reach an earlier run's firings ==")
+    # cooldown 5m, so anything older than 5m belongs to a firing an earlier run already answered.
+    # Reporting it would overwrite that run's report for the same delivery.
+    store = Store([(600, {"delivery_id": "old"}), (30, {"delivery_id": "new"})])
+    got = keys_for(store)
+    check("older than the cooldown is excluded", got == ["new"], str(got))
+    asked = (now_utc() - store.since_asked).total_seconds()
+    check("lookback is the cooldown, not a wider floor", 290 <= asked <= 310, f"{asked:.0f}s")
+    # A cooldown shorter than the window is the binding constraint, and vice versa.
+    store = Store([(30, {"delivery_id": "n"})], )
+    keys_for(store, trig=Trigger(window="5m", cooldown=60.0))
+    asked = (now_utc() - store.since_asked).total_seconds()
+    check("min(window, cooldown) wins when cooldown is shorter", 55 <= asked <= 65, f"{asked:.0f}s")
+    store = Store([(30, {"delivery_id": "n"})])
+    keys_for(store, trig=Trigger(window="1m", cooldown=300.0))
+    asked = (now_utc() - store.since_asked).total_seconds()
+    check("min(window, cooldown) wins when window is shorter", 55 <= asked <= 65, f"{asked:.0f}s")
+    store = Store([(30, {"delivery_id": "n"})])
+    keys_for(store, trig=Trigger(window="2m", cooldown=0.0))
+    asked = (now_utc() - store.since_asked).total_seconds()
+    check("no cooldown falls back to the window", 115 <= asked <= 125, f"{asked:.0f}s")
+
+    print("== a burst larger than the store's default cap ==")
+    big = [(200 - i, {"delivery_id": f"b{i}"}) for i in range(40)]
+    store = Store(big)
+    got = keys_for(store)
+    check("more than the default cap of 12 is reported", len(got) == 40, str(len(got)))
+    check("the cap asked for is the callback cap", store.cap_asked == CALLBACK_KEY_CAP,
+          str(store.cap_asked))
+
+    print("== fallbacks: never drop the field ==")
+    check("no label named -> the entity",
+          keys_for(Store(burst), agent={"name": "a"}) == ["billing-svc"])
+    check("label on no event -> the entity",
+          keys_for(Store([(5, {"service": "billing-svc"})])) == ["billing-svc"])
+    check("no events at all -> the entity", keys_for(Store([])) == ["billing-svc"])
+    r = runner(Store(burst))
+    r.runtime = Runtime(Catalog(Trigger()))
+    r.runtime.catalog.views = []          # a trigger naming a view that is gone
+    check("missing view -> the entity",
+          r._callback_keys(AGENT, "rius_alert_fired", "billing-svc") == ["billing-svc"])
+
+    print("== the store raising must not lose the write-back ==")
+    class Boom(Store):
+        def read_view_window(self, *a, **k):
+            raise RuntimeError("duckdb is unhappy")
+    check("lookup failure -> the entity", keys_for(Boom([])) == ["billing-svc"])
+
+    print("== _deliver_finding posts once per key ==")
+    posts = []
+
+    async def fake_webhook(agent, body, attempts=3):
+        posts.append(body)
+        return "ok", None
+
+    r = runner(Store(burst))
+    r._webhook = fake_webhook
+    delivery, err = await r._deliver_finding(AGENT, "rius_alert_fired", "billing-svc",
+                                             {"event": "finding", "run_id": "run_1"})
+    check("one post per firing", len(posts) == 6, str(len(posts)))
+    check("each carries its own key", [p["key"] for p in posts] == [f"d{i}" for i in range(6)],
+          str([p["key"] for p in posts]))
+    check("all share one run id", {p["run_id"] for p in posts} == {"run_1"})
+    check("the body is otherwise identical",
+          all(p["event"] == "finding" for p in posts))
+    check("all ok -> ok", (delivery, err) == ("ok", None), f"{delivery} {err}")
+
+    print("== one key failing does not stop or mask the others ==")
+    posts.clear()
+    calls = {"n": 0}
+
+    async def flaky(agent, body, attempts=3):
+        calls["n"] += 1
+        posts.append(body)
+        if calls["n"] == 2:
+            return "http 400", "bad request"
+        if calls["n"] == 4:
+            return "failed", "connection reset"
+        return "ok", None
+
+    r = runner(Store(burst))
+    r._webhook = flaky
+    delivery, err = await r._deliver_finding(AGENT, "rius_alert_fired", "billing-svc", {})
+    check("every key still attempted", len(posts) == 6, str(len(posts)))
+    check("the FIRST failure is what the run reports", (delivery, err) == ("http 400", "bad request"),
+          f"{delivery} {err}")
+
+    print(f"\n{PASS} passed, {FAIL} failed")
+    return 1 if FAIL else 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))


### PR DESCRIPTION
## What's wrong

A trigger fires on an **aggregate over a window**, never on a single event, so a burst of firings inside one cooldown is one investigation. But the write-back reported a single `webhook_key_label` value — the newest event in a 15m lookback (`_callback_key`). On the Rius RCA path that has two consequences:

1. the report is keyed to an **arbitrary member** of the burst, usually *not* the firing the agent wrote up, so Rius attaches the finding to the wrong alert; and
2. every **other** firing in the burst gets no report at all.

## Seen on staging today

Six Rius alerts for one service inside 2.2s (`consistent_error_pattern` ×2, `silent_failure` ×2, `tool_loop`, custom). All six were accepted by the cell. They produced **one** run, `run_41b05676e9f1`:

| | |
|---|---|
| run started | `09:33:03.445` — 397ms after delivery **1**, before deliveries 2-6 existed |
| deliveries 2-6 | recorded `deduped (already running)` |
| agent wrote up | delivery `73e2764a` → alert `caae018f` (consistent_error_pattern / `billing_run`) |
| callback posted `key` | `e9031347` → alert `e4818ff5` (**tool_loop**) |

Rius resolves the alert from that `key`, so its console showed the **tool_loop** alert displaying a `billing_run` incident note, and the alert actually investigated showed no finding at all. The other five showed nothing. Rius links a valid delivery id happily, so nothing on either side flagged it.

(This is also the other half of the earlier report-drop: the `return key` fallback sends the *entity* — a service name, not a UUID — which Rius's receiver 400s and drops.)

## The change

- `_callback_key` → **`_callback_keys`**: returns every distinct value the label takes over the events the run answers for, oldest first.
- New **`_deliver_finding`** posts the finding once per value, all sharing the `run_id` — which is what marks them as one investigation rather than several. A run has one `delivery` column, so it reports the first failure in the existing vocabulary; one key failing neither stops the rest nor masks the outcome.
- Lookback drops to **`min(window, cooldown)`** — the span no earlier firing can have covered — so a fan-out can never overwrite an earlier run's report for the same value. The old `max(..., 900.0)` floor could reach back into events another run had already answered, which becomes a clobbering hazard once we post to more than one.
- Cap is `CALLBACK_KEY_CAP = 200`; `read_view_window`'s default of 12 would silently truncate a larger burst.
- **Prompt**: it said *"You are handed ONE alert firing from Rius"*, which is why the note read as one alert's analysis. It now says the firings are for one service, that the note goes back to every firing shown, and asks for the service + window in the heading.

Fallbacks are unchanged in spirit: no label, label on no event, no events, missing view, or a store that raises all still yield `[entity]`, so a wrong name never drops the field.

## Tests

New `tests/test_rca_fanout.py` (24 checks), added to the CI list — 6-firing burst reported in full and oldest-first, dedup/blank/JSON-label handling, the `min(window, cooldown)` bound in all four combinations, burst larger than the default cap, all five fallbacks, and the fan-out itself (one post per key, shared run id, first-failure reporting, one failure not stopping the others).

Verified the tests have teeth by reverting the fix: reporting only the newest value fails 10 checks — including the literal production symptom, `['d5']` — and restoring the 900s floor fails 5.

Full CI backend list run locally: 27/29 pass. `test_auth` and `test_degraded` fail identically on a clean tree before this branch (`test_degraded` wants a real `ui/dist`; `test_auth` is a local socket read error), so they're environmental here, not from this change.

## Note for the Rius side

No Rius change is needed: each post is its own `delivery_id`, resolves its own `alert_id`, and `rca_reports` already treats a shared `run_id` as one investigation. Worth knowing that firings suppressed by the **cooldown** after a run finishes are still uncovered — the report can only be posted once, at run end. That's arguably correct ("one investigation per service per 5 minutes"), but it does mean an alert can legitimately have no RCA; flagging it rather than fixing it here.

---
Ticket: [TR-294](https://linear.app/glassflow/issue/TR-294/rca-write-back-keys-the-finding-to-the-wrong-firing-and-drops-the-rest) (follows TR-285)
