### PR TITLE
Write-back: resolve the callback key at run start, not at write-back (TR-294)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Backend — install + tests
         run: |
           pip install -e .
-          for t in test_labels test_normalize test_auth test_api_keys test_pricing test_agents test_catalog_sync test_cli test_status test_usage test_slack test_slack_verify test_slack_ask test_degraded test_loki test_projects test_rius_rca test_ai_sre_demo test_seed test_session_flow test_challenger_workflow test_plugin_challenger test_tracing test_agent_runs_filter test_delete_cascade test_agent_build test_builder_flow test_http_poll; do
+          for t in test_labels test_normalize test_auth test_api_keys test_pricing test_agents test_catalog_sync test_cli test_status test_usage test_slack test_slack_verify test_slack_ask test_degraded test_loki test_projects test_rius_rca test_rca_callback_anchor test_ai_sre_demo test_seed test_session_flow test_challenger_workflow test_plugin_challenger test_tracing test_agent_runs_filter test_delete_cascade test_agent_build test_builder_flow test_http_poll; do
             echo "== $t =="
             python "tests/$t.py"
           done

--- a/tares/builtin_agents.py
+++ b/tares/builtin_agents.py
@@ -406,6 +406,12 @@ class AgentRunner:
             self.store.finish_agent_run(run_id, "capped", error=msg)
             return "capped", msg
 
+        # BEFORE the loop: the write-back's key names the firing this run answers for, and only
+        # now is that unambiguous — the trigger has just fired on it. Resolved after the loop
+        # instead, it named whichever firing had arrived most recently by then, which for a burst
+        # inside one cooldown is a different alert from the one the agent wrote up (TR-294).
+        callback_key, callback_labels = self._callback_anchor(agent, trigger_name, key)
+
         # Usage accumulates in a mutable dict rather than the loop's return value, so a run that
         # dies mid-loop still records the tokens it already paid for (the finally below).
         model = agent.get("model") or MODEL
@@ -457,8 +463,12 @@ class AgentRunner:
                 "event": "finding",
                 "agent": agent["name"], "trigger": trigger_name,
                 # `key` is the entity, unless the agent names a label to report instead: Rius
-                # attributes reports by delivery id while the entity is the service (TR-285)
-                "key": self._callback_key(agent, trigger_name, key),
+                # attributes reports by delivery id while the entity is the service (TR-285).
+                # Both were resolved at run start — see _callback_anchor.
+                "key": callback_key,
+                # The firing's own labels, so a receiver can attribute the report on something
+                # other than `key` alone and reject a mismatch rather than mis-file it silently.
+                "labels": callback_labels,
                 "finding": finding,
                 "run_id": run_id, "dispatch_id": dispatch_id,
                 "model": model,
@@ -474,13 +484,22 @@ class AgentRunner:
             self.store.set_run_delivery(run_id, delivery, derr)
         return "ok", None
 
-    def _callback_key(self, agent: dict, trigger_name: str, key: str) -> str:
-        """The `key` the write-back carries: the entity, or the value of `webhook_key_label` on
-        the most recent event that woke this run, when the agent names one. Falls back to the
-        entity when the label is not on the event, so a wrong name never drops the field."""
+    def _callback_anchor(self, agent: dict, trigger_name: str, key: str) -> tuple[str, dict]:
+        """The firing this run answers for: the `key` the write-back reports, and that firing's
+        labels.
+
+        The key is the entity, or the value of `webhook_key_label` on the firing when the agent
+        names a label. MUST be called at run START: the trigger has just fired, so the newest
+        event in the window is the firing the run was woken by. Called after the model loop
+        instead, it named whichever firing had arrived most recently by then — for a burst inside
+        one cooldown, a different alert from the one the agent wrote up (TR-294).
+
+        Falls back to the entity and no labels when the label is on no event, so a wrong name
+        never drops the field.
+        """
         label = (agent.get("webhook_key_label") or "").strip()
         if not label:
-            return key
+            return key, {}
         try:
             catalog = self.runtime.catalog
             triggers = catalog.triggers
@@ -492,22 +511,24 @@ class AgentRunner:
                 view = (views.get(trig.view) if isinstance(views, dict)
                         else next((v for v in views if v.name == trig.view), None))
             if view is None:
-                return key
+                return key, {}
             window = max(parse_duration(trig.condition.window or "15m"), 900.0)
             since = now_utc() - timedelta(seconds=window)
             rows = self.store.read_view_window(view.sources, key, since, cap=1,
                                                filters=view.filters)
             latest = max(rows, key=lambda r: r[0]) if rows else None
             if latest is None:
-                return key
+                return key, {}
             labels = latest[3]
             if isinstance(labels, str):
                 labels = json.loads(labels or "{}")
-            value = (labels or {}).get(label)
-            return str(value) if value not in (None, "") else key
+            labels = labels or {}
+            value = labels.get(label)
+            return (str(value) if value not in (None, "") else key), labels
         except Exception as e:  # noqa: BLE001 — never lose the write-back over the key lookup
-            print(f"[agent {agent['name']}] callback key from {label!r}: {type(e).__name__}: {e}")
-            return key
+            print(f"[agent {agent['name']}] callback anchor from {label!r}: "
+                  f"{type(e).__name__}: {e}")
+            return key, {}
 
     # ── the bounded model loop ────────────────────────────────────────────────
     async def _loop(self, agent: dict, trigger_name: str, key: str, payload: str,

--- a/tests/test_rca_callback_anchor.py
+++ b/tests/test_rca_callback_anchor.py
@@ -1,0 +1,208 @@
+"""The write-back's key names the firing the run was woken by (TR-294).
+
+Run: .venv/bin/python tests/test_rca_callback_anchor.py   (no external services needed)
+
+The key used to be resolved after the model loop, from the newest event in the window at that
+moment. A run takes ~40s, so any firing that arrived for the same entity meanwhile became the
+reported key — and Rius attributes reports by that key, so the finding landed on an alert the
+agent had never looked at while the alert it did investigate showed nothing.
+
+The important test here is the one that drives `_run_traced` with newer events arriving DURING
+the loop: a unit test on `_callback_anchor` alone would still pass if the call moved back after
+the loop, which is exactly the bug.
+"""
+import asyncio
+import json
+import os
+import sys
+from datetime import timedelta
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import tares.builtin_agents as ba
+from tares.envelope import now_utc
+
+PASS = FAIL = 0
+
+
+def check(label, cond, detail=""):
+    global PASS, FAIL
+    if cond:
+        PASS += 1; print(f"  ok   {label}")
+    else:
+        FAIL += 1; print(f"  FAIL {label}  {detail}")
+
+
+class Condition:
+    window = "5m"
+
+
+class Trigger:
+    name = "rius_alert_fired"
+    view = "rius_alerts_view"
+    condition = Condition()
+    cooldown_seconds = 300.0
+
+
+class View:
+    name = "rius_alerts_view"
+    sources = ["rius_alerts"]
+    filters = None
+
+
+class Runtime:
+    class catalog:
+        triggers = [Trigger()]
+        views = [View()]
+
+
+class Store:
+    """Only the methods the run path touches. `events` is a mutable list of (age_s, labels)."""
+
+    def __init__(self, events, labels_as_json=False):
+        self.events = list(events)
+        self.labels_as_json = labels_as_json
+        self.finished = []
+        self.delivery = None
+
+    def read_view_window(self, sources, key, since, cap=12, filters=None, where=None,
+                         include_payload=False):
+        rows = []
+        for age, labels in self.events:
+            at = now_utc() - timedelta(seconds=age)
+            if at < since:
+                continue
+            rows.append((at, sources[0], "text",
+                         json.dumps(labels) if self.labels_as_json else labels))
+        return sorted(rows, key=lambda r: r[0])[-cap:]
+
+    # the run path's bookkeeping
+    def agent_runs_today(self, name, exclude_run_id=None):
+        return 0
+
+    def agent_cost_total(self, name):
+        return 0.0
+
+    def finish_agent_run(self, run_id, status, **kw):
+        self.finished.append((run_id, status))
+
+    def set_run_delivery(self, run_id, delivery, error=None):
+        self.delivery = (delivery, error)
+
+    def record_run_usage(self, *a, **k):
+        pass
+
+    def record_model_usage(self, *a, **k):
+        pass
+
+
+class Obs:
+    def set_output(self, *a):
+        pass
+
+    def set_attribute(self, *a):
+        pass
+
+
+AGENT = {"name": "rius_rca_agent", "prompt": "investigate", "webhook_key_label": "delivery_id",
+         "webhook_url": "https://ingest.rius.invalid/v1/rca/reports"}
+
+
+def runner(store):
+    """An AgentRunner without __init__: it reaps stale runs and wants a real store, and nothing
+    under test here touches anything but `store` and `runtime`."""
+    r = object.__new__(ba.AgentRunner)
+    r.store = store
+    r.runtime = Runtime()
+    return r
+
+
+def anchor(store, agent=AGENT):
+    return runner(store)._callback_anchor(agent, "rius_alert_fired", "billing-svc")
+
+
+async def main():
+    # The module resolves these from the store; the run path needs them non-empty to proceed.
+    ba.resolve_anthropic_headers = lambda store: ({"x-api-key": "test"}, "test")
+    ba.resolve_api_base = lambda store: ("https://api.invalid", "test")
+
+    print("== THE REGRESSION: newer firings during the run must not move the key ==")
+    # One firing when the run starts; three more land while the model loop is running, exactly as
+    # a burst of alerts for one service does.
+    store = Store([(1, {"service": "billing-svc", "delivery_id": "d-woke",
+                        "alert_id": "a-woke"})])
+    r = runner(store)
+    posted = {}
+
+    async def fake_loop(*a, **k):
+        # arrive mid-run, newest last — this is the state the old code read from
+        store.events.append((0.5, {"delivery_id": "d-later-1", "alert_id": "a-later-1"}))
+        store.events.append((0.2, {"delivery_id": "d-newest", "alert_id": "a-newest"}))
+        return "the finding", 2, 3, [], False, None
+
+    async def fake_record(*a, **k):
+        pass
+
+    async def fake_webhook(agent, body, attempts=3):
+        posted.update(body)
+        return "ok", None
+
+    r._loop, r._record, r._webhook = fake_loop, fake_record, fake_webhook
+    status, err = await r._run_traced(AGENT, "rius_alert_fired", "billing-svc", "payload",
+                                      "run_1", "dispatch_1", None, Obs())
+    check("the run concluded", (status, err) == ("ok", None), f"{status} {err}")
+    check("key is the firing that woke the run", posted.get("key") == "d-woke",
+          str(posted.get("key")))
+    check("NOT the newest firing at write-back time (the old bug)",
+          posted.get("key") != "d-newest", str(posted.get("key")))
+    check("labels are the waking firing's",
+          (posted.get("labels") or {}).get("alert_id") == "a-woke",
+          str(posted.get("labels")))
+    # Proves the test is not vacuous: the later firings really are in the store, so resolving
+    # after the loop WOULD have returned d-newest.
+    check("newer firings were in fact present by write-back time",
+          anchor(store)[0] == "d-newest", str(anchor(store)[0]))
+    check("delivery recorded on the run", store.delivery == ("ok", None), str(store.delivery))
+
+    print("== the anchor itself ==")
+    store = Store([(9, {"delivery_id": "old"}), (2, {"delivery_id": "new", "alert_id": "a2"})])
+    key, labels = anchor(store)
+    check("newest firing in the window at call time", key == "new", key)
+    check("its labels come back", labels.get("alert_id") == "a2", str(labels))
+
+    print("== labels arriving as a JSON string ==")
+    key, labels = anchor(Store([(2, {"delivery_id": "j1", "alert_id": "aj"})],
+                               labels_as_json=True))
+    check("json labels parsed", (key, labels.get("alert_id")) == ("j1", "aj"), f"{key} {labels}")
+
+    print("== fallbacks: never drop the field ==")
+    check("no label named -> the entity, no labels",
+          anchor(Store([(1, {"delivery_id": "d"})]), agent={"name": "a"}) == ("billing-svc", {}))
+    check("label on no event -> the entity",
+          anchor(Store([(1, {"service": "billing-svc"})]))[0] == "billing-svc")
+    check("blank label value -> the entity",
+          anchor(Store([(1, {"delivery_id": ""})]))[0] == "billing-svc")
+    check("no events -> the entity, no labels", anchor(Store([])) == ("billing-svc", {}))
+
+    r = runner(Store([(1, {"delivery_id": "d"})]))
+    r.runtime = Runtime()
+
+    class NoViews:
+        triggers = [Trigger()]
+        views = []
+    r.runtime.catalog = NoViews
+    check("a trigger whose view is gone -> the entity",
+          r._callback_anchor(AGENT, "rius_alert_fired", "billing-svc") == ("billing-svc", {}))
+
+    class Boom(Store):
+        def read_view_window(self, *a, **k):
+            raise RuntimeError("duckdb is unhappy")
+    check("a store that raises -> the entity, write-back preserved",
+          anchor(Boom([])) == ("billing-svc", {}))
+
+    print(f"\n{PASS} passed, {FAIL} failed")
+    return 1 if FAIL else 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))


### PR DESCRIPTION
Replaces #127, which I closed — that one tried to change the coalescing. **Coalescing one investigation per entity per cooldown is correct and is untouched here.** The defect is narrower and it is a timing bug.

## What's wrong

`_callback_key` is called from the write-back block, **after** `finish_agent_run`. Its `key` argument is the **entity** (`alerts-e2e-probe`) — no delivery id is among its inputs — and it then does:

```python
rows = self.store.read_view_window(view.sources, key, since, cap=1, filters=view.filters)
latest = max(rows, key=lambda r: r[0]) if rows else None
value = (labels or {}).get(label)      # label = "delivery_id"
```

`max(...)` by `event_time` is the newest event in the window **at that moment**, and a run takes ~40s. So any firing that arrived for the same entity during the run becomes the reported key. Rius attributes RCA reports by that key, so the finding gets filed against an alert the agent never looked at, and the alert it did investigate shows no finding.

## Proven twice on staging, second time as a deliberate repro

| | instance 1 | instance 2 (repro) |
|---|---|---|
| dispatch | `cf9c7fd7…` | `3e02ac87…` |
| **delivery_ids in the dispatch payload** | **1** — `73e2764a` | **1** — `e4e7c908` |
| run starts | `09:33:03.301` (8ms after fire) | `10:51:52.806` (12ms after fire) |
| more firings, same service | 5, from `09:33:04.168` | 3, from `10:51:52.889` |
| Tares run | `delivery: "ok"`, no error — one POST | `delivery: "ok"`, no error — one POST |
| finding names | `73e2764a` / alert `caae018f` | `e4e7c908` / alert `997081bf` |
| **`key` in the body Rius received** | **`e9031347`** | **`9c69c2fa`** |
| Rius filed it under | `e4818ff5` (tool_loop) | `433c259e` (tool_loop) |

Each body carries your own `run_id`, `dispatch_id`, `cost_usd`, `rounds` and `tool_calls`, matching the run record exactly — so it is provably that run's body — next to a `key` naming a firing that dispatch never carried.

Worth saying explicitly, since every Tares screen shows the right id: they all show **inputs**. The dispatch payload is right, the finding is right, and `set_run_delivery` stores only the outcome (`"ok"`) — the posted body is the one thing not persisted on this side. Rius holds the only copy.

Nothing was sent-and-lost either: on the Rius side `rius_receiver_rca_reports_total` is `accepted` only — no `invalid_payload`, `read_error`, `store_error`, `duplicate` or `replaced` — and accepted callbacks reconcile 1:1 with stored rows, none carrying `73e2764a` or `e4e7c908`.

## The change

- `_callback_key` → **`_callback_anchor`**, returning the firing's key **and its labels**, and called **before** the model loop. At run start the trigger has just fired, so the newest event in the window *is* the firing the run was woken by. No lookback change needed.
- The labels ride along in the body as **`labels`**. Rius derives the alert from `key` alone today, which is why a valid-but-wrong key mis-filed silently — it took diffing the stored row against the finding's own prose to spot. `alert_id` is already a label on these events (`alert_id=997081bf` is in the dispatch payload above), so this costs one field and lets a receiver reject a mismatch instead of mis-filing it.
- Fallbacks unchanged in spirit: no label, label on no event, blank value, missing view, or a store that raises all still yield the entity — a wrong name never drops the field.

Deliberately **not** changed: the per-entity dedupe, the cooldown, and the `max(window, 900s)` lookback.

## Tests

`tests/test_rca_callback_anchor.py`, 15 checks, added to the CI list.

The important one drives `_run_traced` with newer firings arriving **during** a stubbed model loop, and asserts the posted key is still the waking firing's — then asserts the newer firings really were present by write-back time, so the test can't pass vacuously. A unit test on `_callback_anchor` alone would stay green if the call moved back after the loop, which is precisely the bug.

Mutation-checked: moving the resolution back to write-back time fails 3 checks and returns `d-newest` — the same shape as the production symptom.

Full CI backend list locally: 27/29. `test_auth` and `test_degraded` fail identically on a clean tree before this branch (`test_degraded` wants a real `ui/dist`; `test_auth` is a local socket read error) and both pass in your CI.

## One note back to Rius

No Rius change is required. Separately we're adding a log line per callback outcome on our receiver carrying `workspace`, `key`, `run_id` and outcome — today it logs the success path at DEBUG only and the reject paths not at all, which is why this took a day to see. That's on us.

---
Ticket: [TR-294](https://linear.app/glassflow/issue/TR-294/rca-write-back-posts-the-newest-delivery-id-in-the-window-not-the-one)